### PR TITLE
Fix inconsistent vertical alignment in DataGrid query result cells

### DIFF
--- a/src/Lib/ui/MainForm.xaml
+++ b/src/Lib/ui/MainForm.xaml
@@ -488,7 +488,13 @@
                                                         <Image Grid.Column="1" IsHitTestVisible="False" x:Name="ImageOutputStatus" Tag="/images/table_15x15.png" Source="/images/table_15x15.png" />
                                                         <TextBlock Grid.Column="3" x:Name="TextBlockOutputBox" Text="Results:" />
                                                 </Grid>
-                                                <DataGrid x:Name="DataGridQueryResult" Grid.Row="1" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto" FontFamily="Consolas" IsReadOnly="True" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Background="{DynamicResource {x:Static SystemColors.WindowBrushKey}}" AlternationCount="{Binding MyObservableCollection.Count}" MinHeight="200" ScrollViewer.CanContentScroll="True" ScrollViewer.VerticalScrollBarVisibility="Auto" ScrollViewer.HorizontalScrollBarVisibility="Auto" CanUserResizeColumns="True" CanUserReorderColumns="True" CanUserSortColumns="True" Focusable="True" IsTabStop="True" SelectionMode="Extended" SelectionUnit="CellOrRowHeader" ClipboardCopyMode="IncludeHeader" />
+                                                <DataGrid x:Name="DataGridQueryResult" Grid.Row="1" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto" FontFamily="Consolas" IsReadOnly="True" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Background="{DynamicResource {x:Static SystemColors.WindowBrushKey}}" AlternationCount="{Binding MyObservableCollection.Count}" MinHeight="200" ScrollViewer.CanContentScroll="True" ScrollViewer.VerticalScrollBarVisibility="Auto" ScrollViewer.HorizontalScrollBarVisibility="Auto" CanUserResizeColumns="True" CanUserReorderColumns="True" CanUserSortColumns="True" Focusable="True" IsTabStop="True" SelectionMode="Extended" SelectionUnit="CellOrRowHeader" ClipboardCopyMode="IncludeHeader">
+                                                    <DataGrid.Resources>
+                                                        <Style TargetType="TextBlock">
+                                                            <Setter Property="VerticalAlignment" Value="Center"/>
+                                                        </Style>
+                                                    </DataGrid.Resources>
+                                                </DataGrid>
                                         </Grid>
                                 </Grid>
                                 <StatusBar Height="30" Grid.Row="2" VerticalAlignment="Bottom" HorizontalAlignment="Stretch" Background="Khaki">


### PR DESCRIPTION
> Recreated against the new `main` (the previous `main` was replaced, which auto-closed the original PR #2). The change was cherry-picked cleanly onto the current `main`.

## Summary

Duplicate-renamed columns (e.g. `ValidTo_`, `IsDeleted_`) rendered their cell content top-aligned while all other columns appeared vertically centred.

## Root cause

The global `TextBlock` style in `MainForm.xaml` sets `VerticalAlignment="Top"`. This leaks into auto-generated `DataGridTextColumn` cells. Regular columns appeared centred incidentally because their cell height matched the TextBlock's fixed `Height="25"`, leaving no visible gap. Duplicate-renamed columns rendered in taller cells, making the top alignment visible.

## Fix

Added `DataGrid.Resources` with a scoped `TextBlock` style that sets `VerticalAlignment="Center"`. This only affects TextBlocks inside the DataGrid — all other form labels, buttons and ComboBoxes are unchanged.

## Test plan

- [ ] Run a query with duplicate column names (e.g. `SELECT TOP(100) A.Uid, A.ValidTo, A.IsDeleted, B.ValidTo, B.IsDeleted, B.ExpirationTime`)
- [ ] Verify renamed duplicate columns (`ValidTo_`, `IsDeleted_`) are vertically centred consistently with all other columns
- [ ] Verify no visual regressions in labels, buttons or ComboBoxes elsewhere in the form

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TY5Hy3GFMJ8cZrfovVezcd)_