### PR TITLE
Fix build.ps1 swallowing psake task failures (Analyze/Test never gate…

### DIFF
--- a/build/build.ps1
+++ b/build/build.ps1
@@ -22,8 +22,12 @@ $ScriptBlockString = @"
 
     `$Location = Get-Location
     Invoke-psake -buildFile "`$Location\psakeBuild.ps1" -taskList `$Task -Verbose:`$VerbosePreference -parameters @{"BuildVersion" = `$BuildVersion }
+    if (-not `$psake.build_success) { exit 1 }
 "@
 
 $TaskParam = ($Task | ForEach-Object { "'$_'" }) -join ','
 $Command = "Set-Location '$($PSScriptRoot)'; & {$ScriptBlockString} -Task @($TaskParam) -BuildVersion '$BuildVersion'"
-Start-Process -FilePath "pwsh.exe" -ArgumentList "-NoProfile", "-NoLogo", "-ExecutionPolicy", "Bypass", "-Command", $Command -Wait -NoNewWindow
+$Process = Start-Process -FilePath "pwsh.exe" -ArgumentList "-NoProfile", "-NoLogo", "-ExecutionPolicy", "Bypass", "-Command", $Command -Wait -NoNewWindow -PassThru
+if ($Process.ExitCode -ne 0) {
+    throw "Build failed: psake exited with code $($Process.ExitCode). See output above for the failing task."
+}


### PR DESCRIPTION
…d anything)

build.ps1 runs psake in a child pwsh.exe via Start-Process -Wait, but never checked the child process's exit code, and Invoke-psake itself doesn't throw or exit on a failed task when called directly (only in nested psake invocations) - it just sets $psake.build_success = $false and returns quietly.

Net effect: Analyze and Test really did run as dependencies of the Build task (confirmed in the last Release run's logs - 6 Pester tests executed), but a failing analyzer rule or failing test would never fail the GitHub Actions step. release.yml, nightly.yml and pr-validation.yml all call this same build.ps1, so none of them were actually gated on tests passing - only on the script not throwing.

Now the inner script checks $psake.build_success and exits 1 on failure, and the outer Start-Process call captures that exit code (-PassThru) and throws, so a test or analyzer failure now genuinely fails the workflow step before the release approval gate is reached.