### PR TITLE
Publish nightly builds to PSGallery as pre-release; scope check to sr…

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,24 +19,32 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Check if main has new commits since last nightly tag
+      - name: Check if src/** changed since last nightly tag
         id: check
         shell: bash
         run: |
           LAST_NIGHTLY_TAG=$(git tag -l 'v*-nightly' --sort=-creatordate | head -n 1)
           if [ -z "$LAST_NIGHTLY_TAG" ]; then
-            echo "No previous nightly tag found, will build."
-            echo "should_build=true" >> "$GITHUB_OUTPUT"
+            BASE_COMMIT=$(git rev-list --max-parents=0 HEAD)
+            echo "No previous nightly tag found, comparing against first commit ($BASE_COMMIT)."
           else
-            LAST_NIGHTLY_COMMIT=$(git rev-list -n 1 "$LAST_NIGHTLY_TAG")
+            BASE_COMMIT=$(git rev-list -n 1 "$LAST_NIGHTLY_TAG")
             HEAD_COMMIT=$(git rev-parse HEAD)
-            if [ "$LAST_NIGHTLY_COMMIT" = "$HEAD_COMMIT" ]; then
+            if [ "$BASE_COMMIT" = "$HEAD_COMMIT" ]; then
               echo "No new commits since last nightly tag ($LAST_NIGHTLY_TAG), skipping build."
               echo "should_build=false" >> "$GITHUB_OUTPUT"
-            else
-              echo "New commits found since last nightly tag ($LAST_NIGHTLY_TAG), will build."
-              echo "should_build=true" >> "$GITHUB_OUTPUT"
+              exit 0
             fi
+            echo "Comparing src/** changes since $LAST_NIGHTLY_TAG ($BASE_COMMIT)."
+          fi
+          CHANGED=$(git diff --name-only "$BASE_COMMIT" HEAD -- src/)
+          if [ -z "$CHANGED" ]; then
+            echo "No src/** changes since last nightly tag, skipping build."
+            echo "should_build=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "src/** changes found:"
+            echo "$CHANGED"
+            echo "should_build=true" >> "$GITHUB_OUTPUT"
           fi
 
   build:
@@ -105,6 +113,15 @@ jobs:
         with:
           name: BuildOutput
           path: buildoutput/
+
+      - name: Publish to PSGallery (pre-release)
+        shell: pwsh
+        run: |
+          ./build/PushToPsGallery.ps1 `
+            -SystemDefaultWorkingDirectory '${{ github.workspace }}' `
+            -PsGalleryKey '${{ secrets.PSGALLERY_API_KEY }}' `
+            -BuildPath 'OmadaSqlTroubleshooter' `
+            -Prerelease 'nightly'
 
       - name: Pack NuGet package
         shell: pwsh

--- a/build/PushToPsGallery.ps1
+++ b/build/PushToPsGallery.ps1
@@ -1,7 +1,8 @@
 ﻿PARAM(
     [string]$SystemDefaultWorkingDirectory,
     [string]$PsGalleryKey,
-    [string]$BuildPath
+    [string]$BuildPath,
+    [string]$Prerelease = ""
 )
 
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12, [Net.SecurityProtocolType]::Tls11, [Net.SecurityProtocolType]::Tls13
@@ -17,6 +18,16 @@ catch {
 try {
     "Publish-Module to PSGallery" | Write-Host
     $SourcePath = "{0}/buildoutput/{1}" -f $SystemDefaultWorkingDirectory, $BuildPath.TrimStart('/')
+
+    if (-not [string]::IsNullOrWhiteSpace($Prerelease)) {
+        $Manifest = Get-ChildItem -Path $SourcePath -Filter '*.psd1' | Select-Object -First 1
+        if ($null -eq $Manifest) {
+            throw "No .psd1 manifest found in '$SourcePath'."
+        }
+        "Setting prerelease string '$Prerelease' on $($Manifest.Name)" | Write-Host
+        Update-ModuleManifest -Path $Manifest.FullName -Prerelease $Prerelease
+    }
+
     Publish-Module -Path $SourcePath -NuGetApiKey "$PsGalleryKey" -Verbose
 }
 catch {


### PR DESCRIPTION
…c/**

Two changes:

1. Nightly check now diffs src/ between the last nightly tag and HEAD instead of comparing commit SHAs. A push that only touches docs, workflows, tests, or other non-src files no longer triggers a build. On first run (no prior nightly tag) it falls back to the repo's initial commit as the baseline.

2. The nightly-release job now publishes to PSGallery before tagging. PushToPsGallery.ps1 gains an optional -Prerelease parameter: when set it calls Update-ModuleManifest to stamp the built manifest with the prerelease string (e.g. 'nightly') before Publish-Module runs, so the package lands in PSGallery as a pre-release and requires -AllowPrerelease to install. The production release path is unchanged (no -Prerelease passed there).