### PR TITLE
Fix missing scrollbar in SQL schema tree view

### DIFF
--- a/src/Lib/ui/SqlSchemaForm.xaml
+++ b/src/Lib/ui/SqlSchemaForm.xaml
@@ -33,7 +33,7 @@
         </Grid.ColumnDefinitions>
 
         <Border Grid.Row="1" Grid.Column="1" BorderBrush="Gray" BorderThickness="1" Background="{DynamicResource {x:Static SystemColors.AppWorkspaceBrushKey}}">
-            <TreeView  x:Name="TreeViewSqlSchema" FontFamily="Consolas"></TreeView>
+            <TreeView  x:Name="TreeViewSqlSchema" FontFamily="Consolas" VirtualizingStackPanel.IsVirtualizing="True" ScrollViewer.VerticalScrollBarVisibility="Auto" ScrollViewer.HorizontalScrollBarVisibility="Auto"></TreeView>
         </Border>
         <StackPanel Orientation="Horizontal" Grid.Row="2" Grid.Column="1" VerticalAlignment="Center">
             <Grid>


### PR DESCRIPTION
## Summary
- Adds explicit `ScrollViewer.VerticalScrollBarVisibility` and `ScrollViewer.HorizontalScrollBarVisibility` to the SQL schema TreeView so the scrollbar appears immediately when items overflow, not only after expanding a sub-node
- Also enables `VirtualizingStackPanel.IsVirtualizing` for better performance with large schemas

## Test plan
- [ ] Open the SQL schema panel with a schema that has many items
- [ ] Verify the vertical scrollbar is visible without needing to expand a node first

🤖 Generated with [Claude Code](https://claude.com/claude-code)