### PR TITLE
Fix schema panel scrollbar not appearing on initial load

### DIFF
--- a/src/Lib/Functions/Private/Open-SqlSchemaForm.ps1
+++ b/src/Lib/Functions/Private/Open-SqlSchemaForm.ps1
@@ -72,6 +72,11 @@ function Open-SqlSchemaForm {
             $Script:SqlSchemaForm.Definition.Left = [Int]::Abs($Position.Split("x")[0])
             $Script:SqlSchemaForm.Definition.Top = [Int]::Abs($Position.Split("x")[1])
         }
+        if ($null -ne ($Script:SqlSchemaForm.Definition | Get-FormSizeConfig)) {
+            $Size = $Script:SqlSchemaForm.Definition | Get-FormSizeConfig
+            "Sql Schema form size (pre-show): {0}" -f $Size | Write-LogOutput -LogType DEBUG
+            $Script:SqlSchemaForm.Definition.Width = [Int]$Size.Split("x")[0]
+        }
 
         #region SqlSchemaForm events
 
@@ -116,15 +121,6 @@ function Open-SqlSchemaForm {
                         $Script:SqlSchemaForm.PositionManager.PositionOffSetLeft = [Int]::Abs($Script:MainForm.Definition.Left) - [Int]::Abs($Script:SqlSchemaForm.Definition.Left)
 
                         "PositionManagerSqlSchemaForm PositionOffSetLeft: {0}" -f $Script:SqlSchemaForm.PositionManager.PositionOffSetLeft | Write-LogOutput -LogType DEBUG
-                        if ($null -ne ($Script:SqlSchemaForm.Definition | Get-FormSizeConfig)) {
-                            $Size = $Script:SqlSchemaForm.Definition | Get-FormSizeConfig
-
-                            "Sql Schema form size: {0}" -f $Size | Write-LogOutput -LogType DEBUG
-                            $Script:SqlSchemaForm.Definition.Width = $Size.Split("x")[0]
-                            $Script:SqlSchemaForm.Definition.Height = $Size.Split("x")[1]
-
-                            "SqlSchemaForm Height: {0}" -f $Script:SqlSchemaForm.Definition.Height | Write-LogOutput -LogType DEBUG
-                        }
                         $Script:SqlSchemaForm.PositionManager.Synchronizing = $false
                     }, [System.Windows.Threading.DispatcherPriority]::Render)
 
@@ -138,6 +134,21 @@ function Open-SqlSchemaForm {
 
                 "SqlSchemaForm Position: {0}x{1}, Dimensions: {2}x{3}" -f $Script:SqlSchemaForm.Definition.Left, $Script:SqlSchemaForm.Definition.Top, $Script:SqlSchemaForm.Definition.Width , $Script:SqlSchemaForm.Definition.Height | Write-LogOutput -LogType DEBUG
                 $Script:SqlSchemaForm.State = "Open"
+                $tv = $Script:TreeViewSqlSchema
+                $Script:SqlSchemaForm.Definition.Dispatcher.Invoke(
+                    {
+                        if ($tv.Items.Count -gt 0) {
+                            $firstSchema = $tv.Items[0]
+                            if ($null -ne $firstSchema -and $firstSchema.Items.Count -gt 0) {
+                                $firstTable = $firstSchema.Items[0]
+                                $firstTable.IsExpanded = $true
+                                $tv.UpdateLayout()
+                                $firstTable.IsExpanded = $false
+                            }
+                        }
+                    },
+                    [System.Windows.Threading.DispatcherPriority]::Background
+                )
                 Restore-MainFormFocus
             })
 

--- a/src/Lib/ui/SqlSchemaForm.xaml
+++ b/src/Lib/ui/SqlSchemaForm.xaml
@@ -22,8 +22,8 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="10"/>
             <RowDefinition Height="*"/>
-            <RowDefinition Height="40"/>
-            <RowDefinition Height="30"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="10"/>
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
@@ -33,7 +33,7 @@
         </Grid.ColumnDefinitions>
 
         <Border Grid.Row="1" Grid.Column="1" BorderBrush="Gray" BorderThickness="1" Background="{DynamicResource {x:Static SystemColors.AppWorkspaceBrushKey}}">
-            <TreeView  x:Name="TreeViewSqlSchema" FontFamily="Consolas" VirtualizingStackPanel.IsVirtualizing="True" ScrollViewer.VerticalScrollBarVisibility="Auto" ScrollViewer.HorizontalScrollBarVisibility="Auto"></TreeView>
+            <TreeView x:Name="TreeViewSqlSchema" FontFamily="Consolas" VirtualizingStackPanel.IsVirtualizing="True" ScrollViewer.VerticalScrollBarVisibility="Auto" ScrollViewer.HorizontalScrollBarVisibility="Auto"></TreeView>
         </Border>
         <StackPanel Orientation="Horizontal" Grid.Row="2" Grid.Column="1" VerticalAlignment="Center">
             <Grid>

--- a/src/Lib/ui/SqlSchemaForm.xaml
+++ b/src/Lib/ui/SqlSchemaForm.xaml
@@ -33,7 +33,7 @@
         </Grid.ColumnDefinitions>
 
         <Border Grid.Row="1" Grid.Column="1" BorderBrush="Gray" BorderThickness="1" Background="{DynamicResource {x:Static SystemColors.AppWorkspaceBrushKey}}">
-            <TreeView  x:Name="TreeViewSqlSchema" FontFamily="Consolas"></TreeView>
+            <TreeView  x:Name="TreeViewSqlSchema" FontFamily="Consolas" VirtualizingStackPanel.IsVirtualizing="True" ScrollViewer.VerticalScrollBarVisibility="Auto" ScrollViewer.HorizontalScrollBarVisibility="Auto"></TreeView>
         </Border>
         <StackPanel Orientation="Horizontal" Grid.Row="2" Grid.Column="1" VerticalAlignment="Center">
             <Grid>


### PR DESCRIPTION
> Recreated against the new `main` (the previous `main` was replaced, which auto-closed the original PR #1). Changes re-applied as new commits on top of the current `main`. The original `SqlSchemaWindow.xaml` edit was dropped because that file no longer exists in the new `main` (the TreeView now lives in `SqlSchemaForm.xaml`, which is updated here).

## Summary

- Scrollbar now appears immediately when the schema tree content overflows the panel, without requiring the user to expand an item first
- Schema panel no longer resizes after opening — saved width is applied before `Show()`, height always matches the main window
- Empty placeholder rows at the bottom of the panel (40px + 30px) collapsed to `Auto`, so the TreeView fills the full available height

## Root causes

**Scrollbar not appearing:** `VirtualizingStackPanel.IsVirtualizing="True"` is required for the WPF scroll extent to be calculated correctly, but the initial layout pass after programmatic `Items.Add()` doesn't trigger the same scroll-extent update that user-driven expand does. Fixed by adding a `Background`-priority `Dispatcher.Invoke` (after all layout/render passes settle) that briefly expands then collapses the first table item — this reuses the exact mechanism that manual expand triggers.

**Visible resize on open:** Saved size was being restored inside the `Loaded` event handler (after the window was already visible). Fixed by restoring only the width before `Show()`; height is intentionally left to `Initialize-FormObject` so it always matches the main window height.

## Test plan

- [ ] Open schema panel — scrollbar visible immediately if content overflows
- [ ] Panel height matches main window height regardless of saved config
- [ ] Panel width is restored from previous session
- [ ] Manually expanding a table still works normally
- [ ] Resizing the panel and reopening preserves the width

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TY5Hy3GFMJ8cZrfovVezcd)_