### PR TITLE
Add third-party notices and privacy documentation

### DIFF
--- a/OmadaSqlTroubleshooter.nuspec
+++ b/OmadaSqlTroubleshooter.nuspec
@@ -4,8 +4,13 @@
         <id>OmadaSqlTroubleshooter</id>
         <version>$VERSION$</version>
         <authors>Fortigi</authors>
-        <description>This module contains the Omada Sql Troubleshooter application.</description>
+        <description>This module contains the Omada Sql Troubleshooter application. Third-party components bundled with, downloaded by, or required by this package are listed with their licences in THIRD-PARTY-NOTICES.md, included in this package. Data handling and privacy are documented in the "Data handling and privacy" section of README.md.</description>
         <copyright>Copyright $YEAR$ - present Fortigi</copyright>
+        <license type="expression">MIT</license>
+        <projectUrl>https://github.com/Fortigi/OmadaSqlTroubleshooter</projectUrl>
+        <!-- LICENSE and THIRD-PARTY-NOTICES.md are copied into the build output by
+             build/psakeBuild.ps1, so they are picked up by the wildcard below and ship inside
+             the package alongside the module. -->
     </metadata>
     <files>
         <file src="buildoutput\OmadaSqlTroubleShooter\**" target="" />

--- a/README.md
+++ b/README.md
@@ -269,6 +269,109 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 > This is a limitation of the SQL Troubleshooter component in Omada Identity Suite,
 > which does not distinguish between an empty result set and a query execution failure.
 
