### PR TITLE
Gate releases behind manual approval; fix broken PSGallery publish step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Build module
         shell: pwsh
         run: |
-          ./Build/build.ps1 -Task Build -BuildVersion '${{ steps.versioning.outputs.build_version }}'
+          ./build/build.ps1 -Task Build -BuildVersion '${{ steps.versioning.outputs.build_version }}'
 
       - name: Upload build output
         uses: actions/upload-artifact@v4
@@ -55,6 +55,7 @@ jobs:
     name: Package and Release
     runs-on: windows-latest
     needs: build
+    environment: release
 
     env:
       BUILD_VERSION: ${{ needs.build.outputs.build_version }}
@@ -83,7 +84,7 @@ jobs:
       - name: Publish to PSGallery
         shell: pwsh
         run: |
-          ./deploy/PushToPsGallery.ps1 `
+          ./build/PushToPsGallery.ps1 `
             -SystemDefaultWorkingDirectory '${{ github.workspace }}' `
             -PsGalleryKey '${{ secrets.PSGALLERY_API_KEY }}' `
             -BuildPath 'OmadaSqlTroubleshooter'

--- a/build/PushToPsGallery.ps1
+++ b/build/PushToPsGallery.ps1
@@ -16,7 +16,7 @@ catch {
 
 try {
     "Publish-Module to PSGallery" | Write-Host
-    $SourcePath = "{0}/_Artifact/{1}" -f $SystemDefaultWorkingDirectory, $BuildPath.TrimStart('/')
+    $SourcePath = "{0}/buildoutput/{1}" -f $SystemDefaultWorkingDirectory, $BuildPath.TrimStart('/')
     Publish-Module -Path $SourcePath -NuGetApiKey "$PsGalleryKey" -Verbose
 }
 catch {


### PR DESCRIPTION
## Summary
- Adds `environment: release` to the `release` job in `release.yml`, so a push to `main` still builds automatically but the publish/tag/release steps now wait for a manual approval before running.
- Fixes two real bugs surfaced while investigating the last 3 failed `Release` workflow runs (all failed at "Publish to PSGallery" with `CommandNotFoundException`):
  - The build step called `./Build/build.ps1`, but the on-disk directory is lowercase `build/` (same case-sensitivity class of bug fixed earlier in `pr-validation.yml`).
  - The publish step called `./deploy/PushToPsGallery.ps1`, which doesn't exist — the real script lives at `build/PushToPsGallery.ps1`. Also fixed that script's `$SourcePath`, which referenced a nonexistent `_Artifact` folder; the actual build output lands in `buildoutput/<ModuleName>` (matching the artifact downloaded earlier in the same job).

## Manual follow-up required (no admin/API access from this session)
To make the approval gate actually pause for a reviewer, someone with repo admin access needs to:
1. Go to **Settings → Environments → New environment**, name it `release`.
2. Add required reviewers (the people who should approve a release).

Without this one-time setup, `environment: release` is a no-op (job still runs immediately) — but it's needed either way for the gate to take effect, and is the only way to do this without GitHub UI access.

## Test plan
- [ ] Merge to `main` (touching `src/**`) and confirm the `Build` job runs immediately, but `Package and Release` shows "Waiting for approval" until a reviewer approves it.
- [ ] After approval, confirm "Publish to PSGallery" no longer fails with `CommandNotFoundException` and actually attempts `Publish-Module` against the correct build output path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01HneVERvRW1zLiP6aCW1sUK)_