### PR TITLE
Fix underscore in DataGrid column headers rendered as mnemonic

### DIFF
--- a/src/Lib/Events/MainForm.Elements.DataGridQueryResult.ps1
+++ b/src/Lib/Events/MainForm.Elements.DataGridQueryResult.ps1
@@ -234,6 +234,22 @@
 #         }
 #     })
 
+$Script:MainForm.Elements.DataGridQueryResult.Add_AutoGeneratingColumn({
+        param(
+            $EventSender,
+            $EventArgs
+        )
+        try {
+            $Private:HeaderTemplate = [System.Windows.Markup.XamlReader]::Parse(
+                '<DataTemplate xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"><TextBlock Text="{Binding}" TextTrimming="CharacterEllipsis"/></DataTemplate>'
+            )
+            $EventArgs.Column.HeaderTemplate = $Private:HeaderTemplate
+        }
+        catch {
+            $_.Exception.Message | Write-LogOutput -LogType ERROR -ErrorObject $_
+        }
+    })
+
 $Script:MainForm.Elements.DataGridQueryResult.Add_LoadingRow({
         param(
             $EventSender,


### PR DESCRIPTION
> Recreated against the new `main` (the previous `main` was replaced, which auto-closed the original PR #3). The change was cherry-picked cleanly onto the current `main`.

## Summary
- WPF's `ContentPresenter` uses `AccessText` to render string column headers, which consumes `_` as a mnemonic prefix — `Account_BusinessKey` was displayed as `AccountBusinessKey`
- Added `AutoGeneratingColumn` event handler that sets `HeaderTemplate` on each auto-generated column to render via a `TextBlock` instead of `AccessText`
- `Header` stays a plain string, so clipboard copy and data binding are unaffected
- `TextTrimming="CharacterEllipsis"` ensures the header updates correctly on column resize

## Test plan
- [ ] Run a query that returns columns with underscores (e.g. `Account_BusinessKey`)
- [ ] Verify the column header displays the underscore correctly
- [ ] Verify Ctrl+C copy includes the correct column name (not `System.Windows.Controls.TextBlock`)
- [ ] Verify resizing the column updates the header text display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TY5Hy3GFMJ8cZrfovVezcd)_