+## DATA HANDLING & PRIVACY
+
+OmadaSqlTroubleshooter is used by identity professionals against production IGA data, so it is
+worth stating plainly — and checkably — what the application does with that data.
+
+In short: **the application sends no telemetry, all identity data flows only between your
+machine and your own Omada tenant, and everything it keeps is kept locally in your own Windows
+user profile.**
+
+### No telemetry
+
+The module contains no analytics, telemetry, usage-tracking or crash-reporting code, and no
+such SDK is bundled. Nothing about you, your tenant, your queries or your results is sent to
+Fortigi or to any third party.
+
+Every destination the module can contact is hard-coded in the source and listed below; there
+are no others. You can verify this for yourself in two ways: search the module source for
+`http`, or start the application with `Invoke-OmadaSqlTroubleshooter -LogLevel VERBOSE
+-LogToConsole` and watch every request it makes.
+
+### Where the application connects
+
+| Destination | When | What is sent | Why |
+|---|---|---|---|
+| **Your Omada tenant** (`https://<tenant>.omada.cloud` or the URL you enter) | While connected | Your SQL query text, saved query metadata and OData requests; the session credential or token for the tenant | This is the application's actual work: the SQL Troubleshooter OData endpoint (`C_P_SQLTROUBLESHOOTING`) and the Omada Enterprise Server API |
+| **Your identity provider** (Entra ID or the tenant's own sign-in page) | On sign-in only | Your credentials, handled by the browser/WebView2 sign-in flow of [OmadaWeb.PS](https://github.com/Fortigi/OmadaWeb.PS) | Authentication |
+| `api.nuget.org` and `www.nuget.org` | On module import | Nothing but the package request itself | Resolve and download the Microsoft WebView2 .NET SDK — see [THIRD-PARTY-NOTICES.md](THIRD-PARTY-NOTICES.md) |
+| `www.powershellgallery.com` | On module import, and only when the module was installed from the PowerShell Gallery | The module name, in a public package-lookup request | Warn you when a newer version is available |
+
+The last two are ordinary package requests to Microsoft-operated services. They carry no
+tenant name, no user name and no query data. No other host is contacted by this module.
+
+### Data stored on your machine
+
+All of it lives in your own Windows user profile. Nothing is written to a shared or roaming
+location beyond `%APPDATA%`, and nothing is written outside your profile.
+
+| Path | Contents | Protection | Lifetime | How to clear |
+|---|---|---|---|---|
+| `%APPDATA%\OmadaSqlTroubleshooter\config\OmadaSqlTroubleshooter.json` | Application settings only: log level, window positions and sizes, last-used export folder and file type, tab capacity, and `InstanceGuid` (see below). No credentials, no query text, no results. | NTFS permissions on your profile | Until deleted | `Invoke-OmadaSqlTroubleshooter -Reset` restores defaults, or delete the file |
+| `%APPDATA%\OmadaSqlTroubleshooter\config\tabs.clixml` | Per-tab session state written when the application closes: tenant URL, user name, Entra application ID URI and tenant ID, the selected data connection, the *name* of the selected saved query, and — only if you ticked **Save password** — your password. The SQL text itself is not stored here; it lives in your Omada tenant. | The password field is encrypted with Windows DPAPI, bound to your Windows user account on that machine. The remaining fields are stored as plain CliXml. | Overwritten at each close; kept until deleted | `Invoke-OmadaSqlTroubleshooter -Reset` deletes the file, or delete it yourself |
+| `%LOCALAPPDATA%\OmadaSqlTroubleshooter\Bin\...` | The Microsoft WebView2 .NET SDK assemblies downloaded from NuGet. No user data. | NTFS permissions on your profile | Until deleted; refreshed when a newer SDK is released | Delete the folder; it is re-downloaded on the next import |
+| `%LOCALAPPDATA%\OmadaSqlTroubleshooter\Edge User Data\OmadaWebView2Profile` | A WebView2 browser-profile folder created when the first tab's editor starts. It is created but not currently used as a profile location — the editor's WebView2 uses the `%TEMP%` folder below — so it stays empty. | NTFS permissions on your profile | Until deleted | Delete the folder |
+| `%TEMP%\OmadaSqlTroubleshooter` | The WebView2 user-data folder (browser cache and local storage) for the editor. This WebView2 instance only ever loads the local Monaco editor page — it never loads Omada or a sign-in page, so it holds no session cookies and no tenant data. | NTFS permissions on your profile | Until deleted; `%TEMP%` is not cleared automatically by the application | Delete the folder while the application is closed |
+| `%LOCALAPPDATA%\OmadaSqlTroubleShooter\Run.ps1`, plus Start Menu and Desktop shortcuts | A small launcher script and shortcuts. No user data. | NTFS permissions on your profile | Until deleted | Delete the file and the shortcuts |
+| Files you export | Query results, query history, or the application log — see the next section | Whatever you choose; the application applies no encryption | Until you delete them | Delete them |
+
+Two details worth knowing:
+
+- **`InstanceGuid`** is a random GUID generated on first run and stored in the settings file. It
+  is never transmitted to Fortigi or to any third party. Its only use is to give the temporary
+  query object that the application creates *inside your own tenant* a stable name
+  (`TMP_<InstanceGuid>`), so repeated runs reuse one object instead of leaving new ones behind.
+- On the very first run, before `%APPDATA%\OmadaSqlTroubleshooter` exists, the settings file is
+  written next to the installed module instead. From the next run onwards it is read and
+  written under `%APPDATA%`.
+
+Authentication cookies, tokens and browser profiles used for signing in are managed by the
+[OmadaWeb.PS](https://github.com/Fortigi/OmadaWeb.PS) module, not by this one; see that
+module's documentation for where it caches them and how to clear them.
+
+### What exports and logs can contain
+
+Query results are production identity data. Treat them accordingly.
+
+- **Exported result files** (JSON, CSV, CliXml, plain text) and **clipboard copies** contain the
+  full rows your query returned. Depending on the query, that can include personal data such as
+  names, e-mail addresses, employee identifiers, manager relationships and account details.
+  Files are written unencrypted, to a location you choose.
+- **Exported query history** contains the SQL text, its change history and the names of the
+  users who created or modified each query.
+- **The application log** records connection URLs, user names and application events. At the
+  default log level it does not contain result data. At `VERBOSE` and `VERBOSE2` it additionally
+  records complete request and response bodies, **including full result-set rows**. Only raise
+  the log level when you need it, and treat an exported log from those levels as if it were an
+  exported result set. Passwords are held as `SecureString`/`PSCredential` and are not written
+  to the log in readable form at any log level.
+
+### Your responsibilities
+
+Once you export a result set, copy rows to the clipboard, or export a `VERBOSE` log, that data
+leaves the application's control and becomes your organisation's responsibility to handle under
+its own data-protection obligations — the GDPR included, where it applies. In practice:
+
+- Export only the columns and rows you actually need, and prefer filtering in the query.
+- Store exports on encrypted, access-controlled storage — not in a personal downloads folder,
+  a shared drive, a ticket attachment or a chat message.
+- Delete exports as soon as the troubleshooting task is finished; there is no automatic cleanup.
+- Remember that a query and its results are visible in Omada under your account, and that the
+  application acts only with the permissions of the signed-in user.
+
+### Scope of this statement
+
+This statement covers the OmadaSqlTroubleshooter module. Authentication is performed by the
+separate [OmadaWeb.PS](https://github.com/Fortigi/OmadaWeb.PS) module, and the Microsoft Edge
+WebView2 Runtime is a Microsoft component installed on your machine; both are governed by their
+own documentation and terms. Third-party components are inventoried in
+[THIRD-PARTY-NOTICES.md](THIRD-PARTY-NOTICES.md).
+
+If you find a statement here that does not match what the code does, please
+[open an issue](https://github.com/Fortigi/OmadaSqlTroubleshooter/issues) — an inaccurate
+privacy statement is a bug.
+
 ## CONTRIBUTING
 
 Contributions are welcome! If you have ideas for improvements or bug fixes, feel free to open a pull request on [GitHub](https://github.com/Fortigi/OmadaSqlTroubleshooter).
@@ -281,3 +384,11 @@ Contributions are welcome! If you have ideas for improvements or bug fixes, feel
 ## LICENSE
 
 This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.
+
+### Third-party components
+
+OmadaSqlTroubleshooter bundles the Monaco editor, downloads the Microsoft WebView2 .NET SDK at
+run time, and requires the Microsoft Edge WebView2 Runtime and the OmadaWeb.PS module. Every
+such component, its version, its licence and where it comes from is listed in
+[THIRD-PARTY-NOTICES.md](THIRD-PARTY-NOTICES.md), which also records the review confirming that
+this project does not redistribute the WebView2 Runtime.

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -1,0 +1,196 @@
+# Third-Party Notices
+
+OmadaSqlTroubleshooter is published by Fortigi under the MIT License — see [LICENSE](LICENSE).
+
+This file lists every third-party component that OmadaSqlTroubleshooter **redistributes**,
+**downloads at run time**, or **requires as a prerequisite**. Each component remains licensed
+under its own terms, reproduced or linked below.
+
+Components are grouped by how they reach the end user, because that determines which
+obligations apply:
+
+| Section | How the component reaches the user | Redistributed by Fortigi? |
+|---|---|---|
+| [1. Redistributed components](#1-redistributed-components) | Committed to this repository and shipped inside the published module | **Yes** |
+| [2. Downloaded at run time](#2-components-downloaded-at-run-time) | Fetched from the vendor's servers onto the user's machine by this module | No |
+| [3. Prerequisites](#3-prerequisites-installed-by-the-user) | Installed separately by the user | No |
+
+Last reviewed: **2026-08-13**, against commit contents of `src/`.
+The inventory below is checked automatically on every pull request by
+`tests/ThirdPartyNotices.Tests.ps1`, so it cannot silently drift out of date.
+
+---
+
+## 1. Redistributed components
+
+The files below are committed to this repository and are copied into the published
+`OmadaSqlTroubleshooter` package by `build/psakeBuild.ps1`. Their licence notices travel with
+the package: `LICENSE` and this file are included in the module output.
+
+### 1.1 Monaco Editor
+
+| Field | Value |
+|---|---|
+| Component | Monaco Editor |
+| Version | 0.52.0 (commit `f6dc0eb8fce67e57f6036f4769d92c1666cdf546`) |
+| Publisher | Microsoft Corporation |
+| Licence | MIT |
+| Project | <https://github.com/microsoft/monaco-editor> |
+| Licence text | <https://github.com/microsoft/monaco-editor/blob/v0.52.0/LICENSE.txt> |
+| Upstream notices | <https://github.com/microsoft/monaco-editor/blob/v0.52.0/ThirdPartyNotices.txt> |
+| Location in repository | `src/Monaco/min/vs/**` |
+| Location in package | `Monaco/min/vs/**` |
+
+Monaco provides the SQL query editor. The redistributed subset comprises the AMD loader
+(`loader.js`), the editor core and its web worker, the `basic-languages/sql` grammar, the
+JSON/HTML/CSS/TypeScript language services, and the localisation message bundles
+(`nls.messages.*.js`).
+
+The MIT licence requires the copyright notice to be preserved. It is preserved in two places:
+in the header comment of each redistributed Monaco file (unmodified from upstream), and here:
+
+```
+The MIT License (MIT)
+
+Copyright (c) 2016 - present Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+### 1.2 Codicons (`codicon.ttf`)
+
+| Field | Value |
+|---|---|
+| Component | Codicons — the VS Code icon font, distributed inside Monaco Editor |
+| Version | As bundled with Monaco Editor 0.52.0 |
+| Publisher | Microsoft Corporation |
+| Licence | Icons: **CC BY 4.0** · Code: **MIT** |
+| Project | <https://github.com/microsoft/vscode-codicons> |
+| Licence text | Icons: <https://github.com/microsoft/vscode-codicons/blob/main/LICENSE> · Code: <https://github.com/microsoft/vscode-codicons/blob/main/LICENSE-CODE> |
+| Location in repository | `src/Monaco/min/vs/base/browser/ui/codicons/codicon/codicon.ttf` |
+| Location in package | `Monaco/min/vs/base/browser/ui/codicons/codicon/codicon.ttf` |
+
+The font file supplies the editor's glyphs and is referenced from
+`src/Monaco/min/vs/editor/editor.main.css`. It is listed separately from Monaco because the
+icon artwork carries a different licence (CC BY 4.0) from the surrounding MIT-licensed code.
+
+Attribution, as CC BY 4.0 requires: *Codicons* © Microsoft Corporation, licensed under
+[CC BY 4.0](https://creativecommons.org/licenses/by/4.0/), unmodified.
+
+---
+
+## 2. Components downloaded at run time
+
+These are **not** redistributed by Fortigi. Each user's machine fetches them directly from the
+vendor, under the vendor's own terms, and they are stored only in that user's profile.
+
+### 2.1 Microsoft.Web.WebView2 (WebView2 .NET SDK)
+
+| Field | Value |
+|---|---|
+| Component | `Microsoft.Web.WebView2` |
+| Version | The latest stable version, resolved at run time |
+| Publisher | Microsoft Corporation |
+| Licence | Microsoft Software License Terms, embedded in the NuGet package |
+| Licence text | <https://www.nuget.org/packages/Microsoft.Web.WebView2/#license-body> |
+| Project | <https://aka.ms/webview> |
+| Downloaded by | `src/Lib/Functions/Private/Install-WebView2.ps1`, on module import |
+| Downloaded from | `https://www.nuget.org/api/v2/package/Microsoft.Web.WebView2/<version>` |
+| Version resolved via | `https://api.nuget.org/v3-flatcontainer/microsoft.web.webview2/index.json` |
+| Installed to | `%LOCALAPPDATA%\OmadaSqlTroubleshooter\Bin\<edition>\win-x64\` (or `win-x86`) |
+
+Four files are extracted from the package: `Microsoft.Web.WebView2.Core.dll`,
+`Microsoft.Web.WebView2.WinForms.dll`, `Microsoft.Web.WebView2.Wpf.dll` and
+`WebView2Loader.dll`. They host the Monaco editor inside the WPF application.
+
+No copy of this package is committed to this repository or included in the published module.
+
+---
+
+## 3. Prerequisites installed by the user
+
+### 3.1 Microsoft Edge WebView2 Runtime
+
+| Field | Value |
+|---|---|
+| Component | Microsoft Edge WebView2 Runtime (Evergreen or Fixed Version) |
+| Publisher | Microsoft Corporation |
+| Licence | Microsoft Software License Terms, accepted by the user on download/installation |
+| Obtained from | <https://developer.microsoft.com/en-us/microsoft-edge/webview2> |
+
+**Redistribution review — conclusion (reviewed 2026-08-13):**
+OmadaSqlTroubleshooter does **not** redistribute the WebView2 Runtime in either distribution
+mode, so Microsoft's redistribution terms for the Runtime do not apply to this project.
+
+- **Evergreen mode (default).** The application uses whichever Runtime is already installed on
+  the machine, installed by the user or by their organisation directly from Microsoft.
+- **Fixed Version mode (optional fallback).** Where the Evergreen Runtime cannot be installed,
+  the user downloads the Fixed Version `.cab` **from Microsoft themselves** and extracts it to
+  `%LOCALAPPDATA%\OmadaSqlTroubleshooter\bin\Webview2Runtime` — the procedure documented in the
+  [README](README.md#requirements). `src/Lib/Functions/Private/Initialize-WebViewForTab.ps1`
+  only *reads* that folder if the user has populated it; nothing in this project ships,
+  downloads, or mirrors those binaries.
+
+This repository contains no `.exe`, `.dll`, `.msi` or `.cab` files, which is asserted by
+`tests/ThirdPartyNotices.Tests.ps1` so that a Runtime cannot be committed by accident.
+
+Microsoft's guidance on the two modes:
+<https://learn.microsoft.com/microsoft-edge/webview2/concepts/distribution>
+
+### 3.2 OmadaWeb.PS
+
+| Field | Value |
+|---|---|
+| Component | OmadaWeb.PS (version 2026.07.09.9 or higher) |
+| Publisher | Fortigi |
+| Licence | MIT — Copyright (c) 2024 Fortigi |
+| Licence text | <https://github.com/Fortigi/OmadaWeb.PS/blob/main/LICENSE> |
+| Project | <https://github.com/Fortigi/OmadaWeb.PS> |
+| Installed by | The user, with `Install-Module -Name OmadaWeb.PS` |
+
+OmadaWeb.PS handles all authentication and REST traffic to the Omada tenant. It is a required
+dependency — imported by `src/OmadaSqlTroubleShooter.psm1` at load time and declared in the
+`#requires` statement of `src/Lib/Functions/Public/Invoke-OmadaSqlTroubleshooter.ps1`. It is
+installed from the PowerShell Gallery by the user and is not redistributed with this module.
+
+OmadaWeb.PS downloads its own dependencies at run time — **Selenium WebDriver**
+(Apache-2.0), **Newtonsoft.Json** (MIT) and **msedgedriver** (Microsoft) — none of which are
+downloaded, bundled, or otherwise handled by OmadaSqlTroubleshooter. They are covered by the
+third-party notices of that module.
+
+---
+
+## Keeping this file current
+
+`tests/ThirdPartyNotices.Tests.ps1` runs as part of the Pester suite on every pull request and
+nightly build. It fails the build when:
+
+- the bundled Monaco version in the tree no longer matches the version recorded above;
+- a path listed above no longer exists in the repository;
+- a redistributable binary (`.exe`, `.dll`, `.msi`, `.cab`) is committed to the repository;
+- a component listed above loses its entry in this file.
+
+When a component is added, upgraded, or removed, update this file in the same change. Once a
+machine-readable SBOM is produced for the module, generate the inventory table from it and
+keep the licence texts here.
+
+## Reporting a problem
+
+If you believe a component is listed incorrectly, or a notice is missing, please open an issue
+at <https://github.com/Fortigi/OmadaSqlTroubleshooter/issues>.

--- a/build/psakeBuild.ps1
+++ b/build/psakeBuild.ps1
@@ -313,6 +313,18 @@ Task Build -Depends Test {
         "Copy nuspec file" | Write-Host
         Copy-Item -Path "$ParentPath\OmadaSqlTroubleShooter.nuspec" -Destination "$OutputDir" -Force
 
+        # Ship the licence and the third-party notices with the module. The MIT licence of the
+        # bundled Monaco editor requires its copyright notice to travel with the redistribution,
+        # so THIRD-PARTY-NOTICES.md must be part of every published package, not just the repo.
+        "Copy licence and third-party notices" | Write-Host
+        "LICENSE", "THIRD-PARTY-NOTICES.md", "README.md" | ForEach-Object {
+            $NoticeSourcePath = Join-Path $ParentPath -ChildPath $_
+            if (-not (Test-Path $NoticeSourcePath -PathType Leaf)) {
+                "Required file '{0}' was not found at '{1}'" -f $_, $NoticeSourcePath | Write-Error -ErrorAction Stop
+            }
+            Copy-Item -Path $NoticeSourcePath -Destination $OutputDir -Force
+        }
+
         "Copy lib contents" | Write-Host
 
         Get-Item -Path (Join-Path $ModuleSource -ChildPath "Monaco") | Copy-Item -Destination $OutputDir -Force -Recurse

--- a/tests/ThirdPartyNotices.Tests.ps1
+++ b/tests/ThirdPartyNotices.Tests.ps1
@@ -1,0 +1,99 @@
+BeforeAll {
+    $Script:ParentPath = Split-Path -Path $PSScriptRoot -Parent
+    $Script:NoticesPath = Join-Path $Script:ParentPath -ChildPath "THIRD-PARTY-NOTICES.md"
+    $Script:Notices = Get-Content -Path $Script:NoticesPath -Raw -Encoding UTF8
+}
+
+Describe 'THIRD-PARTY-NOTICES' -Tag 'Unit' {
+
+    Context 'The notices file itself' {
+        It 'Should exist at the repository root' {
+            Test-Path $Script:NoticesPath -PathType Leaf | Should -BeTrue
+        }
+
+        It 'Should be referenced from the README' {
+            $ReadMe = Get-Content -Path (Join-Path $Script:ParentPath -ChildPath "README.md") -Raw -Encoding UTF8
+            $ReadMe | Should -Match 'THIRD-PARTY-NOTICES'
+        }
+
+        It 'Should be referenced from the nuspec' {
+            $Nuspec = Get-Content -Path (Join-Path $Script:ParentPath -ChildPath "OmadaSqlTroubleshooter.nuspec") -Raw -Encoding UTF8
+            $Nuspec | Should -Match 'THIRD-PARTY-NOTICES'
+        }
+
+        It 'Should list every component that has an entry heading' {
+            # A component may not be silently dropped: each expected heading must still be present.
+            $ExpectedHeadings = @(
+                'Monaco Editor'
+                'Codicons'
+                'Microsoft.Web.WebView2'
+                'Microsoft Edge WebView2 Runtime'
+                'OmadaWeb.PS'
+            )
+            foreach ($Heading in $ExpectedHeadings) {
+                $Script:Notices | Should -Match ([regex]::Escape($Heading)) -Because "'$Heading' must remain listed in the notices"
+            }
+        }
+    }
+
+    Context 'Bundled Monaco Editor' {
+        It 'Should record the version that is actually bundled in src\Monaco' {
+            # The version banner Monaco itself writes into loader.js is the source of truth; the
+            # notices file must agree with it, so a Monaco upgrade cannot land without the notices
+            # being updated in the same change.
+            $LoaderPath = Join-Path $Script:ParentPath -ChildPath "src\Monaco\min\vs\loader.js"
+            Test-Path $LoaderPath -PathType Leaf | Should -BeTrue
+
+            $LoaderHead = (Get-Content -Path $LoaderPath -TotalCount 10) -join "`n"
+            $BundledMatch = [regex]::Match($LoaderHead, 'Version:\s*(?<Version>\d+\.\d+\.\d+)\((?<Commit>[0-9a-f]+)\)')
+            $BundledMatch.Success | Should -BeTrue -Because "loader.js should carry Monaco's version banner"
+
+            $NoticesMatch = [regex]::Match($Script:Notices, '\|\s*Version\s*\|\s*(?<Version>\d+\.\d+\.\d+)\s*\(commit\s*`(?<Commit>[0-9a-f]+)`\)')
+            $NoticesMatch.Success | Should -BeTrue -Because "the notices should record a Monaco version and commit"
+
+            $NoticesMatch.Groups['Version'].Value | Should -Be $BundledMatch.Groups['Version'].Value
+            $NoticesMatch.Groups['Commit'].Value | Should -Be $BundledMatch.Groups['Commit'].Value
+        }
+
+        It 'Should record the licence of the bundled codicon font' {
+            Test-Path (Join-Path $Script:ParentPath -ChildPath "src\Monaco\min\vs\base\browser\ui\codicons\codicon\codicon.ttf") -PathType Leaf |
+                Should -BeTrue -Because "the codicon entry in the notices describes this file"
+            $Script:Notices | Should -Match 'CC BY 4\.0'
+        }
+    }
+
+    Context 'Declared locations' {
+        It 'Should only point at paths that exist in the repository' {
+            $DeclaredPaths = [regex]::Matches($Script:Notices, '\|\s*Location in repository\s*\|\s*`(?<Path>[^`]+)`\s*\|') |
+                ForEach-Object { $_.Groups['Path'].Value }
+
+            $DeclaredPaths.Count | Should -BeGreaterThan 0 -Because "bundled components must declare where they live"
+
+            foreach ($DeclaredPath in $DeclaredPaths) {
+                # Glob entries ("src/Monaco/min/vs/**") are checked as the directory they point at.
+                $Relative = ($DeclaredPath -replace '/\*\*$', '') -replace '/', '\'
+                $FullPath = Join-Path $Script:ParentPath -ChildPath $Relative
+                Test-Path $FullPath | Should -BeTrue -Because "the notices declare '$DeclaredPath'"
+            }
+        }
+    }
+
+    Context 'No redistributable binaries' {
+        It 'Should not contain committed executables, libraries or installer packages' {
+            # The notices state that neither the WebView2 SDK nor the WebView2 Runtime is
+            # redistributed from this repository. This keeps that statement true.
+            $Binaries = Get-ChildItem -Path (Join-Path $Script:ParentPath -ChildPath "src") -Recurse -File -Include "*.exe", "*.dll", "*.msi", "*.cab" -ErrorAction SilentlyContinue |
+                ForEach-Object { $_.FullName.Substring($Script:ParentPath.Length + 1) }
+
+            $Binaries | Should -BeNullOrEmpty -Because "redistributing binaries would change this project's licence obligations"
+        }
+    }
+
+    Context 'Runtime download sources' {
+        It 'Should record the NuGet source that Install-WebView2 actually downloads from' {
+            $InstallWebView2 = Get-Content -Path (Join-Path $Script:ParentPath -ChildPath "src\lib\functions\Private\Install-WebView2.ps1") -Raw -Encoding UTF8
+            $InstallWebView2 | Should -Match 'https://www\.nuget\.org/api/v2/package/Microsoft\.Web\.WebView2'
+            $Script:Notices | Should -Match 'https://www\.nuget\.org/api/v2/package/Microsoft\.Web\.WebView2'
+        }
+    }
+}

--- a/tests/ThirdPartyNotices.Tests.ps1
+++ b/tests/ThirdPartyNotices.Tests.ps1
@@ -1,7 +1,16 @@
 BeforeAll {
     $Script:ParentPath = Split-Path -Path $PSScriptRoot -Parent
     $Script:NoticesPath = Join-Path $Script:ParentPath -ChildPath "THIRD-PARTY-NOTICES.md"
-    $Script:Notices = Get-Content -Path $Script:NoticesPath -Raw -Encoding UTF8
+
+    # Read defensively. If the notices file is missing or renamed, reading it here would fail
+    # inside BeforeAll and error out every test in this file; leaving the content empty lets the
+    # "Should exist at the repository root" test report the actual problem instead.
+    $Script:Notices = if (Test-Path $Script:NoticesPath -PathType Leaf) {
+        Get-Content -Path $Script:NoticesPath -Raw -Encoding UTF8
+    }
+    else {
+        [string]::Empty
+    }
 }
 
 Describe 'THIRD-PARTY-NOTICES' -Tag 'Unit' {
@@ -91,7 +100,7 @@ Describe 'THIRD-PARTY-NOTICES' -Tag 'Unit' {
 
     Context 'Runtime download sources' {
         It 'Should record the NuGet source that Install-WebView2 actually downloads from' {
-            $InstallWebView2 = Get-Content -Path (Join-Path $Script:ParentPath -ChildPath "src\lib\functions\Private\Install-WebView2.ps1") -Raw -Encoding UTF8
+            $InstallWebView2 = Get-Content -Path (Join-Path $Script:ParentPath -ChildPath "src\Lib\Functions\Private\Install-WebView2.ps1") -Raw -Encoding UTF8
             $InstallWebView2 | Should -Match 'https://www\.nuget\.org/api/v2/package/Microsoft\.Web\.WebView2'
             $Script:Notices | Should -Match 'https://www\.nuget\.org/api/v2/package/Microsoft\.Web\.WebView2'
         }


### PR DESCRIPTION
## Summary

This change adds comprehensive third-party licensing and privacy documentation to the OmadaSqlTroubleshooter project, ensuring transparency about dependencies, data handling, and compliance with open-source licensing obligations.

## Key Changes

- **THIRD-PARTY-NOTICES.md** (new file): Complete inventory of all third-party components, organized by distribution method:
  - Redistributed components (Monaco Editor 0.52.0, Codicons font)
  - Runtime downloads (Microsoft.Web.WebView2 SDK)
  - User-installed prerequisites (WebView2 Runtime, OmadaWeb.PS)
  - Includes full MIT and CC BY 4.0 license texts
  - Documents that the WebView2 Runtime is NOT redistributed by this project

- **README.md**: Added "DATA HANDLING & PRIVACY" section covering:
  - No telemetry or analytics
  - All network destinations (Omada tenant, identity provider, NuGet, PowerShell Gallery)
  - Local data storage locations and protection mechanisms
  - What exports and logs can contain
  - User responsibilities for handling exported identity data
  - Scope statement referencing third-party documentation

- **tests/ThirdPartyNotices.Tests.ps1** (new file): Automated validation tests that:
  - Verify the notices file exists and is referenced from README and nuspec
  - Confirm all expected components remain listed
  - Validate Monaco version in notices matches bundled version
  - Check that declared file paths exist in the repository
  - Prevent accidental commit of redistributable binaries (.exe, .dll, .msi, .cab)
  - Verify NuGet download sources match between code and documentation

- **build/psakeBuild.ps1**: Updated to include LICENSE, THIRD-PARTY-NOTICES.md, and README.md in published packages

- **OmadaSqlTroubleshooter.nuspec**: Updated description and added explicit MIT license declaration with reference to third-party notices

## Notable Implementation Details

- The notices file is machine-checked on every PR via Pester tests to prevent drift
- Monaco version is validated against the actual bundled loader.js header
- Binary file check prevents accidental redistribution of WebView2 or other runtime components
- Privacy statement is checkable against source code (all HTTP destinations are hard-coded and listed)
- DPAPI encryption of stored passwords is documented
- Temporary query object naming strategy (using InstanceGuid) is explained
