### PR TITLE
Stop the tab strip stealing Home/End from the editor; fix Alt key collisions

### DIFF
--- a/src/Lib/Events/MainForm.Definition.ps1
+++ b/src/Lib/Events/MainForm.Definition.ps1
@@ -124,6 +124,25 @@ $Script:MainForm.Definition.Add_Closing({
         }
     })
 
+# Second half of the Home/End fix (first half: the TabControl class handler in
+# Initialize-OmadaSqltroubleShooter). That handler marks Home/End handled so the TabControl cannot
+# jump to the first/last tab - but WebView2 only forwards a key to Monaco when the WPF routed event
+# returns UNhandled, so leaving it handled would stop the caret moving instead. By here the bubble
+# has passed the TabControl and it can no longer act on the key, so hand it back to the editor.
+# handledEventsToo is required: the event is handled at this point, which is exactly why we are here.
+$Script:MainForm.Definition.AddHandler(
+    [System.Windows.Input.Keyboard]::KeyDownEvent,
+    [System.Windows.Input.KeyEventHandler] {
+        param(
+            $EventSender,
+            $EventArgs
+        )
+        if ((Test-EditorNavigationKey -KeyName ([string]$EventArgs.Key)) -and $EventArgs.OriginalSource -is [Microsoft.Web.WebView2.Wpf.WebView2]) {
+            $EventArgs.Handled = $false
+        }
+    },
+    $true)
+
 $Script:MainForm.Definition.Add_PreviewKeyDown({
         param(
             $EventSender,

--- a/src/Lib/Functions/Private/Initialize-OmadaSqltroubleShooter.ps1
+++ b/src/Lib/Functions/Private/Initialize-OmadaSqltroubleShooter.ps1
@@ -108,6 +108,30 @@ namespace Fortigi {
 "@
         }
 
+        # Stop WPF's TabControl from claiming Home/End (see Test-EditorNavigationKey for the full
+        # story). TabControl.OnKeyDown is invoked through UIElement's class handler; a class handler
+        # registered on the more derived TabControl runs FIRST, so marking the key handled here means
+        # OnKeyDown never runs and the tab does not change. Marking it handled would normally also
+        # withhold the key from Monaco - WebView2 only forwards a key to the web content when the WPF
+        # routed event returns unhandled - so MainForm.Definition resets Handled at the end of the
+        # bubble, once the TabControl can no longer act on it. Gated on the event coming from a
+        # WebView2 so ordinary controls (TextBox, DataGrid) keep their normal Home/End behaviour.
+        if (-not $Script:EditorNavigationKeyHandlerRegistered) {
+            [System.Windows.EventManager]::RegisterClassHandler(
+                [System.Windows.Controls.TabControl],
+                [System.Windows.Input.Keyboard]::KeyDownEvent,
+                [System.Windows.Input.KeyEventHandler] {
+                    # $args[1] is the KeyEventArgs; the sender is not needed. Read from $args rather
+                    # than a param block so the handler does not shadow PowerShell's automatic
+                    # $EventArgs or declare a sender parameter it never uses.
+                    $KeyEventArgs = $args[1]
+                    if ((Test-EditorNavigationKey -KeyName ([string]$KeyEventArgs.Key)) -and $KeyEventArgs.OriginalSource -is [Microsoft.Web.WebView2.Wpf.WebView2]) {
+                        $KeyEventArgs.Handled = $true
+                    }
+                })
+            $Script:EditorNavigationKeyHandlerRegistered = $true
+        }
+
         # Per-tab state ($RunTimeData/$WebView/$AppConfig/$ConnectionStatus/$Task/$MainForm.Elements)
         # now lives on each entry in $Script:Tabs and is repointed onto these same global names by
         # Set-ActiveTabContext, one tab at a time - see New-TabSession.ps1 for the per-tab shape

--- a/src/Lib/Functions/Private/Set-SqlConnectionState.ps1
+++ b/src/Lib/Functions/Private/Set-SqlConnectionState.ps1
@@ -17,7 +17,7 @@ function Set-SqlConnectionState {
             $Script:MainForm.Elements.TextBoxEntraIdTenantId.IsEnabled = $false
             $Script:MainForm.Elements.TextBoxUrl.IsEnabled = $false
             $Script:MainForm.Elements.TextBlockStatusBarConnectionStatus | Set-TextBlockText -Text "Connected"
-            $Script:MainForm.Elements.ButtonConnectText | Set-ButtonText -Value "_Disconnect"
+            $Script:MainForm.Elements.ButtonConnectText | Set-ButtonText -Value "Dis_connect"
             $Script:MainForm.Elements.TextBlockStatusBarUrl.Text = ([System.Uri]::new($Script:MainForm.Elements.TextBoxUrl.Text)).Authority
 
             if (($Script:MainForm.Elements.ComboBoxSelectDataConnection.Items | Measure-Object).Count -le 1 -or ($Script:MainForm.Elements.ComboBoxSelectQuery.Items | Measure-Object).Count -le 1 -and $null -ne $Script:RunTimeConfig.ReconnectStatus -and $Script:RunTimeConfig.ReconnectStatus -ge 2) {

--- a/src/Lib/Functions/Private/Test-ConnectionButton.ps1
+++ b/src/Lib/Functions/Private/Test-ConnectionButton.ps1
@@ -24,7 +24,7 @@ function Test-ConnectionButton {
             else {
                 $Script:MainForm.Elements.ButtonConnect.IsEnabled = $true
                 if ($Script:ConnectionStatus) {
-                    $Script:MainForm.Elements.ButtonConnectText | Set-ButtonText -Value "_Disconnect"
+                    $Script:MainForm.Elements.ButtonConnectText | Set-ButtonText -Value "Dis_connect"
                     $Script:MainForm.Elements.ButtonConnect.ToolTip = "Disconnect from Omada"
                 }
                 else {

--- a/src/Lib/Functions/Private/Test-EditorNavigationKey.ps1
+++ b/src/Lib/Functions/Private/Test-EditorNavigationKey.ps1
@@ -1,0 +1,35 @@
+function Test-EditorNavigationKey {
+    <#
+    .SYNOPSIS
+    Returns whether a key is one that WPF's TabControl claims for its own first/last-tab navigation
+    and must therefore be kept away from it, so the editor can use it instead.
+
+    .DESCRIPTION
+    WPF's TabControl.OnKeyDown moves the selection to the FIRST tab on Home and to the LAST tab on
+    End. It switches on the key alone, so every modifier combination triggers it - Home, Shift+Home
+    (select to line start), Ctrl+Home (jump to the document start), and the End equivalents.
+
+    A WPF TextBox never triggers this because it handles Home/End itself and marks the event handled,
+    so the key never bubbles as far as the TabControl. The WebView2 hosting the Monaco editor does
+    not: the key surfaces as an unhandled routed event, reaches the TabControl and switches tab. To
+    make it worse, WebView2 only forwards the key to the web content when the WPF routed event comes
+    back unhandled - so once the TabControl claims it, the caret does not move either.
+
+    See Initialize-OmadaSqltroubleShooter (class handler) and MainForm.Definition (the matching reset)
+    for how this is used to stop the TabControl without withholding the key from Monaco.
+
+    Takes the key as its [System.Windows.Input.Key] name (what .ToString() yields, e.g. "Home").
+    Working with names rather than the WPF enum type keeps this testable without PresentationCore.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $false)]
+        [string]$KeyName
+    )
+
+    if ([string]::IsNullOrWhiteSpace($KeyName)) {
+        return $false
+    }
+
+    return ($KeyName.Trim() -in @("Home", "End"))
+}

--- a/src/Lib/ui/MainFormTabContent.xaml
+++ b/src/Lib/ui/MainFormTabContent.xaml
@@ -298,7 +298,7 @@
                                                                                 <ColumnDefinition Width="40" />
                                                                         </Grid.ColumnDefinitions>
                                                                         <TextBlock Grid.Column="1" x:Name="ButtonShowSqlSchemaImage" Style="{StaticResource ToolbarGlyphStyle}" Text="&#xE8FD;" />
-                                                                        <AccessText Grid.Column="3" IsHitTestVisible="False" x:Name="ButtonShowSqlSchemaText" Text="S_chema" Style="{StaticResource ButtonAccessTextStyle}" />
+                                                                        <AccessText Grid.Column="3" IsHitTestVisible="False" x:Name="ButtonShowSqlSchemaText" Text="Sche_ma" Style="{StaticResource ButtonAccessTextStyle}" />
                                                                 </Grid>
                                                         </Border>
                                                 </Button>
@@ -424,7 +424,7 @@
                                                                                 <ColumnDefinition Width="40" />
                                                                         </Grid.ColumnDefinitions>
                                                                         <TextBlock Grid.Column="1" x:Name="ButtonResetImage" Style="{StaticResource ToolbarGlyphStyle}" Text="&#xE777;" />
-                                                                        <AccessText Grid.Column="3" IsHitTestVisible="False" x:Name="ButtonResetText" Text="_Reset" Style="{StaticResource ButtonAccessTextStyle}" />
+                                                                        <AccessText Grid.Column="3" IsHitTestVisible="False" x:Name="ButtonResetText" Text="Reset" Style="{StaticResource ButtonAccessTextStyle}" />
                                                                 </Grid>
                                                         </Border>
                                                 </Button>

--- a/tests/Test-EditorNavigationKey.Tests.ps1
+++ b/tests/Test-EditorNavigationKey.Tests.ps1
@@ -1,0 +1,56 @@
+BeforeAll {
+    . $PSScriptRoot\..\src\Lib\Functions\Private\Test-EditorNavigationKey.ps1
+}
+
+Describe "Test-EditorNavigationKey" {
+    Context "keys WPF's TabControl claims for first/last-tab navigation" {
+        # Key names are passed as [System.Windows.Input.Key] names (what .ToString() yields) rather
+        # than the WPF types, so this suite runs headless without PresentationCore.
+        It "returns true for Home (TabControl would jump to the first tab)" {
+            Test-EditorNavigationKey -KeyName "Home" | Should -BeTrue
+        }
+
+        It "returns true for End (TabControl would jump to the last tab)" {
+            Test-EditorNavigationKey -KeyName "End" | Should -BeTrue
+        }
+
+        It "is case-insensitive on the key name" {
+            Test-EditorNavigationKey -KeyName "home" | Should -BeTrue
+            Test-EditorNavigationKey -KeyName "END" | Should -BeTrue
+        }
+
+        It "trims surrounding whitespace" {
+            Test-EditorNavigationKey -KeyName " Home " | Should -BeTrue
+        }
+    }
+
+    Context "keys the TabControl does not claim must not be intercepted" {
+        # Verified empirically against a real WPF TabControl: only Home and End are stolen. Anything
+        # else listed here must keep flowing normally, so the editor and grid behave as usual.
+        It "returns false for <_>" -ForEach @(
+            "PageUp", "PageDown", "Up", "Down", "Left", "Right",
+            "Tab", "Back", "Delete", "Enter", "Escape", "Space", "A", "S", "F5"
+        ) {
+            Test-EditorNavigationKey -KeyName $_ | Should -BeFalse
+        }
+    }
+
+    Context "defensive input" {
+        It "returns false for an empty key name" {
+            Test-EditorNavigationKey -KeyName "" | Should -BeFalse
+        }
+
+        It "returns false for whitespace" {
+            Test-EditorNavigationKey -KeyName "   " | Should -BeFalse
+        }
+
+        It "returns false when no key name is supplied at all" {
+            Test-EditorNavigationKey | Should -BeFalse
+        }
+
+        It "does not match a key whose name merely contains Home or End" {
+            Test-EditorNavigationKey -KeyName "HomePage" | Should -BeFalse
+            Test-EditorNavigationKey -KeyName "Append" | Should -BeFalse
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`Home` / `End` in the SQL editor jump to the first/last **tab** instead of moving the caret. Reported for `Shift+Home` / `Shift+End`, but it affects `Home`, `End`, and every modifier combination — including `Ctrl+Home` / `Ctrl+End` (document start/end).

Nothing in the app binds these keys. WPF's `TabControl.OnKeyDown` claims `Home`/`End` for its own first/last-tab navigation and switches on the key alone, ignoring modifiers. A WPF `TextBox` never triggers it because it handles Home/End itself and marks the event handled; the WebView2 hosting Monaco does not, so the key bubbles out of the editor and reaches the TabControl.

Pre-existing, from the tabbed-sessions feature (#28 / #31) — not from the autocompletion work in #33.

## Why the obvious fix doesn't work

Verified against a **real WebView2 + Monaco**: simply marking the key handled is not enough. WebView2 only forwards a key to the web content when the WPF routed event returns *unhandled*, so handling it stops the tab switch **but also kills the caret move**. Measured directly — with the stock TabControl, Home switched tab, the caret did not move, and the page saw no keydown at all.

`TabItem.Focusable = false` was also tested and rejected: it stops the tab switch but still leaves `Handled = true`, so the caret stays dead.

## The fix (two halves — both required)

- **`Initialize-OmadaSqltroubleShooter`** — a class handler on `TabControl`. Class handlers of a derived type run before `UIElement`'s (which is what invokes `OnKeyDown`), so marking Home/End handled there means the tab never changes.
- **`MainForm.Definition`** — a `handledEventsToo` handler at the window resets `Handled` once the bubble is past the TabControl, handing the key back to Monaco.

Both are gated on the event originating from a `WebView2` (confirmed `OriginalSource` is exactly `Microsoft.Web.WebView2.Wpf.WebView2`), so `TextBox` / `DataGrid` keep normal Home/End behaviour.

Measured with the fix in place, real WebView2 + Monaco:

| key | caret | tab |
|---|---|---|
| `HOME` | col 10 → **1** | stays |
| `END` | col 10 → **21** | stays |

## Alt access keys

All live in one scope, so duplicates only cycle focus instead of invoking:

- **Alt+C** was bound to *both* Schema and Connect. Schema moves to **Alt+M** (`Sche_ma`); Alt+C is now Connect — and Disconnect becomes `Dis_connect` so the same key works in **both** connection states.
- **Alt+R** was bound to *both* Refresh and Reset. Reset loses its access key; **Alt+R** is unambiguously Refresh.

## Ctrl+S

No change needed and **no double-save**: the WPF handler marks it handled, which withholds it from the browser, so Monaco's `Ctrl+S_global` postMessage never fires and exactly one save runs. Verified empirically.

## Verification

- PSScriptAnalyzer clean · **106/106** unit tests (23 new) · **29/29** E2E
- `Test-EditorNavigationKey` holds the key predicate and is unit tested from key names, without loading PresentationCore (keeps it CI-safe)
- Key-steal set confirmed empirically as exactly `Home` + `End` — PageUp/PageDown, arrows, Tab, Enter, Escape, letters and F5 are unaffected

Not yet done: a click-through in the real app (validated in an isolated real-WebView2 harness instead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P7BXcWcnRUEPy8gvs8p1GH