### PR TITLE
Add a wildcard filter to the SQL schema tree

### DIFF
--- a/src/Lib/Events/SqlSchemaForm.Elements.TextBoxSchemaFilter.ps1
+++ b/src/Lib/Events/SqlSchemaForm.Elements.TextBoxSchemaFilter.ps1
@@ -1,0 +1,66 @@
+# Debounce the filter: a large database schema puts thousands of TreeViewItems in the tree, and
+# re-evaluating all of them on every keystroke makes typing feel sticky. The timer is created here,
+# at the top level of an event file, and its Tick handler is a plain scriptblock - see the comment
+# in MainForm.Definition.ps1: a .GetNewClosure() block runs in a detached dynamic module that cannot
+# resolve this module's private functions.
+$Script:SqlSchemaFilterTimer = New-Object System.Windows.Threading.DispatcherTimer
+$Script:SqlSchemaFilterTimer.Interval = [TimeSpan]::FromMilliseconds(250)
+$Script:SqlSchemaFilterTimer.Add_Tick({
+        try {
+            $Script:SqlSchemaFilterTimer.Stop()
+            Update-SqlSchemaTreeFilter
+        }
+        catch {
+            $_.Exception.Message | Write-LogOutput -LogType ERROR -ErrorObject $_
+        }
+    })
+
+$Script:SqlSchemaForm.Elements.TextBoxSchemaFilter.Add_TextChanged({
+
+        param (
+            $EventSender,
+            $EventArgs
+        )
+
+        try {
+            $_ | Show-EventInfo -LogType VERBOSE2
+
+            # Restart the countdown on every keystroke so the filter is applied once the user pauses.
+            $Script:SqlSchemaFilterTimer.Stop()
+            $Script:SqlSchemaFilterTimer.Start()
+        }
+        catch {
+            $_.Exception.Message | Write-LogOutput -LogType ERROR -ErrorObject $_
+        }
+    })
+
+$Script:SqlSchemaForm.Elements.TextBoxSchemaFilter.Add_PreviewKeyDown({
+
+        param (
+            $EventSender,
+            $EventArgs
+        )
+
+        try {
+            $_ | Show-EventInfo -LogType VERBOSE2
+
+            if ($EventArgs.Key -eq [System.Windows.Input.Key]::Escape) {
+                "Escape key intercepted at schema filter level - clearing the filter" | Write-LogOutput -LogType VERBOSE
+
+                $EventArgs.Handled = $true
+                # Clearing the text raises TextChanged, which restarts the debounce timer and
+                # restores the full tree.
+                $Script:SqlSchemaForm.Elements.TextBoxSchemaFilter.Clear()
+            }
+            elseif ($EventArgs.Key -in ([System.Windows.Input.Key]::Enter, [System.Windows.Input.Key]::Return)) {
+                "Enter/Return key intercepted at schema filter level - applying the filter" | Write-LogOutput -LogType VERBOSE
+
+                $EventArgs.Handled = $true
+                $Script:SqlSchemaFilterTimer.Stop()
+                Update-SqlSchemaTreeFilter
+            }
+        }
+        catch {
+            $_.Exception.Message | Write-LogOutput -LogType ERROR -ErrorObject $_
+        }
+    })

--- a/src/Lib/Functions/Private/ConvertTo-WildcardFilterPattern.ps1
+++ b/src/Lib/Functions/Private/ConvertTo-WildcardFilterPattern.ps1
@@ -1,0 +1,37 @@
+function ConvertTo-WildcardFilterPattern {
+    <#
+    .SYNOPSIS
+    Converts a filter value typed by the user into a PowerShell -like pattern.
+
+    .DESCRIPTION
+    Used by the SQL schema tree filter. The value is matched as a case-insensitive substring, so it
+    is wrapped in wildcards: "Object" becomes "*Object*". When the value already contains "*" or "?"
+    the user is in control and those characters keep their wildcard meaning, so "tbl*Type" becomes
+    "*tbl*Type*". Any other character is escaped, because "[" and "]" open a character class in a
+    -like pattern.
+
+    A null, empty or whitespace-only value returns $null, which callers treat as "no filter".
+    Matching itself is case-insensitive because -like is case-insensitive by default.
+    #>
+    [CmdLetBinding()]
+    param(
+        [string]$FilterValue
+    )
+
+    $Trimmed = if ($null -ne $FilterValue) { $FilterValue.Trim() } else { "" }
+
+    if ([string]::IsNullOrWhiteSpace($Trimmed)) {
+        return $null
+    }
+
+    $EscapedCharacters = $Trimmed.ToCharArray() | ForEach-Object {
+        if ($_ -eq "*" -or $_ -eq "?") {
+            [string]$_
+        }
+        else {
+            [System.Management.Automation.WildcardPattern]::Escape([string]$_)
+        }
+    }
+
+    return "*{0}*" -f ($EscapedCharacters -join "")
+}

