### PR TITLE
Include run number in nightly PSGallery prerelease string

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -121,7 +121,7 @@ jobs:
             -SystemDefaultWorkingDirectory '${{ github.workspace }}' `
             -PsGalleryKey '${{ secrets.PSGALLERY_API_KEY }}' `
             -BuildPath 'OmadaSqlTroubleshooter' `
-            -Prerelease 'nightly'
+            -Prerelease 'nightly${{ github.run_number }}'
 
       - name: Pack NuGet package
         shell: pwsh


### PR DESCRIPTION
## Summary

Changes the PSGallery prerelease string from the static `nightly` to `nightly{run_number}` (e.g. `nightly42`), so each nightly build publishes as a distinct version on PSGallery (e.g. `2026.7.3-nightly42`).

Without the run number, a second nightly triggered on the same date (e.g. via `workflow_dispatch`) would be rejected by PSGallery because the version would be identical to the one already published that day.

## Test plan

- [ ] Trigger nightly via `workflow_dispatch` and confirm PSGallery receives e.g. `2026.7.3-nightly{N}` where N is the workflow run number.
- [ ] Trigger a second dispatch on the same date and confirm the second publish succeeds with a higher run number suffix (e.g. `nightly{N+1}`).

---
_Generated by [Claude Code](https://claude.ai/code/session_019nUHcTZwDCwaxHHjHw8vzt)_