### PR TITLE
Compare release notes against the last non-nightly release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,6 +81,14 @@ jobs:
             -Properties "VERSION=${{ env.BUILD_VERSION }};YEAR=${{ env.YEAR }}" `
             -OutputDirectory staging/
 
+      - name: Find last non-nightly release tag
+        id: prev_tag
+        shell: bash
+        run: |
+          PREV_TAG=$(git tag -l 'v*' | grep -v -- '-nightly$' | sort -V | tail -n 1)
+          echo "Previous non-nightly tag: ${PREV_TAG:-<none>}"
+          echo "previous_tag=$PREV_TAG" >> "$GITHUB_OUTPUT"
+
       - name: Publish to PSGallery
         shell: pwsh
         run: |
@@ -104,3 +112,4 @@ jobs:
           name: Release v${{ env.BUILD_VERSION }}
           files: staging/*.nupkg
           generate_release_notes: true
+          previous_tag: ${{ steps.prev_tag.outputs.previous_tag }}


### PR DESCRIPTION
generate_release_notes was diffing against whatever release came right before it chronologically, which is almost always the previous night's nightly prerelease - so a real release's auto-generated notes only showed the handful of commits since last night instead of everything since the last actual release.

Adds a step that walks all 'v*' tags, drops '-nightly' ones, and picks the highest remaining version to pass as previous_tag to action-gh-release, so notes always span every change since the last non-nightly release.