### PR TITLE
Fail PR validation when branch is behind main

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -21,6 +21,17 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Check branch is up to date with main
+        shell: pwsh
+        run: |
+          git fetch origin main
+          git merge-base --is-ancestor origin/main HEAD
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "This branch is behind 'main'. Please merge or rebase 'main' into your branch and push again."
+            exit 1
+          }
+          Write-Host "Branch is up to date with main."
+
       - name: Determine changed files
         shell: pwsh
         run: |


### PR DESCRIPTION
## Summary
- Adds a "Check branch is up to date with main" step to `pr-validation.yml`'s `validate` job, right after checkout. It runs `git merge-base --is-ancestor origin/main HEAD` and fails fast if the PR branch doesn't already contain `main`'s latest commit — before spending time on install/build/test.
- This only makes the check *visible and failing* on stale PRs; it does not yet *block* the merge button. Does not auto-merge/rebase — the author has to update their branch manually.

## Manual follow-up (repo admin, not done by me)
1. **Settings → Branches** → branch protection rule for `main` → "Require status checks to pass before merging" → enable "Require branches to be up to date before merging" and add "Validate" as a required check. This makes the new check above actually block merging.
2. **Settings → General → Pull Requests** → enable "Automatically delete head branches". Built-in GitHub feature that deletes a PR's source branch the moment it merges, for every future PR — no workflow code needed for this.

## Test plan
- [ ] Confirm this PR's own "Validate" check passes (branch is up to date with main).
- [ ] After merging, open a small test PR from a branch that's deliberately behind main (don't rebase) and confirm the new step fails with the "behind main" message while other steps would otherwise still pass.
- [ ] Apply the two manual Settings steps above and confirm: a stale PR's merge button is now blocked, and a merged PR's branch is auto-deleted.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HneVERvRW1zLiP6aCW1sUK)_