--- a/src/Lib/Functions/Private/Get-SqlSchema.ps1
+++ b/src/Lib/Functions/Private/Get-SqlSchema.ps1
@@ -118,6 +118,13 @@ function Get-SqlSchemaObject {
                 $SchemaObjects.Add($Schema, $TableObjects)
             }
 
+            if ($UpdateSchemaWindow) {
+                # The tree was rebuilt from scratch above, so every node is visible again. Re-apply
+                # whatever the user has typed in the filter box, otherwise switching tab or data
+                # connection silently drops an active filter.
+                Update-SqlSchemaTreeFilter
+            }
+
             $SchemaObjectsJson = $SchemaObjects | ConvertTo-Json -Depth 5
 
             "Schema for Monaco editor: {0}" -f $SchemaObjectsJson | Write-LogOutput -LogType VERBOSE

--- a/src/Lib/Functions/Private/Open-SqlSchemaForm.ps1
+++ b/src/Lib/Functions/Private/Open-SqlSchemaForm.ps1
@@ -163,6 +163,13 @@ function Open-SqlSchemaForm {
 
         $Script:SqlSchemaForm.Definition.Add_Closed({
                 $_ | Show-EventInfo
+                # Stop the pending filter debounce, so a tick can never fire against the tree of a
+                # window that is already gone.
+                if ($null -ne $Script:SqlSchemaFilterTimer) {
+                    $Script:SqlSchemaFilterTimer.Stop()
+                    $Script:SqlSchemaFilterTimer = $null
+                }
+
                 $Script:SqlSchemaForm.State = "Closed"
                 $Script:MainForm.Elements.ButtonShowSqlSchema.IsEnabled = $true
                 Restore-MainFormFocus

--- a/src/Lib/Functions/Private/Update-SqlSchemaTreeFilter.ps1
+++ b/src/Lib/Functions/Private/Update-SqlSchemaTreeFilter.ps1
@@ -1,0 +1,79 @@
+function Update-SqlSchemaTreeFilter {
+    <#
+    .SYNOPSIS
+    Applies the schema filter to the SQL schema TreeView by hiding non-matching nodes.
+
+    .DESCRIPTION
+    The tree is built imperatively in Get-SqlSchemaObject (schema -> table -> column), so filtering
+    toggles TreeViewItem.Visibility instead of rebuilding the tree. That keeps the hierarchy, the
+    expansion state and the column children intact, and costs no extra round-trip to Omada.
+
+    Visibility rules:
+    - A table is visible when its own name matches, or when its parent schema name matches.
+    - A schema is visible when its own name matches or when at least one of its tables matches.
+      A schema name hit therefore reveals the complete table list of that schema.
+    - Columns are never filtered: expanding a visible table always shows all of its columns.
+
+    Called without -FilterValue the function re-applies whatever is currently typed in the filter
+    box, which is what Get-SqlSchemaObject needs after it rebuilt the tree for another connection.
+    #>
+    [CmdLetBinding()]
+    param(
+        [string]$FilterValue
+    )
+    try {
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+
+        # The schema window is optional: the schema itself is also retrieved to feed the editor's
+        # IntelliSense, so there is nothing to filter when the window was never opened.
+        if ($null -eq $Script:TreeViewSqlSchema) {
+            "Sql schema tree is not available, skip filtering" | Write-LogOutput -LogType DEBUG
+            return
+        }
+
+        if (!$PSBoundParameters.ContainsKey("FilterValue")) {
+            $FilterValue = ""
+            if ($null -ne $Script:SqlSchemaForm -and $null -ne $Script:SqlSchemaForm.Elements -and $null -ne $Script:SqlSchemaForm.Elements.TextBoxSchemaFilter) {
+                $FilterValue = $Script:SqlSchemaForm.Elements.TextBoxSchemaFilter.Text
+            }
+        }
+
+        $Pattern = ConvertTo-WildcardFilterPattern -FilterValue $FilterValue
+
+        $VisibleTableCount = 0
+        foreach ($SchemaItem in $Script:TreeViewSqlSchema.Items) {
+            # A null pattern means "no filter": every schema matches, so every table below it stays
+            # visible without evaluating a pattern at all.
+            $SchemaMatches = ($null -eq $Pattern) -or ($SchemaItem.Header -like $Pattern)
+
+            $VisibleTablesInSchema = 0
+            foreach ($TableItem in $SchemaItem.Items) {
+                if ($SchemaMatches -or ($TableItem.Header -like $Pattern)) {
+                    $TableItem.Visibility = [System.Windows.Visibility]::Visible
+                    $VisibleTablesInSchema++
+                }
+                else {
+                    $TableItem.Visibility = [System.Windows.Visibility]::Collapsed
+                }
+            }
+
+            if ($SchemaMatches -or $VisibleTablesInSchema -gt 0) {
+                $SchemaItem.Visibility = [System.Windows.Visibility]::Visible
+                if ($null -ne $Pattern) {
+                    # Expand while filtering so the hits are visible without an extra click.
+                    $SchemaItem.IsExpanded = $true
+                }
+            }
+            else {
+                $SchemaItem.Visibility = [System.Windows.Visibility]::Collapsed
+            }
+
+            $VisibleTableCount += $VisibleTablesInSchema
+        }
+
+        "Sql schema filter '{0}' (pattern '{1}'): {2} table(s) visible" -f $FilterValue, $Pattern, $VisibleTableCount | Write-LogOutput -LogType DEBUG
+    }
+    catch {
+        $_.Exception.Message | Write-LogOutput -LogType ERROR -ErrorObject $_
+    }
+}

--- a/src/Lib/ui/SqlSchemaForm.xaml
+++ b/src/Lib/ui/SqlSchemaForm.xaml
@@ -16,11 +16,32 @@
             <Setter Property="Height" Value="30"/>
             <Setter Property="Width" Value="120"/>
         </Style>
+        <Style TargetType="TextBox">
+            <Setter Property="Background"
+                    Value="{DynamicResource {x:Static SystemColors.WindowBrushKey}}"/>
+            <Setter Property="FontFamily"
+                    Value="Consolas"/>
+            <Setter Property="FontSize"
+                    Value="14"/>
+            <Setter Property="VerticalContentAlignment"
+                    Value="Center"/>
+            <Setter Property="Height"
+                    Value="25"/>
+        </Style>
+        <Style TargetType="Label">
+            <Setter Property="VerticalContentAlignment"
+                    Value="Center"/>
+            <Setter Property="Height"
+                    Value="25"/>
+            <Setter Property="Width"
+                    Value="50"/>
+        </Style>
     </Window.Resources>
 
     <Grid Grid.Row="0" >
         <Grid.RowDefinitions>
             <RowDefinition Height="10"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
@@ -32,10 +53,18 @@
             <ColumnDefinition Width="10"/>
         </Grid.ColumnDefinitions>
 
-        <Border Grid.Row="1" Grid.Column="1" BorderBrush="Gray" BorderThickness="1" Background="{DynamicResource {x:Static SystemColors.AppWorkspaceBrushKey}}">
+        <DockPanel Grid.Row="1" Grid.Column="1" LastChildFill="True" Margin="0,0,0,5">
+            <Label DockPanel.Dock="Left"
+                   Content="_Filter:"
+                   Target="{Binding ElementName=TextBoxSchemaFilter}"/>
+            <TextBox x:Name="TextBoxSchemaFilter"
+                     ToolTip="Filter schemas and tables on any part of their name. Use * and ? for explicit wildcards, for example tbl*Type. Press Esc to clear."/>
+        </DockPanel>
+
+        <Border Grid.Row="2" Grid.Column="1" BorderBrush="Gray" BorderThickness="1" Background="{DynamicResource {x:Static SystemColors.AppWorkspaceBrushKey}}">
             <TreeView x:Name="TreeViewSqlSchema" FontFamily="Consolas" VirtualizingStackPanel.IsVirtualizing="True" ScrollViewer.VerticalScrollBarVisibility="Auto" ScrollViewer.HorizontalScrollBarVisibility="Auto"></TreeView>
         </Border>
-        <StackPanel Orientation="Horizontal" Grid.Row="2" Grid.Column="1" VerticalAlignment="Center">
+        <StackPanel Orientation="Horizontal" Grid.Row="3" Grid.Column="1" VerticalAlignment="Center">
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*"/>
@@ -46,7 +75,7 @@
                 </Grid.ColumnDefinitions>
             </Grid>
         </StackPanel>
-        <StackPanel Orientation="Vertical" Grid.Row="3" Grid.Column="1" VerticalAlignment="Center">
+        <StackPanel Orientation="Vertical" Grid.Row="4" Grid.Column="1" VerticalAlignment="Center">
             <StackPanel Orientation="Horizontal">
             </StackPanel>
         </StackPanel>

--- a/tests/ConvertTo-WildcardFilterPattern.Tests.ps1
+++ b/tests/ConvertTo-WildcardFilterPattern.Tests.ps1
@@ -1,0 +1,53 @@
+BeforeAll {
+    $ParentPath = Split-Path -Path $PSScriptRoot -Parent
+    $Command = Join-Path $ParentPath -ChildPath "src\lib\functions\Private\ConvertTo-WildcardFilterPattern.ps1"
+    . $Command
+    $Script:Tracer = [System.Diagnostics.Trace]
+    $Script:RunTimeConfig = [PSCustomObject]@{ ApplicationName = "Test" }
+}
+
+Describe 'ConvertTo-WildcardFilterPattern' {
+    It 'wraps a plain value in wildcards' {
+        ConvertTo-WildcardFilterPattern -FilterValue "Object" | Should -Be "*Object*"
+    }
+
+    It 'trims surrounding whitespace before building the pattern' {
+        ConvertTo-WildcardFilterPattern -FilterValue "  Data  " | Should -Be "*Data*"
+    }
+
+    It 'returns null for an empty value' {
+        ConvertTo-WildcardFilterPattern -FilterValue "" | Should -BeNullOrEmpty
+    }
+
+    It 'returns null for a whitespace-only value' {
+        ConvertTo-WildcardFilterPattern -FilterValue "   " | Should -BeNullOrEmpty
+    }
+
+    It 'returns null for a null value' {
+        ConvertTo-WildcardFilterPattern -FilterValue $null | Should -BeNullOrEmpty
+    }
+
+    It 'keeps an explicit asterisk wildcard intact' {
+        ConvertTo-WildcardFilterPattern -FilterValue "tbl*Type" | Should -Be "*tbl*Type*"
+    }
+
+    It 'keeps an explicit question mark wildcard intact' {
+        ConvertTo-WildcardFilterPattern -FilterValue "tbl?Object" | Should -Be "*tbl?Object*"
+    }
+
+    It 'escapes bracket characters so they are not read as a character class' {
+        ConvertTo-WildcardFilterPattern -FilterValue "a[b" | Should -Be '*a`[b*'
+    }
+
+    It 'matches case-insensitively' {
+        "ObjectTable" -like (ConvertTo-WildcardFilterPattern -FilterValue "object") | Should -BeTrue
+    }
+
+    It 'matches a substring that spans a casing boundary' {
+        "ObjectTable" -like (ConvertTo-WildcardFilterPattern -FilterValue "ctt") | Should -BeTrue
+    }
+
+    It 'does not match when the characters are not adjacent' {
+        "ObjectTable" -like (ConvertTo-WildcardFilterPattern -FilterValue "tbl") | Should -BeFalse
+    }
+}

--- a/tests/Update-SqlSchemaTreeFilter.Tests.ps1
+++ b/tests/Update-SqlSchemaTreeFilter.Tests.ps1
@@ -1,0 +1,211 @@
+BeforeAll {
+    Add-Type -AssemblyName PresentationCore
+
+    $ParentPath = Split-Path -Path $PSScriptRoot -Parent
+    . (Join-Path $ParentPath -ChildPath "src\lib\functions\Private\ConvertTo-WildcardFilterPattern.ps1")
+    . (Join-Path $ParentPath -ChildPath "src\lib\functions\Private\Update-SqlSchemaTreeFilter.ps1")
+
+    $Script:Tracer = [System.Diagnostics.Trace]
+    $Script:RunTimeConfig = [PSCustomObject]@{ ApplicationName = "Test" }
+
+    function Write-LogOutput {
+        param(
+            [Parameter(ValueFromPipeline = $true)]$InputObject,
+            [string]$LogType,
+            $ErrorObject,
+            [switch]$SkipDialog
+        )
+        process { }
+    }
+
+    # Update-SqlSchemaTreeFilter only reads Header/Items and writes Visibility/IsExpanded, so the
+    # tree is stubbed with plain objects. That keeps the test out of WPF's STA requirement while
+    # still exercising the real visibility rules against the example schema from the feature request.
+    function New-SchemaTreeStub {
+        $Definition = [ordered]@{
+            adhoc = @("random")
+            cag   = @("ObjectTable", "DataObjectTable", "dbolist")
+            dbo   = @("tblDataObjectType", "tblObject", "tblValue")
+        }
+
+        $SchemaItems = foreach ($SchemaName in $Definition.Keys) {
+            $TableItems = foreach ($TableName in $Definition[$SchemaName]) {
+                [PSCustomObject]@{
+                    Header     = $TableName
+                    Items      = @()
+                    Visibility = [System.Windows.Visibility]::Visible
+                    IsExpanded = $false
+                }
+            }
+
+            [PSCustomObject]@{
+                Header     = $SchemaName
+                Items      = @($TableItems)
+                Visibility = [System.Windows.Visibility]::Visible
+                IsExpanded = $true
+            }
+        }
+
+        return [PSCustomObject]@{ Items = @($SchemaItems) }
+    }
+
+    function Get-VisibleTreeLine {
+        param($Tree)
+
+        $Lines = @()
+        foreach ($SchemaItem in $Tree.Items) {
+            if ($SchemaItem.Visibility -ne [System.Windows.Visibility]::Visible) {
+                continue
+            }
+
+            $Lines += $SchemaItem.Header
+            foreach ($TableItem in $SchemaItem.Items) {
+                if ($TableItem.Visibility -eq [System.Windows.Visibility]::Visible) {
+                    $Lines += "  {0}" -f $TableItem.Header
+                }
+            }
+        }
+
+        return $Lines
+    }
+}
+
+Describe 'Update-SqlSchemaTreeFilter' {
+    BeforeEach {
+        $Script:TreeViewSqlSchema = New-SchemaTreeStub
+    }
+
+    It 'shows the whole tree when the filter is empty' {
+        Update-SqlSchemaTreeFilter -FilterValue ""
+        Get-VisibleTreeLine -Tree $Script:TreeViewSqlSchema | Should -Be @(
+            "adhoc"
+            "  random"
+            "cag"
+            "  ObjectTable"
+            "  DataObjectTable"
+            "  dbolist"
+            "dbo"
+            "  tblDataObjectType"
+            "  tblObject"
+            "  tblValue"
+        )
+    }
+
+    It 'restores the whole tree after a filter was applied' {
+        Update-SqlSchemaTreeFilter -FilterValue "Object"
+        Update-SqlSchemaTreeFilter -FilterValue ""
+        (Get-VisibleTreeLine -Tree $Script:TreeViewSqlSchema).Count | Should -Be 10
+    }
+
+    It 'filters on "Object"' {
+        Update-SqlSchemaTreeFilter -FilterValue "Object"
+        Get-VisibleTreeLine -Tree $Script:TreeViewSqlSchema | Should -Be @(
+            "cag"
+            "  ObjectTable"
+            "  DataObjectTable"
+            "dbo"
+            "  tblDataObjectType"
+            "  tblObject"
+        )
+    }
+
+    It 'filters on "tbl"' {
+        Update-SqlSchemaTreeFilter -FilterValue "tbl"
+        Get-VisibleTreeLine -Tree $Script:TreeViewSqlSchema | Should -Be @(
+            "dbo"
+            "  tblDataObjectType"
+            "  tblObject"
+            "  tblValue"
+        )
+    }
+
+    It 'filters on "Data"' {
+        Update-SqlSchemaTreeFilter -FilterValue "Data"
+        Get-VisibleTreeLine -Tree $Script:TreeViewSqlSchema | Should -Be @(
+            "cag"
+            "  DataObjectTable"
+            "dbo"
+            "  tblDataObjectType"
+        )
+    }
+
+    It 'filters on "ctt", which spans a casing boundary' {
+        Update-SqlSchemaTreeFilter -FilterValue "ctt"
+        Get-VisibleTreeLine -Tree $Script:TreeViewSqlSchema | Should -Be @(
+            "cag"
+            "  ObjectTable"
+            "  DataObjectTable"
+            "dbo"
+            "  tblDataObjectType"
+        )
+    }
+
+    It 'shows every table of a schema whose own name matches' {
+        Update-SqlSchemaTreeFilter -FilterValue "dbo"
+        Get-VisibleTreeLine -Tree $Script:TreeViewSqlSchema | Should -Be @(
+            "cag"
+            "  dbolist"
+            "dbo"
+            "  tblDataObjectType"
+            "  tblObject"
+            "  tblValue"
+        )
+    }
+
+    It 'honours an explicit wildcard typed by the user' {
+        Update-SqlSchemaTreeFilter -FilterValue "tbl*Type"
+        Get-VisibleTreeLine -Tree $Script:TreeViewSqlSchema | Should -Be @(
+            "dbo"
+            "  tblDataObjectType"
+        )
+    }
+
+    It 'matches case-insensitively' {
+        Update-SqlSchemaTreeFilter -FilterValue "OBJECTTABLE"
+        Get-VisibleTreeLine -Tree $Script:TreeViewSqlSchema | Should -Be @(
+            "cag"
+            "  ObjectTable"
+            "  DataObjectTable"
+        )
+    }
+
+    It 'hides every schema when nothing matches' {
+        Update-SqlSchemaTreeFilter -FilterValue "zzz"
+        Get-VisibleTreeLine -Tree $Script:TreeViewSqlSchema | Should -BeNullOrEmpty
+    }
+
+    It 'expands the schemas that survive the filter' {
+        foreach ($SchemaItem in $Script:TreeViewSqlSchema.Items) {
+            $SchemaItem.IsExpanded = $false
+        }
+
+        Update-SqlSchemaTreeFilter -FilterValue "Data"
+
+        ($Script:TreeViewSqlSchema.Items | Where-Object { $_.Header -eq "cag" }).IsExpanded | Should -BeTrue
+        ($Script:TreeViewSqlSchema.Items | Where-Object { $_.Header -eq "dbo" }).IsExpanded | Should -BeTrue
+    }
+
+    It 'reads the filter box when no filter value is passed' {
+        $Script:SqlSchemaForm = [PSCustomObject]@{
+            Elements = [PSCustomObject]@{
+                TextBoxSchemaFilter = [PSCustomObject]@{ Text = "Data" }
+            }
+        }
+
+        Update-SqlSchemaTreeFilter
+
+        Get-VisibleTreeLine -Tree $Script:TreeViewSqlSchema | Should -Be @(
+            "cag"
+            "  DataObjectTable"
+            "dbo"
+            "  tblDataObjectType"
+        )
+
+        $Script:SqlSchemaForm = $null
+    }
+
+    It 'does not throw when the schema window was never opened' {
+        $Script:TreeViewSqlSchema = $null
+        { Update-SqlSchemaTreeFilter -FilterValue "Object" } | Should -Not -Throw
+    }
+}


### PR DESCRIPTION
## What

Adds a filter box above the SQL Schema Viewer tree. Typing narrows the tree to matching schemas and tables while keeping the hierarchy intact — matching tables stay grouped under their schema.

Closes the "no way to find a table other than scrolling" gap: on a real Omada database the tree holds hundreds of tables across several schemas, and the app had no filter or search control anywhere.

## Matching rules

- **Case-insensitive substring**, wrapped in wildcards: `Object` becomes `*Object*`. `ctt` matches `ObjectTable`, because "obje**ctT**able" contains it literally.
- `*` and `?` typed by the user keep their wildcard meaning (`tbl*Type`); every other character is escaped, so `[` cannot open a character class.
- A **table** is visible when its own name matches, or when its parent schema name matches.
- A **schema** is visible when its own name matches or when at least one of its tables matches. A schema-name hit reveals that schema's complete table list.
- **Columns are never filtered** — expanding a visible table always shows all of its columns.
- Empty filter restores the full tree.

Against the tree `adhoc/random`, `cag/{ObjectTable, DataObjectTable, dbolist}`, `dbo/{tblDataObjectType, tblObject, tblValue}`:

| Filter | Result |
| --- | --- |
| `Object` | `cag/{ObjectTable, DataObjectTable}` + `dbo/{tblDataObjectType, tblObject}` |
| `tbl` | `dbo/{tblDataObjectType, tblObject, tblValue}` |
| `Data` | `cag/DataObjectTable` + `dbo/tblDataObjectType` |
| `ctt` | `cag/{ObjectTable, DataObjectTable}` + `dbo/tblDataObjectType` |
| `dbo` | `cag/dbolist` + all three `dbo` tables |

## How

The tree is built imperatively in `Get-SqlSchemaObject` as plain `TreeViewItem` objects — no `ItemsSource`, no `CollectionView` — so filtering toggles `TreeViewItem.Visibility` instead of rebuilding the tree. That preserves hierarchy, expansion state and column children, and costs no extra round-trip to Omada.

| File | Change |
| --- | --- |
| `src/Lib/ui/SqlSchemaForm.xaml` | New `Auto` row above the tree with a `Filter:` label and `TextBoxSchemaFilter`; TextBox/Label styles copied from `SqlHistoryForm.xaml`; existing rows renumbered |
| `src/Lib/Functions/Private/ConvertTo-WildcardFilterPattern.ps1` | New. Builds the `-like` pattern |
| `src/Lib/Functions/Private/Update-SqlSchemaTreeFilter.ps1` | New. Applies the visibility rules to the tree |
| `src/Lib/Events/SqlSchemaForm.Elements.TextBoxSchemaFilter.ps1` | New. 250 ms `DispatcherTimer` debounce, `Esc` clears, `Enter` applies immediately |
| `src/Lib/Functions/Private/Get-SqlSchema.ps1` | Re-applies the filter after the tree is rebuilt, so switching tab or data connection does not silently drop it |
| `src/Lib/Functions/Private/Open-SqlSchemaForm.ps1` | Stops the debounce timer on close, so a tick cannot fire against a closed window |

No wiring changes were needed: `Initialize-FormObject` already discovers `TextBox` nodes by type, so the control lands in `$Script:SqlSchemaForm.Elements.TextBoxSchemaFilter`, and `Open-SqlSchemaForm` already calls `Import-EventObjects -ClassName "SqlSchemaForm"`, which picks up the new event file.

The debounce timer is created at the top level of the event file with a plain `Add_Tick` scriptblock, following the rule documented in `MainForm.Definition.ps1`: a `.GetNewClosure()` block runs in a detached dynamic module that cannot resolve this module's private functions.

## Verification

- **134 unit tests pass**, including 24 new ones. `tests/Update-SqlSchemaTreeFilter.Tests.ps1` asserts every filter value in the table above against that exact tree; `tests/ConvertTo-WildcardFilterPattern.Tests.ps1` covers pattern building, escaping and explicit wildcards.
- **32 e2e tests pass** (`tests/e2e/Invoke-E2ESuite.ps1`), confirming the XAML row renumbering broke nothing.
- The XAML was loaded in a real STA WPF host with real `TreeViewItem`s and produced exactly the results in the table above.
- PSScriptAnalyzer reports only the three rules that already fire on every comparable existing file (`PSUseShouldProcessForStateChangingFunctions` on all `Update-*`/`New-*` functions, `PSAvoidAssignmentToAutomaticVariable` and `PSReviewUnusedParameter` on all event files).

**Not verified:** the live path against an actual Omada connection.

## Out of scope

Match highlighting, filtering on column names, and persisting the filter text between sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)