### PR TITLE
Use YYYY.M.D-nightly{N} version format for PSGallery pre-releases

### DIFF
--- a/build/PushToPsGallery.ps1
+++ b/build/PushToPsGallery.ps1
@@ -26,10 +26,11 @@ try {
         }
 
         # PSGallery requires exactly 3-part version for pre-release packages (SemVer).
-        # Convert YYYY.M.D.N → YYYY.MMDD.N so the version stays unique and date-sortable.
+        # Drop the 4th part (run number) — it is already encoded in the Prerelease string
+        # (e.g. 'nightly15'), giving a final version like 2026.7.3-nightly15.
         $Parts = ($ManifestData = Import-PowerShellDataFile -Path $Manifest.FullName).ModuleVersion -split '\.'
         if ($Parts.Count -eq 4) {
-            $ThreePartVersion = '{0}.{1}.{2}' -f $Parts[0], ($Parts[1].PadLeft(2,'0') + $Parts[2].PadLeft(2,'0')), $Parts[3]
+            $ThreePartVersion = '{0}.{1}.{2}' -f $Parts[0], $Parts[1], $Parts[2]
             "Converting version $($ManifestData.ModuleVersion) to 3-part prerelease version $ThreePartVersion" | Write-Host
             Update-ModuleManifest -Path $Manifest.FullName -ModuleVersion $ThreePartVersion -Prerelease $Prerelease
         }


### PR DESCRIPTION
## Summary

Fixes the PSGallery pre-release version format to match the intended style `2026.7.3-nightly15`.

The previous approach merged month and day into a single component to satisfy PSGallery's 3-part version requirement, producing an awkward `2026.703.15-nightly15`. Since the run number is already carried in the prerelease string (`nightly15`), the 4th version component (run number) can simply be dropped instead:

| Before | After |
|--------|-------|
| `2026.703.15-nightly15` | `2026.7.3-nightly15` |

## Test plan

- [ ] Trigger nightly via `workflow_dispatch` and confirm PSGallery receives version `2026.7.3-nightly{N}`.
- [ ] Confirm `Install-Module OmadaSqlTroubleshooter -AllowPrerelease` picks up the nightly.

---
_Generated by [Claude Code](https://claude.ai/code/session_019nUHcTZwDCwaxHHjHw8vzt)_