### PR TITLE
Central log-redaction layer: stop serializing credentials, tokens and result data into logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,18 +340,25 @@ Query results are production identity data. Treat them accordingly.
   Files are written unencrypted, to a location you choose.
 - **Exported query history** contains the SQL text, its change history and the names of the
   users who created or modified each query.
-- **The application log** records connection URLs, user names and application events. At the
-  default log level it does not contain result data. At `VERBOSE` and `VERBOSE2` it additionally
-  records complete request and response bodies, **including full result-set rows**. Only raise
-  the log level when you need it, and treat an exported log from those levels as if it were an
-  exported result set. Passwords are held as `SecureString`/`PSCredential` and are not written
-  to the log in readable form at any log level.
+- **The application log** records connection URLs, user names and application events. It is
+  designed to be shareable: every request, response and result set reaches it through a single
+  redaction layer, so an exported log should never need scrubbing before you attach it to a
+  support ticket. At every log level, including `VERBOSE` and `VERBOSE2`:
+  - `Authorization` headers, session cookies and tokens are masked.
+  - Passwords are held as `SecureString`/`PSCredential` and are never written in readable form.
+    The account's user name is recorded, because knowing which account authenticated is what
+    makes a permission failure diagnosable.
+  - Request bodies are recorded as their field names and value shapes, not their values.
+  - Result sets are recorded as row and column counts plus column names — **never cell values**.
+
+  Result data therefore does not reach the log at any level. This applies to the log only; the
+  export and clipboard paths above are unaffected and still contain full rows by design.
 
 ### Your responsibilities
 
-Once you export a result set, copy rows to the clipboard, or export a `VERBOSE` log, that data
-leaves the application's control and becomes your organisation's responsibility to handle under
-its own data-protection obligations — the GDPR included, where it applies. In practice:
+Once you export a result set or copy rows to the clipboard, that data leaves the application's
+control and becomes your organisation's responsibility to handle under its own data-protection
+obligations — the GDPR included, where it applies. In practice:
 
 - Export only the columns and rows you actually need, and prefer filtering in the query.
 - Store exports on encrypted, access-controlled storage — not in a personal downloads folder,

--- a/src/Lib/Functions/Private/Add-ConfigProperty.ps1
+++ b/src/Lib/Functions/Private/Add-ConfigProperty.ps1
@@ -4,7 +4,7 @@ function Add-ConfigProperty {
         $Property
     )
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
         if ($Property.Name -notin $CurrentProperties.Name) {
             # "Add property {0} to config object!" -f $Property | Write-LogOutput -LogType VERBOSE
             $Private:Value = $null

--- a/src/Lib/Functions/Private/Add-QueryToConnectedPoolTabs.ps1
+++ b/src/Lib/Functions/Private/Add-QueryToConnectedPoolTabs.ps1
@@ -22,7 +22,7 @@ function Add-QueryToConnectedPoolTabs {
         [string]$FullName
     )
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
 
         if ([string]::IsNullOrWhiteSpace($DoId)) {
             return

--- a/src/Lib/Functions/Private/Close-AllTabSessions.ps1
+++ b/src/Lib/Functions/Private/Close-AllTabSessions.ps1
@@ -8,7 +8,7 @@ function Close-AllTabSessions {
     [CmdLetBinding()]
     param()
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
 
         # Snapshot the ids first: Close-TabSession mutates $Script:Tabs as it goes.
         $TabIds = @($Script:Tabs | ForEach-Object { $_.Id })

--- a/src/Lib/Functions/Private/Close-OtherTabSessions.ps1
+++ b/src/Lib/Functions/Private/Close-OtherTabSessions.ps1
@@ -10,7 +10,7 @@ function Close-OtherTabSessions {
         [string]$KeepTabId
     )
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
 
         $TabIds = @($Script:Tabs | Where-Object { $_.Id -ne $KeepTabId } | ForEach-Object { $_.Id })
         foreach ($TabId in $TabIds) {

--- a/src/Lib/Functions/Private/Close-SplashScreenForm.ps1
+++ b/src/Lib/Functions/Private/Close-SplashScreenForm.ps1
@@ -2,7 +2,7 @@ function Close-SplashScreenForm {
     [CmdLetBinding()]
     param()
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
         "Closing Splash Screen" | Write-LogOutput -LogType DEBUG
         try {
             if ($null -ne $Script:SplashScreenForm -and $null -ne $Script:SplashScreenForm.Definition) {

--- a/src/Lib/Functions/Private/Close-TabSession.ps1
+++ b/src/Lib/Functions/Private/Close-TabSession.ps1
@@ -10,7 +10,7 @@ function Close-TabSession {
         [string]$TabId
     )
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
 
         $TabToClose = $Script:Tabs | Where-Object { $_.Id -eq $TabId } | Select-Object -First 1
         if ($null -eq $TabToClose) {

--- a/src/Lib/Functions/Private/Complete-DuplicateTab.ps1
+++ b/src/Lib/Functions/Private/Complete-DuplicateTab.ps1
@@ -18,7 +18,7 @@ function Complete-DuplicateTab {
         [switch]$UseSourceName
     )
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
 
         $Source = $Script:Tabs | Where-Object { $_.Id -eq $SourceTabId } | Select-Object -First 1
         if ($null -eq $Source) {

--- a/src/Lib/Functions/Private/Complete-TabClose.ps1
+++ b/src/Lib/Functions/Private/Complete-TabClose.ps1
@@ -20,7 +20,7 @@ function Complete-TabClose {
         $PreviouslyActiveTab
     )
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
 
         $ClosingIndex = $Script:Tabs.IndexOf($TabToClose)
 

--- a/src/Lib/Functions/Private/ConvertTo-RedactedLogString.ps1
+++ b/src/Lib/Functions/Private/ConvertTo-RedactedLogString.ps1
@@ -197,9 +197,18 @@ function Get-RedactedMemberValue {
         [string]$RedactedToken
     )
 
-    foreach ($Pattern in $SensitiveNamePatterns) {
-        if ($Name -like "*$Pattern*") {
-            return $RedactedToken
+    # Credential objects are handled by the type rules in the walker, which keep the user name -
+    # knowing which account authenticated is diagnostic - while the password stays in its
+    # SecureString. Applying the name rule here instead would throw that away for no gain.
+    $HandledByTypeRule = $MemberValue -is [System.Management.Automation.PSCredential] -or
+        $MemberValue -is [System.Net.NetworkCredential] -or
+        $MemberValue -is [System.Security.SecureString]
+
+    if (-not $HandledByTypeRule) {
+        foreach ($Pattern in $SensitiveNamePatterns) {
+            if ($Name -like "*$Pattern*") {
+                return $RedactedToken
+            }
         }
     }
 

--- a/src/Lib/Functions/Private/ConvertTo-RedactedLogString.ps1
+++ b/src/Lib/Functions/Private/ConvertTo-RedactedLogString.ps1
@@ -1,0 +1,213 @@
+function ConvertTo-RedactedLogString {
+    <#
+    .SYNOPSIS
+        Serializes an object to JSON for logging with all secret material removed.
+
+    .DESCRIPTION
+        The single path by which request parameters, responses and configuration objects are allowed
+        to reach the log. Sensitive properties are masked by name, credentials and secure strings by
+        type, and bulk data is reduced to a shape summary so result rows never land in a log file that
+        a user can export and attach to a support ticket.
+
+        NOTE: neither function in this file may carry the standard $Script:Tracer preamble or call
+        Write-LogOutput. The tracer preamble in every other function routes through this one, and
+        Write-LogOutput routes through Protect-LogMessage - instrumenting the helpers would make them
+        call themselves.
+    #>
+    [CmdLetBinding()]
+    param(
+        [Parameter(Mandatory = $false, Position = 0, ValueFromPipeline = $true)]
+        [AllowNull()]
+        $InputObject,
+        [int]$MaxDepth = 6,
+        [int]$MaxStringLength = 512
+    )
+
+    try {
+        $Redacted = ConvertTo-RedactedLogValue -Value $InputObject -Depth 0 -MaxDepth $MaxDepth -MaxStringLength $MaxStringLength -Visited ([System.Collections.Generic.List[object]]::new()) -MaskValues $false
+        if ($null -eq $Redacted) {
+            return "null"
+        }
+
+        return ($Redacted | ConvertTo-Json -Depth 20 -WarningAction SilentlyContinue)
+    }
+    catch {
+        # Failing open would leak the very thing this function exists to hide.
+        return "<redaction failed: {0}>" -f $_.Exception.Message
+    }
+}
+
+function ConvertTo-RedactedLogValue {
+    <#
+    .SYNOPSIS
+        Recursive walker behind ConvertTo-RedactedLogString. Returns a redacted clone, not a string.
+    #>
+    [CmdLetBinding()]
+    param(
+        [AllowNull()]
+        $Value,
+        [int]$Depth,
+        [int]$MaxDepth,
+        [int]$MaxStringLength,
+        [System.Collections.Generic.List[object]]$Visited,
+        [bool]$MaskValues
+    )
+
+    $RedactedToken = "***REDACTED***"
+
+    # Property names that identify secret material. Matched as a case-insensitive substring so
+    # composites such as X-CSRF-Token, RefreshToken and SessionCookie are covered too.
+    $SensitiveNamePatterns = @(
+        "authorization", "cookie", "credential", "password", "pwd", "secret", "token",
+        "apikey", "api_key", "clientsecret", "sessionkey", "bearer", "csrf", "assertion",
+        "privatekey", "connectionstring"
+    )
+
+    if ($null -eq $Value) {
+        return $null
+    }
+
+    # Type rules first - these hold regardless of the property name the value arrived under.
+    if ($Value -is [System.Security.SecureString]) {
+        return $RedactedToken
+    }
+
+    if ($Value -is [System.Management.Automation.PSCredential]) {
+        # The user name is diagnostic and not secret; the password never leaves the SecureString.
+        return "PSCredential(UserName={0})" -f $Value.UserName
+    }
+
+    if ($Value -is [System.Net.NetworkCredential]) {
+        return "NetworkCredential(UserName={0})" -f $Value.UserName
+    }
+
+    if ($Value -is [byte[]]) {
+        return "Byte[{0}]" -f $Value.Length
+    }
+
+    if ($Value -is [System.Net.CookieContainer]) {
+        return "CookieContainer(Count={0})" -f $Value.Count
+    }
+
+    if ($Value -is [System.Net.CookieCollection]) {
+        return "CookieCollection(Count={0})" -f $Value.Count
+    }
+
+    if ($Value -is [string]) {
+        if ($MaskValues) {
+            return "String({0})" -f $Value.Length
+        }
+
+        if ($Value.Length -gt $MaxStringLength) {
+            return "{0}...(truncated, {1} chars)" -f $Value.Substring(0, $MaxStringLength), $Value.Length
+        }
+
+        return $Value
+    }
+
+    if ($Value -is [ValueType] -or $Value -is [uri] -or $Value -is [System.Management.Automation.SwitchParameter]) {
+        if ($MaskValues) {
+            return $Value.GetType().Name
+        }
+
+        return $Value
+    }
+
+    if ($Depth -ge $MaxDepth) {
+        return "<max depth {0} reached: {1}>" -f $MaxDepth, $Value.GetType().Name
+    }
+
+    # Live WPF, session and response objects are cyclic - without this the walker never returns.
+    foreach ($Seen in $Visited) {
+        if ([object]::ReferenceEquals($Seen, $Value)) {
+            return "<circular reference: {0}>" -f $Value.GetType().Name
+        }
+    }
+    $Visited.Add($Value)
+
+    if ($Value -is [System.Collections.IDictionary]) {
+        $Result = [ordered]@{}
+        foreach ($Key in @($Value.Keys)) {
+            $Result[[string]$Key] = Get-RedactedMemberValue -Name ([string]$Key) -MemberValue $Value[$Key] -Depth $Depth -MaxDepth $MaxDepth -MaxStringLength $MaxStringLength -Visited $Visited -MaskValues $MaskValues -SensitiveNamePatterns $SensitiveNamePatterns -RedactedToken $RedactedToken
+        }
+
+        return $Result
+    }
+
+    if ($Value -isnot [string] -and $Value -is [System.Collections.IEnumerable]) {
+        $Items = @($Value)
+        $ItemCount = ($Items | Measure-Object).Count
+        if ($ItemCount -gt 3) {
+            # Bulk data - result rows, schema tables. Log the shape, never the contents.
+            $ElementType = "Object"
+            if ($null -ne $Items[0]) {
+                $ElementType = $Items[0].GetType().Name
+            }
+
+            return "Array[{0}] of {1}" -f $ItemCount, $ElementType
+        }
+
+        $Result = @()
+        foreach ($Item in $Items) {
+            $Result += , (ConvertTo-RedactedLogValue -Value $Item -Depth ($Depth + 1) -MaxDepth $MaxDepth -MaxStringLength $MaxStringLength -Visited $Visited -MaskValues $MaskValues)
+        }
+
+        return $Result
+    }
+
+    # Anything else: walk its properties, tolerating members that throw when read.
+    $Result = [ordered]@{}
+    try {
+        foreach ($Property in $Value.PSObject.Properties) {
+            try {
+                $Result[$Property.Name] = Get-RedactedMemberValue -Name $Property.Name -MemberValue $Property.Value -Depth $Depth -MaxDepth $MaxDepth -MaxStringLength $MaxStringLength -Visited $Visited -MaskValues $MaskValues -SensitiveNamePatterns $SensitiveNamePatterns -RedactedToken $RedactedToken
+            }
+            catch {
+                $Result[$Property.Name] = "<unreadable>"
+            }
+        }
+    }
+    catch {
+        return "<{0}>" -f $Value.GetType().Name
+    }
+
+    if ($Result.Count -le 0) {
+        return $Value.ToString()
+    }
+
+    return $Result
+}
+
+function Get-RedactedMemberValue {
+    <#
+    .SYNOPSIS
+        Applies the name-based rules for a single member, then hands off to the recursive walker.
+    #>
+    [CmdLetBinding()]
+    param(
+        [string]$Name,
+        [AllowNull()]
+        $MemberValue,
+        [int]$Depth,
+        [int]$MaxDepth,
+        [int]$MaxStringLength,
+        [System.Collections.Generic.List[object]]$Visited,
+        [bool]$MaskValues,
+        [string[]]$SensitiveNamePatterns,
+        [string]$RedactedToken
+    )
+
+    foreach ($Pattern in $SensitiveNamePatterns) {
+        if ($Name -like "*$Pattern*") {
+            return $RedactedToken
+        }
+    }
+
+    # Request bodies keep their keys and value shapes - enough to tell what was sent - but no values.
+    $ChildMaskValues = $MaskValues
+    if ($Name -eq "Body") {
+        $ChildMaskValues = $true
+    }
+
+    return ConvertTo-RedactedLogValue -Value $MemberValue -Depth ($Depth + 1) -MaxDepth $MaxDepth -MaxStringLength $MaxStringLength -Visited $Visited -MaskValues $ChildMaskValues
+}

--- a/src/Lib/Functions/Private/ConvertTo-RedactedLogString.ps1
+++ b/src/Lib/Functions/Private/ConvertTo-RedactedLogString.ps1
@@ -20,11 +20,14 @@ function ConvertTo-RedactedLogString {
         [AllowNull()]
         $InputObject,
         [int]$MaxDepth = 6,
-        [int]$MaxStringLength = 512
+        [int]$MaxStringLength = 512,
+        # Keep keys and value shapes but no values at all. Used where the object being logged IS a
+        # request body, rather than a parameter set containing one.
+        [switch]$ShapeOnly
     )
 
     try {
-        $Redacted = ConvertTo-RedactedLogValue -Value $InputObject -Depth 0 -MaxDepth $MaxDepth -MaxStringLength $MaxStringLength -Visited ([System.Collections.Generic.List[object]]::new()) -MaskValues $false
+        $Redacted = ConvertTo-RedactedLogValue -Value $InputObject -Depth 0 -MaxDepth $MaxDepth -MaxStringLength $MaxStringLength -Visited ([System.Collections.Generic.List[object]]::new()) -MaskValues ([bool]$ShapeOnly)
         if ($null -eq $Redacted) {
             return "null"
         }

--- a/src/Lib/Functions/Private/ConvertTo-RedactedLogString.ps1
+++ b/src/Lib/Functions/Private/ConvertTo-RedactedLogString.ps1
@@ -203,9 +203,7 @@ function Get-RedactedMemberValue {
     # Credential objects are handled by the type rules in the walker, which keep the user name -
     # knowing which account authenticated is diagnostic - while the password stays in its
     # SecureString. Applying the name rule here instead would throw that away for no gain.
-    $HandledByTypeRule = $MemberValue -is [System.Management.Automation.PSCredential] -or
-        $MemberValue -is [System.Net.NetworkCredential] -or
-        $MemberValue -is [System.Security.SecureString]
+    $HandledByTypeRule = $MemberValue -is [System.Management.Automation.PSCredential] -or $MemberValue -is [System.Net.NetworkCredential] -or $MemberValue -is [System.Security.SecureString]
 
     if (-not $HandledByTypeRule) {
         foreach ($Pattern in $SensitiveNamePatterns) {

--- a/src/Lib/Functions/Private/ConvertTo-TabSessionConfig.ps1
+++ b/src/Lib/Functions/Private/ConvertTo-TabSessionConfig.ps1
@@ -11,7 +11,7 @@ function ConvertTo-TabSessionConfig {
         $LegacyAppConfig
     )
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
 
         $DisplayName = $null
         if ($null -ne $LegacyAppConfig -and $LegacyAppConfig.PSObject.Properties.Match("DisplayName").Count -gt 0) {

--- a/src/Lib/Functions/Private/Get-ActiveTabSession.ps1
+++ b/src/Lib/Functions/Private/Get-ActiveTabSession.ps1
@@ -6,7 +6,7 @@ function Get-ActiveTabSession {
     [CmdLetBinding()]
     param()
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
         # -First 1 guarantees a single object (or $null) rather than a collection, so every
         # caller's "$null -ne $TabSession" check followed by property access stays reliable.
         return $Script:Tabs | Where-Object { $_.Id -eq $Script:ActiveTabId } | Select-Object -First 1

--- a/src/Lib/Functions/Private/Get-AllControls.ps1
+++ b/src/Lib/Functions/Private/Get-AllControls.ps1
@@ -6,7 +6,7 @@ function Get-AllControls {
     )
 
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
         $Controls = @()
         if ($Parent -is [System.Windows.Controls.Control]) {
             $Controls += $Parent

--- a/src/Lib/Functions/Private/Get-DefaultTabDisplayName.ps1
+++ b/src/Lib/Functions/Private/Get-DefaultTabDisplayName.ps1
@@ -8,7 +8,7 @@ function Get-DefaultTabDisplayName {
         [datetime]$Date = (Get-Date)
     )
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
         return "SqlQuery_{0}" -f $Date.ToString("yyyyMMddHHmmss")
     }
     catch {

--- a/src/Lib/Functions/Private/Get-FormPositionConfig.ps1
+++ b/src/Lib/Functions/Private/Get-FormPositionConfig.ps1
@@ -5,7 +5,7 @@ function Get-FormPositionConfig {
         $Form
     )
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
         $Property = "{0}Position" -f $Form.Name
         if ($null -ne $Script:AppGlobalConfig.$Property -and $Script:AppGlobalConfig.$Property -match "\b\d+x\d+\b") {
             return $Script:AppGlobalConfig.$Property

--- a/src/Lib/Functions/Private/Get-GalleryModuleVersion.ps1
+++ b/src/Lib/Functions/Private/Get-GalleryModuleVersion.ps1
@@ -5,7 +5,7 @@
     )
 
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
         $ApiEndpoint = "https://www.powershellgallery.com/api/v2/FindPackagesById()?id='{0}'" -f $ModuleName
         $Parameters = @{
             Uri             = $ApiEndpoint

--- a/src/Lib/Functions/Private/Get-Icon.ps1
+++ b/src/Lib/Functions/Private/Get-Icon.ps1
@@ -6,7 +6,7 @@ function Get-Icon {
     )
 
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
         $ImagePath = (Join-Path $Script:RunTimeConfig.ModuleFolder -ChildPath "lib\ui\icons\AppIcon.ico")
         # Base64 encoded icon (Create via $Base64Icon = [Convert]::ToBase64String([IO.File]::ReadAllBytes("Icon file path")))
         $IconBytes = [IO.File]::ReadAllBytes($ImagePath)

--- a/src/Lib/Functions/Private/Get-InstalledModuleInfo.ps1
+++ b/src/Lib/Functions/Private/Get-InstalledModuleInfo.ps1
@@ -5,7 +5,7 @@
     )
 
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
         $CallStack = Get-PSCallStack
         $ModuleStack = $CallStack | Where-Object { $_.Command -eq ("{0}.psm1" -f $ModuleName) }
 

--- a/src/Lib/Functions/Private/Get-LogResultShape.ps1
+++ b/src/Lib/Functions/Private/Get-LogResultShape.ps1
@@ -1,0 +1,60 @@
+function Get-LogResultShape {
+    <#
+    .SYNOPSIS
+        Describes a result set by its shape - row count, column count and column names - never its contents.
+
+    .DESCRIPTION
+        Query results returned by Omada are identity data. Logging them in full put PII into a log
+        window that users can export and attach to a support ticket. This function replaces those
+        dumps with the part that is actually diagnostic: how many rows came back and what the columns
+        were called.
+
+        NOTE: this function must never carry the standard $Script:Tracer preamble - the tracer routes
+        through ConvertTo-RedactedLogString, and keeping the redaction helpers uninstrumented is what
+        stops them calling themselves.
+    #>
+    [CmdLetBinding()]
+    param(
+        [Parameter(Mandatory = $false, Position = 0, ValueFromPipeline = $true)]
+        [AllowNull()]
+        $InputObject,
+        [int]$MaxColumnNames = 20
+    )
+
+    try {
+        if ($null -eq $InputObject) {
+            return "0 row(s)"
+        }
+
+        $Rows = @($InputObject) | Where-Object { $null -ne $_ }
+        $RowCount = ($Rows | Measure-Object).Count
+        if ($RowCount -le 0) {
+            return "0 row(s)"
+        }
+
+        $FirstRow = $Rows[0]
+        if ($FirstRow -is [System.Collections.IDictionary]) {
+            $ColumnNames = @($FirstRow.Keys)
+        }
+        else {
+            $ColumnNames = @($FirstRow.PSObject.Properties.Name)
+        }
+
+        $ColumnCount = ($ColumnNames | Measure-Object).Count
+        if ($ColumnCount -le 0) {
+            return "{0} row(s)" -f $RowCount
+        }
+
+        $ListedNames = $ColumnNames
+        $Suffix = ""
+        if ($ColumnCount -gt $MaxColumnNames) {
+            $ListedNames = $ColumnNames | Select-Object -First $MaxColumnNames
+            $Suffix = ", and {0} more" -f ($ColumnCount - $MaxColumnNames)
+        }
+
+        return "{0} row(s) x {1} column(s) [{2}{3}]" -f $RowCount, $ColumnCount, ($ListedNames -join ", "), $Suffix
+    }
+    catch {
+        return "<result shape unavailable: {0}>" -f $_.Exception.Message
+    }
+}

--- a/src/Lib/Functions/Private/Get-ModuleBaseFolder.ps1
+++ b/src/Lib/Functions/Private/Get-ModuleBaseFolder.ps1
@@ -3,7 +3,7 @@ function Get-ModuleBaseFolder {
     param()
 
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
         "Return Module Base Folder" | Write-LogOutput -LogType VERBOSE
         return Split-Path -Path ($MyInvocation.MyCommand.Module).Path -Parent
     }

--- a/src/Lib/Functions/Private/Get-OmadaGetPagingDataObject.ps1
+++ b/src/Lib/Functions/Private/Get-OmadaGetPagingDataObject.ps1
@@ -12,7 +12,7 @@ function Get-OmadaGetPagingDataObject {
     )
 
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
         $Script:RunTimeData.RestMethodParam.Body = [ordered]@{
             _search      = $false
             nd           = 1732546553116

--- a/src/Lib/Functions/Private/Get-SqlHistory.ps1
+++ b/src/Lib/Functions/Private/Get-SqlHistory.ps1
@@ -2,7 +2,7 @@ function Get-SqlHistory {
     [CmdLetBinding()]
     param()
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
 
         if ($Script:RunTimeConfig.ReconnectStatus -eq 1) {
             "Skip reconnect" | Write-LogOutput -LogType DEBUG

--- a/src/Lib/Functions/Private/Get-SqlHistory.ps1
+++ b/src/Lib/Functions/Private/Get-SqlHistory.ps1
@@ -40,7 +40,7 @@ function Get-SqlHistory {
                 "filters"      = $null
                 "searchOper"   = $null
             }
-            "Body: {0}" -f ($Script:RunTimeData.RestMethodParam.Body | ConvertTo-Json) | Write-LogOutput -LogType VERBOSE
+            "Body: {0}" -f (ConvertTo-RedactedLogString -InputObject $Script:RunTimeData.RestMethodParam.Body -ShapeOnly) | Write-LogOutput -LogType VERBOSE
             "QueryUrl: {0}" -f $Script:RunTimeData.RestMethodParam.Uri | Write-LogOutput -LogType DEBUG
 
             "Retrieve query output, please wait..." | Write-LogOutput

--- a/src/Lib/Functions/Private/Get-SqlQueryObject.ps1
+++ b/src/Lib/Functions/Private/Get-SqlQueryObject.ps1
@@ -2,7 +2,7 @@ function Get-SqlQueryObject {
     [CmdLetBinding()]
     param()
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
         if (!(Test-ConnectionRequirements)) {
             "Connection not ready" | Write-LogOutput -LogType DEBUG
             return

--- a/src/Lib/Functions/Private/Get-SqlSchema.ps1
+++ b/src/Lib/Functions/Private/Get-SqlSchema.ps1
@@ -2,7 +2,7 @@ function Get-SqlSchemaObject {
     [CmdLetBinding()]
     param()
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
 
         if ($Script:RunTimeConfig.ReconnectStatus -eq 1) {
             "Skip reconnect" | Write-LogOutput -LogType DEBUG

--- a/src/Lib/Functions/Private/Get-SqlTroubleShooterView.ps1
+++ b/src/Lib/Functions/Private/Get-SqlTroubleShooterView.ps1
@@ -2,7 +2,7 @@ function Get-SqlTroubleShooterView {
     [CmdLetBinding()]
     param()
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
         $ViewResult = Get-OmadaGetPagingDataObject -SearchString "SQL Troubleshooting" -DataType "Views" -DataTypeArgs @{OwnerShipType = "Both" }
         $View = $null
         if ($null -ne $ViewResult -and $ViewResult.d.Records -gt 0) {

--- a/src/Lib/Functions/Private/Get-TabControlSessions.ps1
+++ b/src/Lib/Functions/Private/Get-TabControlSessions.ps1
@@ -9,7 +9,7 @@ function Get-TabControlSessions {
     [CmdLetBinding()]
     param()
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
         return $Script:MainForm.Definition.FindName("TabControlSessions")
     }
     catch {

--- a/src/Lib/Functions/Private/Get-TreeViewLevel.ps1
+++ b/src/Lib/Functions/Private/Get-TreeViewLevel.ps1
@@ -4,7 +4,7 @@ function Get-TreeViewItemLevel {
         [System.Windows.Controls.TreeViewItem]$TreeViewItem
     )
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
         $Level = 0
         $Parent = $TreeViewItem.Parent
 

--- a/src/Lib/Functions/Private/Import-EventObjects.ps1
+++ b/src/Lib/Functions/Private/Import-EventObjects.ps1
@@ -4,7 +4,7 @@ function Import-EventObjects {
         [string]$ClassName
     )
 
-    $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+    $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
 
     Get-ChildItem -Path (Join-Path $Script:RunTimeConfig.ModuleFolder -ChildPath "Lib\Events") -Filter *.ps1 | Where-Object { $_.Name -like "$($ClassName).*" -and $_.Name -notlike "_*.ps1" } | ForEach-Object {
 

--- a/src/Lib/Functions/Private/Initialize-FormObject.ps1
+++ b/src/Lib/Functions/Private/Initialize-FormObject.ps1
@@ -12,7 +12,7 @@ function Initialize-FormObject {
         [switch]$AppendVersion
     )
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
         if ($null -eq $FormPath -and $null -eq $Xaml) {
             "Either FormPath or Xaml must be provided!" | Write-LogOutput -LogType ERROR
             break

--- a/src/Lib/Functions/Private/Initialize-GlobalConfigSettings.ps1
+++ b/src/Lib/Functions/Private/Initialize-GlobalConfigSettings.ps1
@@ -11,7 +11,7 @@ function Initialize-GlobalConfigSettings {
         [switch]$Reset
     )
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
 
         Set-ConfigProperty -Reset:$Reset.IsPresent
 

--- a/src/Lib/Functions/Private/Initialize-OmadaSqltroubleShooter.ps1
+++ b/src/Lib/Functions/Private/Initialize-OmadaSqltroubleShooter.ps1
@@ -3,7 +3,7 @@ function Initialize-OmadaSqlTroubleShooter {
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'WebView2AlreadyLoaded', Justification = 'The variable is used, but script analyzer does not recognize it')]
     param()
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
         "Initializing application..." | Write-LogOutput -LogType DEBUG
         Push-Location $Script:RunTimeConfig.ModuleFolder
 

--- a/src/Lib/Functions/Private/Initialize-WebViewForTab.ps1
+++ b/src/Lib/Functions/Private/Initialize-WebViewForTab.ps1
@@ -28,7 +28,7 @@ function Initialize-WebViewForTab {
         $TabSession
     )
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
 
         $TabSession.WebView.Object = $TabSession.Elements.webView21
         if ($null -eq $TabSession.WebView.Object) {

--- a/src/Lib/Functions/Private/Invoke-DuplicateTab.ps1
+++ b/src/Lib/Functions/Private/Invoke-DuplicateTab.ps1
@@ -20,7 +20,7 @@ function Invoke-DuplicateTab {
         [switch]$WithoutQuery
     )
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
 
         $Source = $Script:Tabs | Where-Object { $_.Id -eq $TabId } | Select-Object -First 1
         if ($null -eq $Source) {

--- a/src/Lib/Functions/Private/Invoke-ExecuteQuery.ps1
+++ b/src/Lib/Functions/Private/Invoke-ExecuteQuery.ps1
@@ -2,7 +2,7 @@ function Invoke-ExecuteQuery {
     [CmdLetBinding()]
     param()
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
         if (!(Test-ConnectionRequirements)) {
             "Connection not ready" | Write-LogOutput -LogType DEBUG
             return

--- a/src/Lib/Functions/Private/Invoke-ExecuteQuery.ps1
+++ b/src/Lib/Functions/Private/Invoke-ExecuteQuery.ps1
@@ -50,7 +50,7 @@ function Invoke-ExecuteQuery {
                         "filters"      = $null
                         "searchOper"   = $null
                     }
-                    "Body: {0}" -f ($Script:RunTimeData.RestMethodParam.Body | ConvertTo-Json) | Write-LogOutput -LogType VERBOSE
+                    "Body: {0}" -f (ConvertTo-RedactedLogString -InputObject $Script:RunTimeData.RestMethodParam.Body -ShapeOnly) | Write-LogOutput -LogType VERBOSE
                     "QueryUrl: {0}" -f $Script:RunTimeData.RestMethodParam.Uri | Write-LogOutput -LogType DEBUG
 
                     "Retrieve query output, please wait..." | Write-LogOutput
@@ -79,7 +79,7 @@ function Invoke-ExecuteQuery {
                             #Work-around issue that Omada can return invalid JSON keys.
                             $Script:MainForm.Elements.DataGridQueryResult.ItemsSource = @(($Script:RunTimeData.QueryResult | ConvertTo-Json -Depth 10 | Invoke-SanitizeJsonKeys | ConvertFrom-Json -Depth 10).d.Rows)
                         }
-                        "Result:`r`n{0}" -f ($Script:RunTimeData.QueryResult.d.rows | Format-Table -AutoSize | Out-String -Width 10000000 ) | Write-LogOutput -LogType VERBOSE2
+                        "Result: {0}" -f (Get-LogResultShape -InputObject $Script:RunTimeData.QueryResult.d.rows) | Write-LogOutput -LogType VERBOSE2
                         $Script:MainForm.Elements.ButtonShowOutput.IsEnabled = $true
                         $Script:MainForm.Elements.ButtonSaveOutputFile.IsEnabled = $true
                         "{0} record(s) retrieved!" -f $Script:RunTimeData.QueryResult.d.Records | Write-LogOutput

--- a/src/Lib/Functions/Private/Invoke-ExecuteScriptAsync.ps1
+++ b/src/Lib/Functions/Private/Invoke-ExecuteScriptAsync.ps1
@@ -12,7 +12,7 @@ function Invoke-ExecuteScriptAsync {
         $OnCompletedScriptBlock
     )
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
         if ($null -ne $Script:Webview.Object) {
             # CoreWebView2 must be checked too, not just IsLoaded: while a tab is being torn down
             # (e.g. Close All disposing tabs), a focus-driven editor push can land on a WebView2

--- a/src/Lib/Functions/Private/Invoke-ExecuteScriptWithResultAsync.ps1
+++ b/src/Lib/Functions/Private/Invoke-ExecuteScriptWithResultAsync.ps1
@@ -12,7 +12,7 @@ function Invoke-ExecuteScriptWithResultAsync {
         $OnCompletedScriptBlock
     )
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
         if ($null -ne $Script:Webview.Object) {
             # CoreWebView2 must be checked too, not just IsLoaded: while a tab is being torn down
             # (e.g. Close All disposing tabs), a focus-driven editor push can land on a WebView2

--- a/src/Lib/Functions/Private/Invoke-OmadaPSWebRequestWrapper.ps1
+++ b/src/Lib/Functions/Private/Invoke-OmadaPSWebRequestWrapper.ps1
@@ -2,7 +2,7 @@ function Invoke-OmadaPSWebRequestWrapper {
     [CmdLetBinding()]
     param()
 
-    $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+    $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
 
     # Invoke-OmadaRestMethod (OmadaWeb.PS) can show its own interactive WebView2/Browser login
     # popup when authentication is needed - a modal window this app does not own, but which pumps

--- a/src/Lib/Functions/Private/Invoke-OmadaPSWebRequestWrapper.ps1
+++ b/src/Lib/Functions/Private/Invoke-OmadaPSWebRequestWrapper.ps1
@@ -31,12 +31,12 @@ function Invoke-OmadaPSWebRequestWrapper {
 
                 #$Private:Parameters.Body = $Private:Parameters.Body | ConvertTo-Json
             }
-            "Parameters: {0}" -f ($Private:Parameters | ConvertTo-Json -Depth 15) | Write-LogOutput -LogType VERBOSE
+            "Parameters: {0}" -f (ConvertTo-RedactedLogString -InputObject $Private:Parameters) | Write-LogOutput -LogType VERBOSE
             $Private:Result = Invoke-OmadaRestMethod @Parameters
             if ($null -ne $Script:MainForm -and $null -ne $Script:MainForm.Definitions -and $Script:MainForm.Definitions.IsVisible) {
                 $Script:MainForm.Definitions.TextBlockStatusBarConnectionStatus | Set-TextBlockText -Text "Connected"
             }
-            "Result: {0}" -f ($Private:Result | ConvertTo-Json -Depth 15) | Write-LogOutput -LogType VERBOSE
+            "Result: {0}" -f (ConvertTo-RedactedLogString -InputObject $Private:Result) | Write-LogOutput -LogType VERBOSE
             $Script:RunTimeData.RestMethodParam.ForceAuthentication = $false
             return $Private:Result
         }

--- a/src/Lib/Functions/Private/Invoke-OnTreeViewItemShiftClick.ps1
+++ b/src/Lib/Functions/Private/Invoke-OnTreeViewItemShiftClick.ps1
@@ -9,7 +9,7 @@ function Invoke-OnTreeViewItemShiftClick {
     )
 
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
         "Left shift {0}, Right shift {1}" -f [System.Windows.Input.Keyboard]::IsKeyDown([System.Windows.Input.Key]::LeftShift), [System.Windows.Input.Keyboard]::IsKeyDown([System.Windows.Input.Key]::RightShift) | Write-LogOutput -LogType VERBOSE
 
         if ([System.Windows.Input.Keyboard]::IsKeyDown([System.Windows.Input.Key]::LeftShift) -or

--- a/src/Lib/Functions/Private/Invoke-SanitizeJsonKeys.ps1
+++ b/src/Lib/Functions/Private/Invoke-SanitizeJsonKeys.ps1
@@ -5,7 +5,7 @@ function Invoke-SanitizeJsonKeys {
         [string]$JsonString
     )
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
         $ParsedJson = $JsonString | ConvertFrom-Json -ErrorAction Stop -AsHashtable
 
         $SanitizedObject = Invoke-SanitizeObject -Data $ParsedJson

--- a/src/Lib/Functions/Private/Invoke-SanitizeObject.ps1
+++ b/src/Lib/Functions/Private/Invoke-SanitizeObject.ps1
@@ -5,7 +5,7 @@ function Invoke-SanitizeObject {
         [object]$Data
     )
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
         $ReplacementChar = "_"
         if ($Data -is [hashtable]) {
             $NewData = @{}

--- a/src/Lib/Functions/Private/Invoke-SaveEditorValue.ps1
+++ b/src/Lib/Functions/Private/Invoke-SaveEditorValue.ps1
@@ -5,7 +5,7 @@ function Invoke-SaveEditorValue {
     )
 
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
         $ScriptToExecute = "editor.getValue();"
         $Script:NewQuery = $NewQuery
         $OnCompletedScriptBlock = {

--- a/src/Lib/Functions/Private/Limit-MessageBoxText.ps1
+++ b/src/Lib/Functions/Private/Limit-MessageBoxText.ps1
@@ -2,7 +2,7 @@ function Limit-MessageBoxText {
     param([string]$Text)
 
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
 
         $ScreenWidth = [System.Windows.Forms.Screen]::PrimaryScreen.Bounds.Width
         $ScreenHeight = [System.Windows.Forms.Screen]::PrimaryScreen.Bounds.Height

--- a/src/Lib/Functions/Private/Move-TabSession.ps1
+++ b/src/Lib/Functions/Private/Move-TabSession.ps1
@@ -13,7 +13,7 @@ function Move-TabSession {
         [string]$TargetTabId
     )
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
 
         if ($DraggedTabId -eq $TargetTabId) {
             return

--- a/src/Lib/Functions/Private/New-EmptyTabSession.ps1
+++ b/src/Lib/Functions/Private/New-EmptyTabSession.ps1
@@ -8,7 +8,7 @@ function New-EmptyTabSession {
     [CmdLetBinding()]
     param()
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
 
         $MaxCapacity = if ($null -ne $Script:AppGlobalConfig -and $Script:AppGlobalConfig.TabCapacity -gt 0) { $Script:AppGlobalConfig.TabCapacity } else { 8 }
         if (Test-TabCapacity -CurrentCount $Script:Tabs.Count -MaxCapacity $MaxCapacity) {

--- a/src/Lib/Functions/Private/New-TabSession.ps1
+++ b/src/Lib/Functions/Private/New-TabSession.ps1
@@ -21,7 +21,7 @@ function New-TabSession {
         [switch]$Deferred
     )
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
 
         $MaxCapacity = if ($null -ne $Script:AppGlobalConfig -and $Script:AppGlobalConfig.TabCapacity -gt 0) { $Script:AppGlobalConfig.TabCapacity } else { 8 }
         if (-not (Test-TabCapacity -CurrentCount $Script:Tabs.Count -MaxCapacity $MaxCapacity)) {

--- a/src/Lib/Functions/Private/New-TemporarySqlQueryObject.ps1
+++ b/src/Lib/Functions/Private/New-TemporarySqlQueryObject.ps1
@@ -61,7 +61,7 @@ function New-TemporarySqlQueryObject {
             $Script:RunTimeData.RestMethodParam.Body.Add("C_SQLTROUBLESHOOTING_DATACONNECTION", @{ Id = $Script:AppConfig.CurrentDataConnection.DoId })
         }
 
-        "Body: {0}" -f ($Script:RunTimeData.RestMethodParam.Body | ConvertTo-Json) | Write-LogOutput -LogType VERBOSE
+        "Body: {0}" -f (ConvertTo-RedactedLogString -InputObject $Script:RunTimeData.RestMethodParam.Body -ShapeOnly) | Write-LogOutput -LogType VERBOSE
         "QueryUrl: {0}" -f $Script:RunTimeData.RestMethodParam.Uri | Write-LogOutput -LogType DEBUG
 
         $Private:Result = Invoke-OmadaPSWebRequestWrapper

--- a/src/Lib/Functions/Private/New-TemporarySqlQueryObject.ps1
+++ b/src/Lib/Functions/Private/New-TemporarySqlQueryObject.ps1
@@ -5,7 +5,7 @@ function New-TemporarySqlQueryObject {
         [string]$QueryText
     )
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
 
         $TempName = "TMP_$($Script:RunTimeConfig.InstanceGuid)"
 

--- a/src/Lib/Functions/Private/Open-ChoiceForm.ps1
+++ b/src/Lib/Functions/Private/Open-ChoiceForm.ps1
@@ -11,7 +11,7 @@ function Open-ChoiceForm {
         $RightButtonReturnValue = $false
     )
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
 
         $Script:ChoiceForm = Initialize-FormObject -FormPath (Join-Path $Script:RunTimeConfig.ModuleFolder -ChildPath "lib\ui\ChoiceForm.xaml")
 

--- a/src/Lib/Functions/Private/Open-LogForm.ps1
+++ b/src/Lib/Functions/Private/Open-LogForm.ps1
@@ -3,7 +3,7 @@ function Open-LogForm {
     param()
 
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
 
         "Opening Log form" | Write-LogOutput -LogType DEBUG
         $Script:LogForm = Initialize-FormObject -FormPath (Join-Path $Script:RunTimeConfig.ModuleFolder -ChildPath "lib\ui\LogForm.xaml") -ParentForm $Script:MainForm.Definition

--- a/src/Lib/Functions/Private/Open-SplashScreenForm.ps1
+++ b/src/Lib/Functions/Private/Open-SplashScreenForm.ps1
@@ -2,7 +2,7 @@ function Open-SplashScreenForm {
     [CmdLetBinding()]
     param()
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
 
         "Loading Splash Screen" | Write-LogOutput -LogType DEBUG
 

--- a/src/Lib/Functions/Private/Open-SqlHistoryForm.ps1
+++ b/src/Lib/Functions/Private/Open-SqlHistoryForm.ps1
@@ -5,7 +5,7 @@ function Open-SqlHistoryForm {
     param()
     try {
 
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
 
         if ($Script:RunTimeConfig.ReconnectStatus -eq 1) {
             "Skip show history" | Write-LogOutput -LogType DEBUG

--- a/src/Lib/Functions/Private/Open-SqlSchemaForm.ps1
+++ b/src/Lib/Functions/Private/Open-SqlSchemaForm.ps1
@@ -4,7 +4,7 @@ function Open-SqlSchemaForm {
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidAssignmentToAutomaticVariable', 'EventArgs', Justification = 'The use of the variable is on purpose')]
     param()
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
 
         if ($Script:RunTimeConfig.ReconnectStatus -eq 1) {
             "Skip show schema" | Write-LogOutput -LogType DEBUG

--- a/src/Lib/Functions/Private/Protect-LogMessage.ps1
+++ b/src/Lib/Functions/Private/Protect-LogMessage.ps1
@@ -1,0 +1,54 @@
+function Protect-LogMessage {
+    <#
+    .SYNOPSIS
+        Masks secret material in an already-flattened log line.
+
+    .DESCRIPTION
+        The last gate before a message reaches $Script:RunTimeConfig.Logging.AppLogObject, which the
+        log window's "Export Log File" button writes to disk verbatim. Structure-aware redaction
+        happens earlier in ConvertTo-RedactedLogString; this function is the safety net that catches
+        secrets embedded in free-form text - exception messages, third-party output, and any future
+        call site that forgets to redact.
+
+        NOTE: this function must never call Write-LogOutput and must never carry the standard
+        $Script:Tracer preamble - Write-LogOutput calls it, so either would recurse.
+    #>
+    [CmdLetBinding()]
+    param(
+        [Parameter(Mandatory = $false, Position = 0, ValueFromPipeline = $true)]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [string]$Message
+    )
+
+    if ([string]::IsNullOrEmpty($Message)) {
+        return $Message
+    }
+
+    try {
+        $Redacted = "***REDACTED***"
+        $Result = $Message
+
+        # Auth scheme followed by a token. The token is required, so a bare "AuthenticationType: Basic"
+        # - which is useful diagnostic information - survives untouched.
+        $Result = $Result -replace '(?i)\b(Basic|Bearer|Negotiate|NTLM|Digest)\s+([A-Za-z0-9+/=._\-]{8,})', ('$1 {0}' -f $Redacted)
+
+        # Bare JWTs, which turn up in responses and cached-token messages without a scheme prefix.
+        $Result = $Result -replace '\beyJ[A-Za-z0-9_\-]{4,}\.[A-Za-z0-9_\-]{4,}\.[A-Za-z0-9_\-]*', '***REDACTED-JWT***'
+
+        # JSON-style pairs whose key names a secret, e.g. {"Password": "..."} or {"X-CSRF-Token": "..."}.
+        $Result = $Result -replace '(?i)("[^"]*(?:authorization|cookie|credential|password|pwd|secret|token|apikey|api_key|clientsecret|sessionkey|csrf|assertion|privatekey|connectionstring)[^"]*"\s*:\s*)"[^"]*"', ('$1"{0}"' -f $Redacted)
+
+        # Query-string, form and cookie style pairs, e.g. password=..., ASP.NET_SessionId=...
+        $Result = $Result -replace '(?i)\b([\w.\-]*(?:password|pwd|secret|token|apikey|api_key|sessionid|sessionkey|auth|csrf)[\w.\-]*)\s*=\s*([^\s;,&"'']+)', ('$1={0}' -f $Redacted)
+
+        # Any Set-Cookie header, whatever the cookie is called.
+        $Result = $Result -replace '(?i)(Set-Cookie:\s*)([^\s=;]+)=([^;\s]+)', ('$1$2={0}' -f $Redacted)
+
+        return $Result
+    }
+    catch {
+        # Failing open would leak the very thing this function exists to hide.
+        return "***REDACTION FAILED - MESSAGE SUPPRESSED***"
+    }
+}

--- a/src/Lib/Functions/Private/Protect-LogMessage.ps1
+++ b/src/Lib/Functions/Private/Protect-LogMessage.ps1
@@ -37,7 +37,10 @@ function Protect-LogMessage {
         $Result = $Result -replace '\beyJ[A-Za-z0-9_\-]{4,}\.[A-Za-z0-9_\-]{4,}\.[A-Za-z0-9_\-]*', '***REDACTED-JWT***'
 
         # JSON-style pairs whose key names a secret, e.g. {"Password": "..."} or {"X-CSRF-Token": "..."}.
-        $Result = $Result -replace '(?i)("[^"]*(?:authorization|cookie|credential|password|pwd|secret|token|apikey|api_key|clientsecret|sessionkey|csrf|assertion|privatekey|connectionstring)[^"]*"\s*:\s*)"[^"]*"', ('$1"{0}"' -f $Redacted)
+        # The lookahead spares the one value ConvertTo-RedactedLogString deliberately emits for a
+        # credential - "PSCredential(UserName=...)" - which carries no password and answers the first
+        # question you ask of a 401. Without it the safety net would undo that upstream decision.
+        $Result = $Result -replace '(?i)("[^"]*(?:authorization|cookie|credential|password|pwd|secret|token|apikey|api_key|clientsecret|sessionkey|csrf|assertion|privatekey|connectionstring)[^"]*"\s*:\s*)"(?!(?:PS|Network)Credential\(UserName=)[^"]*"', ('$1"{0}"' -f $Redacted)
 
         # Query-string, form and cookie style pairs, e.g. password=..., ASP.NET_SessionId=...
         $Result = $Result -replace '(?i)\b([\w.\-]*(?:password|pwd|secret|token|apikey|api_key|sessionid|sessionkey|auth|csrf)[\w.\-]*)\s*=\s*([^\s;,&"'']+)', ('$1={0}' -f $Redacted)

--- a/src/Lib/Functions/Private/Push-ToEditor.ps1
+++ b/src/Lib/Functions/Private/Push-ToEditor.ps1
@@ -5,7 +5,7 @@
         [string]$ScriptToExecute
     )
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
         $OnCompletedScriptBlock = {
             try {
                 if ($Script:Task.Status -eq "RanToCompletion") {

--- a/src/Lib/Functions/Private/Remove-SqlQueryObject.ps1
+++ b/src/Lib/Functions/Private/Remove-SqlQueryObject.ps1
@@ -5,7 +5,7 @@ function Remove-SqlQueryObject {
         [string]$DoId
     )
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
 
         "Deleting query object with DoId: {0}" -f $DoId | Write-LogOutput -LogType DEBUG
 

--- a/src/Lib/Functions/Private/Reset-Application.ps1
+++ b/src/Lib/Functions/Private/Reset-Application.ps1
@@ -7,7 +7,7 @@
     )
 
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
         if ($null -ne $Script:SqlSchemaForm -and $null -ne $Script:SqlSchemaForm.Definitions -and $Script:SqlSchemaForm.Definitions.IsVisible) {
             $Script:SqlSchemaForm.Definitions.Close()
         }

--- a/src/Lib/Functions/Private/Restore-TabSessions.ps1
+++ b/src/Lib/Functions/Private/Restore-TabSessions.ps1
@@ -9,7 +9,7 @@ function Restore-TabSessions {
     [CmdLetBinding()]
     param()
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
 
         $MaxCapacity = if ($null -ne $Script:AppGlobalConfig -and $Script:AppGlobalConfig.TabCapacity -gt 0) { $Script:AppGlobalConfig.TabCapacity } else { 8 }
         $TabsPath = Join-Path $Script:RunTimeConfig.AppDataFolder -ChildPath "config\tabs.clixml"

--- a/src/Lib/Functions/Private/Save-FormMeasurements.ps1
+++ b/src/Lib/Functions/Private/Save-FormMeasurements.ps1
@@ -2,7 +2,7 @@ function Save-FormMeasurements {
     [CmdLetBinding()]
     param()
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
 
         "Save-FormMeasurements" | Write-LogOutput -LogType VERBOSE2
         $MinDelta = 500

--- a/src/Lib/Functions/Private/Save-Query.ps1
+++ b/src/Lib/Functions/Private/Save-Query.ps1
@@ -51,7 +51,7 @@ function Save-Query {
         else {
 
             "Saving SQL Query: {0}" -f $Script:RunTimeData.QueryText | Write-LogOutput -LogType DEBUG
-            "Body: {0}" -f ($Script:RunTimeData.RestMethodParam.Body | ConvertTo-Json) | Write-LogOutput -LogType VERBOSE
+            "Body: {0}" -f (ConvertTo-RedactedLogString -InputObject $Script:RunTimeData.RestMethodParam.Body -ShapeOnly) | Write-LogOutput -LogType VERBOSE
             "QueryUrl: {0}" -f $Script:RunTimeData.RestMethodParam.Uri | Write-LogOutput -LogType DEBUG
 
             "Save query" | Write-LogOutput

--- a/src/Lib/Functions/Private/Save-Query.ps1
+++ b/src/Lib/Functions/Private/Save-Query.ps1
@@ -4,7 +4,7 @@ function Save-Query {
         [switch]$NewQuery
     )
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
         if ($NewQuery) {
             "Create new query" | Write-LogOutput -LogType DEBUG
 

--- a/src/Lib/Functions/Private/Save-TabSessions.ps1
+++ b/src/Lib/Functions/Private/Save-TabSessions.ps1
@@ -11,7 +11,7 @@ function Save-TabSessions {
     [CmdLetBinding()]
     param()
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
 
         $TabsPath = Join-Path $Script:RunTimeConfig.AppDataFolder -ChildPath "config\tabs.clixml"
         New-Item -Path (Split-Path $TabsPath) -ItemType Directory -Force -ErrorAction SilentlyContinue | Out-Null

--- a/src/Lib/Functions/Private/Select-AdjacentTab.ps1
+++ b/src/Lib/Functions/Private/Select-AdjacentTab.ps1
@@ -21,7 +21,7 @@ function Select-AdjacentTab {
         [string]$Direction
     )
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
 
         $Count = $Script:Tabs.Count
         if ($Count -le 1) {

--- a/src/Lib/Functions/Private/Set-ActiveTabEditorFocus.ps1
+++ b/src/Lib/Functions/Private/Set-ActiveTabEditorFocus.ps1
@@ -20,7 +20,7 @@ function Set-ActiveTabEditorFocus {
     [CmdLetBinding()]
     param()
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
 
         $Dispatcher = $Script:MainForm.Definition.Dispatcher
         if ($null -eq $Dispatcher) {

--- a/src/Lib/Functions/Private/Set-AuthenticationOption.ps1
+++ b/src/Lib/Functions/Private/Set-AuthenticationOption.ps1
@@ -2,7 +2,7 @@ function Set-AuthenticationOption {
     [CmdLetBinding()]
     param()
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
         if ($null -ne $Script:MainForm.Elements.ComboBoxSelectAuthenticationOption.SelectedItem.Content) {
 
             switch ($Script:MainForm.Elements.ComboBoxSelectAuthenticationOption.SelectedItem.Content) {

--- a/src/Lib/Functions/Private/Set-ButtonText.ps1
+++ b/src/Lib/Functions/Private/Set-ButtonText.ps1
@@ -8,7 +8,7 @@ function Set-ButtonText {
     )
 
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
         $CurrentButtonTextContent = $ButtonTextObject.Text
         if ($CurrentButtonTextContent -ne $Value) {
             $ButtonTextObject.Text = $Value

--- a/src/Lib/Functions/Private/Set-ConfigProperty.ps1
+++ b/src/Lib/Functions/Private/Set-ConfigProperty.ps1
@@ -219,7 +219,7 @@ function Set-ConfigProperty {
                 }
             }
             else {
-                "Store config object to {0}. Contents`r`n{1}`r`n" -f ($Script:RunTimeConfig.ConfigFile.Path), ($Config | ConvertTo-Json) | Write-LogOutput -LogType VERBOSE2
+                "Store config object to {0}. Contents`r`n{1}`r`n" -f ($Script:RunTimeConfig.ConfigFile.Path), (ConvertTo-RedactedLogString -InputObject $Config) | Write-LogOutput -LogType VERBOSE2
                 $Success = $false
                 $Count = 0
                 do {

--- a/src/Lib/Functions/Private/Set-ConfigProperty.ps1
+++ b/src/Lib/Functions/Private/Set-ConfigProperty.ps1
@@ -13,7 +13,7 @@ function Set-ConfigProperty {
 
     begin {
         try {
-            $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+            $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
             $InputObject = @()
 
             if ($null -eq $Script:TabConfigProperties) {

--- a/src/Lib/Functions/Private/Set-DataConnection.ps1
+++ b/src/Lib/Functions/Private/Set-DataConnection.ps1
@@ -2,7 +2,7 @@ function Set-DataConnection {
     [CmdLetBinding()]
     param()
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
         if (!$Script:MainForm.Elements.ComboBoxSelectDataConnection.Items?.Content?.Contains($Script:AppConfig.CurrentDataConnection.FullName)) {
             $ComboBoxDataConnectionItem = New-Object System.Windows.Controls.ComboBoxItem
             $ComboBoxDataConnectionItem.Content = $Script:AppConfig.CurrentDataConnection.FullName

--- a/src/Lib/Functions/Private/Set-EditorBackground.ps1
+++ b/src/Lib/Functions/Private/Set-EditorBackground.ps1
@@ -2,7 +2,7 @@ function Set-EditorBackground {
     [CmdLetBinding()]
     param()
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
         $OnCompletedScriptBlock = {
             try {
                 if (!$Script:Task.Status -eq "RanToCompletion") {

--- a/src/Lib/Functions/Private/Set-EditorValue.ps1
+++ b/src/Lib/Functions/Private/Set-EditorValue.ps1
@@ -2,7 +2,7 @@ function Set-EditorValue {
     [CmdLetBinding()]
     param()
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
 
         if ($null -ne $Script:MainForm.Elements.ComboBoxSelectQuery.SelectedItem) {
             "Selected SQL Query object: {0}" -f $Script:MainForm.Elements.ComboBoxSelectQuery.SelectedItem.Content | Write-LogOutput -LogType DEBUG

--- a/src/Lib/Functions/Private/Set-FormPosition.ps1
+++ b/src/Lib/Functions/Private/Set-FormPosition.ps1
@@ -7,7 +7,7 @@ function Set-FormPosition {
         [string]$Setting
     )
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
         $Form.Left | Write-Host -ForegroundColor DarkYellow
         $Form.Top | Write-Host -ForegroundColor DarkYellow
 

--- a/src/Lib/Functions/Private/Set-OmadaUrl.ps1
+++ b/src/Lib/Functions/Private/Set-OmadaUrl.ps1
@@ -2,7 +2,7 @@ function Set-OmadaUrl {
     [CmdLetBinding()]
     param()
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
 
         if (![string]::IsNullOrWhiteSpace($Script:MainForm.Elements.TextBoxURL.Text)) {
 

--- a/src/Lib/Functions/Private/Set-ShowLogButtonEnabled.ps1
+++ b/src/Lib/Functions/Private/Set-ShowLogButtonEnabled.ps1
@@ -18,7 +18,7 @@ function Set-ShowLogButtonEnabled {
         [bool]$Enabled
     )
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
 
         foreach ($Tab in $Script:Tabs) {
             $Button = $Tab.Elements.ButtonShowLog

--- a/src/Lib/Functions/Private/Set-SqlConnectionState.ps1
+++ b/src/Lib/Functions/Private/Set-SqlConnectionState.ps1
@@ -4,7 +4,7 @@ function Set-SqlConnectionState {
         [bool]$Status = $true
     )
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
 
         Set-SqlQueryFunctionState -Status $Status
         if ($Status) {

--- a/src/Lib/Functions/Private/Set-SqlQueryFunctionState.ps1
+++ b/src/Lib/Functions/Private/Set-SqlQueryFunctionState.ps1
@@ -4,7 +4,7 @@ function Set-SqlQueryFunctionState {
         [bool]$Status = $true
     )
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
 
 
         $ElementList = @{

--- a/src/Lib/Functions/Private/Set-TextBlockContent.ps1
+++ b/src/Lib/Functions/Private/Set-TextBlockContent.ps1
@@ -8,7 +8,7 @@ function Set-TextBlockContent {
     )
 
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
         $CurrentTextBlockContent = $TextBlockObject.Text
         $TextBlockObject.Text = $Content
         "{0} set from '{1}' to '{2}'" -f $TextBlockObject.Name, $CurrentTextBlockContent, $TextBlockObject.Text | Write-LogOutput -LogType DEBUG

--- a/src/Lib/Functions/Private/Set-TextBlockText.ps1
+++ b/src/Lib/Functions/Private/Set-TextBlockText.ps1
@@ -8,7 +8,7 @@ function Set-TextBlockText {
     )
 
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
         $CurrentButtonContent = $TextBlockObject.Text
         if ([string]::IsNullOrEmpty($Text)) {
             $TextBlockObject.Text = $null

--- a/src/Lib/Functions/Private/Set-TextBoxWrapping.ps1
+++ b/src/Lib/Functions/Private/Set-TextBoxWrapping.ps1
@@ -5,7 +5,7 @@
         [bool]$Wrap = $false
     )
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
         "Set TextBox wrapping to {0}" -f $Wrap | Write-LogOutput -LogType DEBUG
         if ($Wrap) {
             $TextBox.TextWrapping = "WrapWithOverflow"

--- a/src/Lib/Functions/Private/Set-WindowSize.ps1
+++ b/src/Lib/Functions/Private/Set-WindowSize.ps1
@@ -7,7 +7,7 @@ function Set-WindowSize {
         [string]$Setting
     )
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
         $Form.Width = [Int]::Abs($Setting.Split("x")[0])
         $Form.Height = [Int]::Abs($Setting.Split("x")[1])
 

--- a/src/Lib/Functions/Private/Show-PopupWindow.ps1
+++ b/src/Lib/Functions/Private/Show-PopupWindow.ps1
@@ -4,7 +4,7 @@ function Show-PopupWindow {
         $Message
     )
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
         if ($null -eq $Script:MainForm -or $null -eq $Script:MainForm.Definition -or !$Script:MainForm.Definition.IsVisible) {
             return
         }

--- a/src/Lib/Functions/Private/Test-ConnectionButton.ps1
+++ b/src/Lib/Functions/Private/Test-ConnectionButton.ps1
@@ -2,7 +2,7 @@ function Test-ConnectionButton {
     [CmdLetBinding()]
     param()
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
 
         if ([string]::IsNullOrEmpty($Script:MainForm.Elements.TextBoxURL.Text) -or $null -eq $Script:MainForm.Elements.ComboBoxSelectAuthenticationOption.SelectedItem) {
             $Script:MainForm.Elements.ButtonConnect.IsEnabled = $false

--- a/src/Lib/Functions/Private/Test-ConnectionRequirements.ps1
+++ b/src/Lib/Functions/Private/Test-ConnectionRequirements.ps1
@@ -2,7 +2,7 @@ function Test-ConnectionRequirements {
     [CmdLetBinding()]
     param()
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
         if ([string]::IsNullOrEmpty($Script:MainForm.Elements.TextBoxURL.Text)) {
             "URL is empty" | Write-LogOutput -LogType DEBUG
             return $false

--- a/src/Lib/Functions/Private/Test-ConnectionSettings.ps1
+++ b/src/Lib/Functions/Private/Test-ConnectionSettings.ps1
@@ -2,7 +2,7 @@ function Test-ConnectionSettings {
     [CmdLetBinding()]
     param()
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
 
         $SelectedAuthentication = $Script:MainForm.Elements.ComboBoxSelectAuthenticationOption.SelectedItem
         $AuthenticationOption = if ($null -ne $SelectedAuthentication) { $SelectedAuthentication.Content } else { $null }

--- a/src/Lib/Functions/Private/Test-LogFormIsVisible.ps1
+++ b/src/Lib/Functions/Private/Test-LogFormIsVisible.ps1
@@ -2,7 +2,7 @@ function Test-LogFormIsVisible {
     [CmdLetBinding()]
     param()
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
         if ($null -ne $Script:LogForm -and $null -ne $Script:LogForm.Definition -and $Script:LogForm.Definition.IsVisible) {
             "Test-LogFormIsVisible: true" | Write-LogOutput -LogType VERBOSE2
             return $true

--- a/src/Lib/Functions/Private/Test-MainFormIsVisible.ps1
+++ b/src/Lib/Functions/Private/Test-MainFormIsVisible.ps1
@@ -2,7 +2,7 @@ function Test-MainFormIsVisible {
     [CmdLetBinding()]
     param()
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
         if ($null -ne $Script:MainForm -and $null -ne $Script:MainForm.Definition -and $Script:MainForm.Definition.IsVisible) {
             return $true
         }

--- a/src/Lib/Functions/Private/Test-Shortcut.ps1
+++ b/src/Lib/Functions/Private/Test-Shortcut.ps1
@@ -2,7 +2,7 @@ function Test-Shortcut {
     [CmdLetBinding()]
     param()
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
         $LocalAppDataPath = Join-Path ([System.Environment]::GetFolderPath([System.Environment+SpecialFolder]::LocalApplicationData)) -ChildPath "OmadaSqlTroubleShooter"
         if (-not (Test-Path -Path $LocalAppDataPath)) {
             New-Item -Path $LocalAppDataPath -ItemType Directory -Force | Out-Null

--- a/src/Lib/Functions/Private/Test-SqlHistoryFormIsVisible.ps1
+++ b/src/Lib/Functions/Private/Test-SqlHistoryFormIsVisible.ps1
@@ -2,7 +2,7 @@ function Test-SqlHistoryFormOpen {
     [CmdLetBinding()]
     param()
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
         if ($null -ne $Script:SqlHistoryForm -and $null -ne $Script:SqlHistoryForm.Definition -and $Script:SqlHistoryForm.Definition.IsVisible) {
             "Test-SqlHistoryFormOpen: true" | Write-LogOutput -LogType VERBOSE2
             return $true

--- a/src/Lib/Functions/Private/Test-SqlSchemaFormIsVisible.ps1
+++ b/src/Lib/Functions/Private/Test-SqlSchemaFormIsVisible.ps1
@@ -2,7 +2,7 @@ function Test-SqlSchemaFormIsVisible {
     [CmdLetBinding()]
     param()
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
         if ($null -ne $Script:SqlSchemaForm -and $null -ne $Script:SqlSchemaForm.Definition -and $Script:SqlSchemaForm.Definition.IsVisible) {
             "Test-SqlSchemaFormIsVisible: true" | Write-LogOutput -LogType VERBOSE2
             return $true

--- a/src/Lib/Functions/Private/Test-TabCapacity.ps1
+++ b/src/Lib/Functions/Private/Test-TabCapacity.ps1
@@ -10,7 +10,7 @@ function Test-TabCapacity {
         [int]$MaxCapacity = 8
     )
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
         return $CurrentCount -lt $MaxCapacity
     }
     catch {

--- a/src/Lib/Functions/Private/Test-Variable.ps1
+++ b/src/Lib/Functions/Private/Test-Variable.ps1
@@ -10,7 +10,7 @@ function Test-Variable {
         [switch]$ExcludeAttribute
     )
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
 
         function ReturnObject {
             if ($ExcludeVariable -and $ExcludeAttribute) {

--- a/src/Lib/Functions/Private/Update-DataConnectionList.ps1
+++ b/src/Lib/Functions/Private/Update-DataConnectionList.ps1
@@ -6,7 +6,7 @@ function Update-DataConnectionList {
     )
 
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
         if (!(Test-ConnectionRequirements)) {
             "Connection not ready" | Write-LogOutput -LogType DEBUG
             return

--- a/src/Lib/Functions/Private/Update-LogWindowPosition.ps1
+++ b/src/Lib/Functions/Private/Update-LogWindowPosition.ps1
@@ -2,7 +2,7 @@ function Update-LogFormPosition {
     [CmdLetBinding()]
     param()
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
         $Script:LogForm.PositionManager.MainFormRight = [Int]::Abs($Script:MainForm.Definition.Left) + [Int]::Abs($Script:MainForm.Definition.Width)
         "PositionManagerLogForm MainFormRight: {0}" -f $Script:LogForm.PositionManager.MainFormRight | Write-LogOutput -LogType DEBUG
         $Script:LogForm.PositionManager.MainFormBottom = [Int]::Abs($Script:MainForm.Definition.Top) - [Int]::Abs($Script:MainForm.Definition.Height)

--- a/src/Lib/Functions/Private/Update-QueryList.ps1
+++ b/src/Lib/Functions/Private/Update-QueryList.ps1
@@ -7,7 +7,7 @@ function Update-QueryList {
 
     try {
 
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
 
         if ($Script:RunTimeConfig.ReconnectStatus -eq 1) {
             "Skip reconnect" | Write-LogOutput -LogType DEBUG

--- a/src/Lib/Functions/Private/Update-SqlSchemaTreeFilter.ps1
+++ b/src/Lib/Functions/Private/Update-SqlSchemaTreeFilter.ps1
@@ -22,7 +22,7 @@ function Update-SqlSchemaTreeFilter {
         [string]$FilterValue
     )
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
 
         # The schema window is optional: the schema itself is also retrieved to feed the editor's
         # IntelliSense, so there is nothing to filter when the window was never opened.

--- a/src/Lib/Functions/Private/Update-SqlSchemaWindow.ps1
+++ b/src/Lib/Functions/Private/Update-SqlSchemaWindow.ps1
@@ -2,7 +2,7 @@ function Update-SqlSchemaForm {
     [CmdLetBinding()]
     param()
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
         if ($null -ne $Script:TreeViewSqlSchema) {
             $Script:TreeViewSqlSchema.Dispatcher.Invoke({
                     $null

--- a/src/Lib/Functions/Private/Update-SqlSchemaWindowPosition.ps1
+++ b/src/Lib/Functions/Private/Update-SqlSchemaWindowPosition.ps1
@@ -2,7 +2,7 @@ function Update-SqlSchemaFormPosition {
     [CmdLetBinding()]
     param()
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
         $Script:SqlSchemaForm.PositionManager.MainFormRight = [Int]::Abs($Script:MainForm.Definition.Left) + [Int]::Abs($Script:MainForm.Definition.Width)
         "PositionManagerSqlSchemaForm MainFormRight: {0}" -f $Script:SqlSchemaForm.PositionManager.MainFormRight | Write-LogOutput -LogType DEBUG
         $Script:SqlSchemaForm.PositionManager.MainFormBottom = [Int]::Abs($Script:MainForm.Definition.Top) - [Int]::Abs($Script:MainForm.Definition.Height)

--- a/src/Lib/Functions/Private/Write-LogOutput.ps1
+++ b/src/Lib/Functions/Private/Write-LogOutput.ps1
@@ -14,6 +14,15 @@ function Write-LogOutput {
         if ($null -eq $Message) {
             $Message = "-"
         }
+
+        # Last gate before anything reaches AppLogObject, which the log window's "Export Log File"
+        # button writes to disk verbatim. Structure-aware redaction already happened at the call
+        # sites via ConvertTo-RedactedLogString; this catches secrets embedded in free-form text -
+        # exception messages, third-party output, and any call site that forgets. Applied to
+        # $Message itself so every derived value (the log line, the dialog text, the Write-Error
+        # and Write-Verbose paths) inherits it.
+        $Message = Protect-LogMessage -Message $Message
+
         $DateTimeObject = Get-Date
         $DateTime = $DateTimeObject.ToString("yyyy-MM-dd HH:mm:ss")
         if ($Script:RunTimeConfig.Logging.LogLevelSetting -in ("VERBOSE", "VERBOSE2")) {

--- a/src/Lib/Functions/Private/_Clear-Variables.ps1
+++ b/src/Lib/Functions/Private/_Clear-Variables.ps1
@@ -3,7 +3,7 @@ function Clear-Variables {
     param()
 
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
         $EndVariables = Get-Variable
         $SkipVariableNames = @("WshShell", "WhatIfPreference", "WarningPreference", "VerbosePreference", "true", "PSItem", "Task")
         foreach ($EndVariable in $EndVariables) {

--- a/src/Lib/Functions/Private/_Invoke-ButtonClick.ps1
+++ b/src/Lib/Functions/Private/_Invoke-ButtonClick.ps1
@@ -5,7 +5,7 @@ function Invoke-ButtonClick {
     )
 
     try {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
 
         if ($Script:SqlHistoryForm.Elements.$ButtonName.IsEnabled) {
             $Script:SqlHistoryForm.Elements.$ButtonName.RaiseEvent([System.Windows.RoutedEventArgs]::new([System.Windows.Controls.Primitives.ButtonBase]::ClickEvent))

--- a/src/Lib/Functions/Private/_Wait-Task.ps1
+++ b/src/Lib/Functions/Private/_Wait-Task.ps1
@@ -5,7 +5,7 @@ function Wait-Task {
     )
 
     begin {
-        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, ($PSBoundParameters | Out-String)))
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
         $Tasks = @()
     }
 

--- a/src/Lib/Functions/Public/Invoke-OmadaSqlTroubleshooter.ps1
+++ b/src/Lib/Functions/Public/Invoke-OmadaSqlTroubleshooter.ps1
@@ -169,7 +169,7 @@ function Invoke-OmadaSqlTroubleshooter {
         $Message = "Application '{0}': Initialized!" -f $Script:RunTimeConfig.ApplicationTitle
         $Message | Write-Host -ForegroundColor Green
         $Message | Write-LogOutput -LogType DEBUG
-        "Loading Main form with settings:`r`n{0}" -f ($Script:AppConfig | ConvertTo-Json) | Write-LogOutput -LogType DEBUG
+        "Loading Main form with settings:`r`n{0}" -f (ConvertTo-RedactedLogString -InputObject $Script:AppConfig) | Write-LogOutput -LogType DEBUG
 
         # End-to-end automation hook. Inert during normal use; only active when OMADASQL_E2E_SCRIPT is
         # set (by the local E2E harness). Once the window is loaded and the dispatcher goes idle (so the

--- a/tests/ConvertTo-RedactedLogString.Tests.ps1
+++ b/tests/ConvertTo-RedactedLogString.Tests.ps1
@@ -1,0 +1,185 @@
+BeforeAll {
+    $ParentPath = Split-Path -Path $PSScriptRoot -Parent
+    $Command = Join-Path $ParentPath -ChildPath "src\lib\functions\Private\ConvertTo-RedactedLogString.ps1"
+    . $Command
+    $Script:Tracer = [System.Diagnostics.Trace]
+    $Script:RunTimeConfig = [PSCustomObject]@{ ApplicationName = "Test" }
+
+    # A real PSCredential - the password must never survive serialization.
+    $Script:TestPassword = "Sup3rSecret!"
+    $Script:TestCredential = [PSCredential]::new("omada\serviceaccount", (ConvertTo-SecureString $Script:TestPassword -AsPlainText -Force))
+}
+
+Describe 'ConvertTo-RedactedLogString' {
+
+    Context 'Sensitive keys' {
+
+        It 'masks the <_> key at the top level' -ForEach @(
+            "Authorization", "Cookie", "Credential", "Password", "Secret", "Token", "ApiKey", "ClientSecret", "SessionKey"
+        ) {
+            $Result = ConvertTo-RedactedLogString -InputObject @{ $_ = "TopSecretValue123" }
+
+            $Result | Should -Not -Match "TopSecretValue123"
+            $Result | Should -Match "REDACTED"
+        }
+
+        It 'matches key names case-insensitively' {
+            $Result = ConvertTo-RedactedLogString -InputObject @{ "AUTHORIZATION" = "Basic dXNlcjpwYXNz" }
+
+            $Result | Should -Not -Match "dXNlcjpwYXNz"
+        }
+
+        It 'matches sensitive names as a substring so composite headers are covered' {
+            # Real header/property names seen in the wild: X-CSRF-Token, RefreshToken, SessionCookie.
+            $Result = ConvertTo-RedactedLogString -InputObject @{
+                "X-CSRF-Token"  = "csrf-abcdef"
+                "RefreshToken"  = "refresh-abcdef"
+                "SessionCookie" = "cookie-abcdef"
+            }
+
+            $Result | Should -Not -Match "abcdef"
+        }
+
+        It 'masks sensitive keys nested several levels deep' {
+            $Result = ConvertTo-RedactedLogString -InputObject @{
+                Level1 = @{
+                    Level2 = @{
+                        Headers = @{ Authorization = "Bearer nested-secret-value" }
+                    }
+                }
+            }
+
+            $Result | Should -Not -Match "nested-secret-value"
+            $Result | Should -Match "REDACTED"
+        }
+
+        It 'masks sensitive keys inside array elements' {
+            $Result = ConvertTo-RedactedLogString -InputObject @(
+                @{ Name = "first"; Password = "array-secret-value" }
+            )
+
+            $Result | Should -Not -Match "array-secret-value"
+        }
+
+        It 'masks sensitive properties on a PSCustomObject as well as a hashtable' {
+            $Result = ConvertTo-RedactedLogString -InputObject ([PSCustomObject]@{ Uri = "https://tenant.omada.cloud"; Token = "pscustom-secret" })
+
+            $Result | Should -Not -Match "pscustom-secret"
+            $Result | Should -Match "tenant.omada.cloud"
+        }
+    }
+
+    Context 'Sensitive types' {
+
+        It 'never serializes the password of a PSCredential' {
+            $Result = ConvertTo-RedactedLogString -InputObject @{ Credential = $Script:TestCredential }
+
+            $Result | Should -Not -Match ([regex]::Escape($Script:TestPassword))
+        }
+
+        It 'keeps the PSCredential user name, which is diagnostic and not secret' {
+            # The credential arrives under a non-sensitive key name here, so only the type rule can save us.
+            $Result = ConvertTo-RedactedLogString -InputObject @{ Identity = $Script:TestCredential }
+
+            $Result | Should -Match "serviceaccount"
+            $Result | Should -Not -Match ([regex]::Escape($Script:TestPassword))
+        }
+
+        It 'masks a bare SecureString' {
+            $Secure = ConvertTo-SecureString "secure-string-secret" -AsPlainText -Force
+            $Result = ConvertTo-RedactedLogString -InputObject @{ Value = $Secure }
+
+            $Result | Should -Not -Match "secure-string-secret"
+            $Result | Should -Match "REDACTED"
+        }
+
+        It 'reduces a byte array to its length instead of dumping its contents' {
+            $Result = ConvertTo-RedactedLogString -InputObject @{ Payload = [byte[]]@(1, 2, 3, 4, 5) }
+
+            $Result | Should -Match "Byte\[5\]"
+        }
+    }
+
+    Context 'Request bodies' {
+
+        It 'keeps body keys and value shapes but not the values' {
+            $Result = ConvertTo-RedactedLogString -InputObject @{
+                Uri  = "https://tenant.omada.cloud/odata"
+                Body = @{ query = "SELECT * FROM dbo.Identity"; page = 1 }
+            }
+
+            $Result | Should -Match "query"
+            $Result | Should -Not -Match "SELECT"
+        }
+    }
+
+    Context 'Volume control' {
+
+        It 'collapses long arrays to a shape summary instead of every element' {
+            $Rows = 1..50 | ForEach-Object { [PSCustomObject]@{ Id = $_; DisplayName = "Person-$_" } }
+            $Result = ConvertTo-RedactedLogString -InputObject @{ Rows = $Rows }
+
+            $Result | Should -Match "Array\[50\]"
+            $Result | Should -Not -Match "Person-42"
+        }
+
+        It 'keeps short arrays intact so small payloads stay readable' {
+            $Result = ConvertTo-RedactedLogString -InputObject @{ Methods = @("GET", "POST") }
+
+            $Result | Should -Match "GET"
+            $Result | Should -Match "POST"
+        }
+
+        It 'truncates very long strings' {
+            $Long = "a" * 2000
+            $Result = ConvertTo-RedactedLogString -InputObject @{ Note = $Long } -MaxStringLength 50
+
+            $Result.Length | Should -BeLessThan 500
+            $Result | Should -Match "truncated"
+        }
+
+        It 'stops at the depth limit rather than walking forever' {
+            $Deep = @{ A = @{ B = @{ C = @{ D = @{ E = @{ F = @{ G = "deep-value-here" } } } } } } }
+            $Result = ConvertTo-RedactedLogString -InputObject $Deep -MaxDepth 3
+
+            $Result | Should -Not -Match "deep-value-here"
+        }
+    }
+
+    Context 'Robustness' {
+
+        It 'terminates on a self-referencing object instead of recursing forever' {
+            # Live WPF/session objects are cyclic; the walker must not hang the UI thread.
+            $Cyclic = @{ Name = "root" }
+            $Cyclic["Self"] = $Cyclic
+
+            $Result = ConvertTo-RedactedLogString -InputObject $Cyclic
+
+            $Result | Should -Match "root"
+            $Result | Should -Match "circular reference"
+        }
+
+        It 'handles $null without throwing' {
+            { ConvertTo-RedactedLogString -InputObject $null } | Should -Not -Throw
+        }
+
+        It 'handles a plain string without throwing' {
+            ConvertTo-RedactedLogString -InputObject "just text" | Should -Match "just text"
+        }
+
+        It 'preserves non-sensitive diagnostic values' {
+            $Result = ConvertTo-RedactedLogString -InputObject @{
+                Uri                = "https://tenant.omada.cloud/odata"
+                Method             = "POST"
+                AuthenticationType = "Basic"
+            }
+
+            $Result | Should -Match "tenant.omada.cloud"
+            $Result | Should -Match "POST"
+        }
+
+        It 'always returns a string, never $null' {
+            ConvertTo-RedactedLogString -InputObject @{} | Should -BeOfType [string]
+        }
+    }
+}

--- a/tests/ConvertTo-RedactedLogString.Tests.ps1
+++ b/tests/ConvertTo-RedactedLogString.Tests.ps1
@@ -85,6 +85,15 @@ Describe 'ConvertTo-RedactedLogString' {
             $Result | Should -Not -Match ([regex]::Escape($Script:TestPassword))
         }
 
+        It 'keeps the user name even under the sensitive key name Credential' {
+            # The type rule wins over the name rule here: which account authenticated is exactly what
+            # you need to know when troubleshooting a 401, and the password never leaves the SecureString.
+            $Result = ConvertTo-RedactedLogString -InputObject @{ Credential = $Script:TestCredential }
+
+            $Result | Should -Match "serviceaccount"
+            $Result | Should -Not -Match ([regex]::Escape($Script:TestPassword))
+        }
+
         It 'masks a bare SecureString' {
             $Secure = ConvertTo-SecureString "secure-string-secret" -AsPlainText -Force
             $Result = ConvertTo-RedactedLogString -InputObject @{ Value = $Secure }

--- a/tests/ConvertTo-RedactedLogString.Tests.ps1
+++ b/tests/ConvertTo-RedactedLogString.Tests.ps1
@@ -123,7 +123,7 @@ Describe 'ConvertTo-RedactedLogString' {
 
         It 'applies the same treatment to a body passed on its own via -ShapeOnly' {
             # The "Body: ..." call sites hand over the body itself, not a parameter set containing it,
-            # so there is no key name for the walker to recognise.
+            # so there is no key name for the walker to recognize.
             $Result = ConvertTo-RedactedLogString -InputObject @{ query = "SELECT * FROM dbo.Identity"; page = 1 } -ShapeOnly
 
             $Result | Should -Match "query"

--- a/tests/ConvertTo-RedactedLogString.Tests.ps1
+++ b/tests/ConvertTo-RedactedLogString.Tests.ps1
@@ -120,6 +120,16 @@ Describe 'ConvertTo-RedactedLogString' {
             $Result | Should -Match "query"
             $Result | Should -Not -Match "SELECT"
         }
+
+        It 'applies the same treatment to a body passed on its own via -ShapeOnly' {
+            # The "Body: ..." call sites hand over the body itself, not a parameter set containing it,
+            # so there is no key name for the walker to recognise.
+            $Result = ConvertTo-RedactedLogString -InputObject @{ query = "SELECT * FROM dbo.Identity"; page = 1 } -ShapeOnly
+
+            $Result | Should -Match "query"
+            $Result | Should -Match "page"
+            $Result | Should -Not -Match "SELECT"
+        }
     }
 
     Context 'Volume control' {

--- a/tests/ConvertTo-TabSessionConfig.Tests.ps1
+++ b/tests/ConvertTo-TabSessionConfig.Tests.ps1
@@ -2,6 +2,8 @@ BeforeAll {
     $ParentPath = Split-Path -Path $PSScriptRoot -Parent
     . (Join-Path $ParentPath -ChildPath "src\lib\functions\Private\Get-DefaultTabDisplayName.ps1")
     . (Join-Path $ParentPath -ChildPath "src\lib\functions\Private\ConvertTo-TabSessionConfig.ps1")
+    # The tracer preamble of the function under test redacts its bound parameters.
+    . (Join-Path $ParentPath -ChildPath "src\lib\functions\Private\ConvertTo-RedactedLogString.ps1")
     $Script:Tracer = [System.Diagnostics.Trace]
     $Script:RunTimeConfig = [PSCustomObject]@{ ApplicationName = "Test" }
 }

--- a/tests/Get-ActiveTabSession.Tests.ps1
+++ b/tests/Get-ActiveTabSession.Tests.ps1
@@ -2,6 +2,8 @@ BeforeAll {
     $ParentPath = Split-Path -Path $PSScriptRoot -Parent
     $Command = Join-Path $ParentPath -ChildPath "src\lib\functions\Private\Get-ActiveTabSession.ps1"
     . $Command
+    # The tracer preamble of the function under test redacts its bound parameters.
+    . (Join-Path $ParentPath -ChildPath "src\lib\functions\Private\ConvertTo-RedactedLogString.ps1")
     $Script:Tracer = [System.Diagnostics.Trace]
     $Script:RunTimeConfig = [PSCustomObject]@{ ApplicationName = "Test" }
 }

--- a/tests/Get-DefaultTabDisplayName.Tests.ps1
+++ b/tests/Get-DefaultTabDisplayName.Tests.ps1
@@ -2,6 +2,8 @@ BeforeAll {
     $ParentPath = Split-Path -Path $PSScriptRoot -Parent
     $Command = Join-Path $ParentPath -ChildPath "src\lib\functions\Private\Get-DefaultTabDisplayName.ps1"
     . $Command
+    # The tracer preamble of the function under test redacts its bound parameters.
+    . (Join-Path $ParentPath -ChildPath "src\lib\functions\Private\ConvertTo-RedactedLogString.ps1")
     $Script:Tracer = [System.Diagnostics.Trace]
     $Script:RunTimeConfig = [PSCustomObject]@{ ApplicationName = "Test" }
 }

--- a/tests/Get-GalleryModuleVersion.Tests.ps1
+++ b/tests/Get-GalleryModuleVersion.Tests.ps1
@@ -2,6 +2,8 @@ BeforeAll {
     $ParentPath = Split-Path -Path $PSScriptRoot -Parent
     $Command = Join-Path $ParentPath -ChildPath "src\lib\functions\Private\Get-GalleryModuleVersion.ps1"
     . $Command
+    # The tracer preamble of the function under test redacts its bound parameters.
+    . (Join-Path $ParentPath -ChildPath "src\lib\functions\Private\ConvertTo-RedactedLogString.ps1")
     $Script:Tracer = [System.Diagnostics.Trace]
     $Script:RunTimeConfig = [PSCustomObject]@{ ApplicationName = "Test" }
 }

--- a/tests/Get-LogResultShape.Tests.ps1
+++ b/tests/Get-LogResultShape.Tests.ps1
@@ -1,0 +1,73 @@
+BeforeAll {
+    $ParentPath = Split-Path -Path $PSScriptRoot -Parent
+    $Command = Join-Path $ParentPath -ChildPath "src\lib\functions\Private\Get-LogResultShape.ps1"
+    . $Command
+    $Script:Tracer = [System.Diagnostics.Trace]
+    $Script:RunTimeConfig = [PSCustomObject]@{ ApplicationName = "Test" }
+
+    function New-FakeRows {
+        param([int]$Count)
+        1..$Count | ForEach-Object {
+            [PSCustomObject]@{
+                Id          = $_
+                DisplayName = "Employee-$_"
+                Email       = "user$_@contoso.com"
+            }
+        }
+    }
+}
+
+Describe 'Get-LogResultShape' {
+
+    It 'reports the row count' {
+        Get-LogResultShape -InputObject (New-FakeRows -Count 42) | Should -Match "42 row"
+    }
+
+    It 'reports the column count and the column names' {
+        $Result = Get-LogResultShape -InputObject (New-FakeRows -Count 3)
+
+        $Result | Should -Match "3 column"
+        $Result | Should -Match "Id"
+        $Result | Should -Match "DisplayName"
+        $Result | Should -Match "Email"
+    }
+
+    It 'never emits a cell value' {
+        # This is the whole point: an exported log may be attached to a support ticket.
+        $Result = Get-LogResultShape -InputObject (New-FakeRows -Count 10)
+
+        $Result | Should -Not -Match "Employee-"
+        $Result | Should -Not -Match "contoso.com"
+    }
+
+    It 'handles a single row that is not wrapped in an array' {
+        $Result = Get-LogResultShape -InputObject ([PSCustomObject]@{ Id = 1; DisplayName = "Solo" })
+
+        $Result | Should -Match "1 row"
+        $Result | Should -Not -Match "Solo"
+    }
+
+    It 'reports an empty result set as zero rows' {
+        Get-LogResultShape -InputObject @() | Should -Match "0 row"
+    }
+
+    It 'handles $null without throwing' {
+        { Get-LogResultShape -InputObject $null } | Should -Not -Throw
+        Get-LogResultShape -InputObject $null | Should -Match "0 row"
+    }
+
+    It 'caps the number of column names it lists' {
+        $Wide = [PSCustomObject]@{}
+        1..40 | ForEach-Object { $Wide | Add-Member -NotePropertyName "Column$_" -NotePropertyValue $_ }
+
+        $Result = Get-LogResultShape -InputObject $Wide
+
+        $Result | Should -Match "40 column"
+        # Only the first batch of names is listed, with an explicit marker that more exist.
+        $Result | Should -Match "more"
+    }
+
+    It 'always returns a string, never $null' {
+        Get-LogResultShape -InputObject (New-FakeRows -Count 1) | Should -BeOfType [string]
+    }
+}

--- a/tests/Protect-LogMessage.Tests.ps1
+++ b/tests/Protect-LogMessage.Tests.ps1
@@ -1,0 +1,88 @@
+BeforeAll {
+    $ParentPath = Split-Path -Path $PSScriptRoot -Parent
+    $Command = Join-Path $ParentPath -ChildPath "src\lib\functions\Private\Protect-LogMessage.ps1"
+    . $Command
+    $Script:Tracer = [System.Diagnostics.Trace]
+    $Script:RunTimeConfig = [PSCustomObject]@{ ApplicationName = "Test" }
+}
+
+Describe 'Protect-LogMessage' {
+
+    Context 'Authorization material' {
+
+        It 'masks a Basic authorization header' {
+            $Result = Protect-LogMessage -Message "Authorization: Basic b21hZGE6UzNjcjN0UGFzcw=="
+
+            $Result | Should -Not -Match "b21hZGE6UzNjcjN0UGFzcw"
+            $Result | Should -Match "REDACTED"
+        }
+
+        It 'masks a Bearer token' {
+            $Result = Protect-LogMessage -Message "Authorization: Bearer abcdef1234567890abcdef"
+
+            $Result | Should -Not -Match "abcdef1234567890"
+        }
+
+        It 'masks a bare JWT that appears without a scheme prefix' {
+            $Jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NSJ9.dBjftJeZ4CVPmB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+            $Result = Protect-LogMessage -Message "Cached response token $Jwt for tenant"
+
+            $Result | Should -Not -Match "dBjftJeZ4CVPmB92K27uhbUJU1p1r"
+            $Result | Should -Match "tenant"
+        }
+
+        It 'leaves the scheme name alone when it is not followed by a token' {
+            # "Basic" as an authentication-type value is useful diagnostic information.
+            Protect-LogMessage -Message "AuthenticationType: Basic" | Should -Match "Basic"
+        }
+    }
+
+    Context 'Serialized key/value pairs' {
+
+        It 'masks a JSON <_> pair' -ForEach @("Password", "Authorization", "Token", "Secret", "ApiKey", "Cookie") {
+            $Result = Protect-LogMessage -Message ('{{"{0}": "LeakedValue987"}}' -f $_)
+
+            $Result | Should -Not -Match "LeakedValue987"
+            $Result | Should -Match "REDACTED"
+        }
+
+        It 'masks a query-string style password' {
+            Protect-LogMessage -Message "url=https://tenant/api?user=bob&password=P@ssw0rd123" | Should -Not -Match "P@ssw0rd123"
+        }
+
+        It 'masks a session cookie value' {
+            $Result = Protect-LogMessage -Message "Set-Cookie: ASP.NET_SessionId=n3v3rl0gth1svalue; path=/"
+
+            $Result | Should -Not -Match "n3v3rl0gth1svalue"
+        }
+    }
+
+    Context 'Non-sensitive text' {
+
+        It 'leaves an ordinary log line untouched' {
+            $Message = "2026-08-13 10:00:00 - INFO    - Main - Invoke-ExecuteQuery (56): Retrieve query output, please wait..."
+
+            Protect-LogMessage -Message $Message | Should -BeExactly $Message
+        }
+
+        It 'keeps the request URL, which is diagnostic' {
+            Protect-LogMessage -Message "QueryUrl: https://tenant.omada.cloud/OData/BuiltIn/C_P_SQLTROUBLESHOOTING" |
+                Should -Match "C_P_SQLTROUBLESHOOTING"
+        }
+    }
+
+    Context 'Robustness' {
+
+        It 'handles $null without throwing' {
+            { Protect-LogMessage -Message $null } | Should -Not -Throw
+        }
+
+        It 'handles an empty string without throwing' {
+            { Protect-LogMessage -Message "" } | Should -Not -Throw
+        }
+
+        It 'accepts pipeline input' {
+            "Authorization: Bearer abcdef1234567890abcdef" | Protect-LogMessage | Should -Not -Match "abcdef1234567890"
+        }
+    }
+}

--- a/tests/Protect-LogMessage.Tests.ps1
+++ b/tests/Protect-LogMessage.Tests.ps1
@@ -46,6 +46,18 @@ Describe 'Protect-LogMessage' {
             $Result | Should -Match "REDACTED"
         }
 
+        It 'still masks a Credential pair holding anything other than the safe rendering' {
+            Protect-LogMessage -Message '{"Credential": "omada\\svc_sql:Sup3rSecret!"}' | Should -Not -Match "Sup3rSecret"
+        }
+
+        It 'keeps the credential rendering ConvertTo-RedactedLogString deliberately emits' {
+            # Otherwise the safety net would undo the walker's decision to report which account
+            # authenticated. The rendering carries a user name and no password.
+            $Result = Protect-LogMessage -Message '{"Credential": "PSCredential(UserName=omada\\svc_sql)"}'
+
+            $Result | Should -Match "svc_sql"
+        }
+
         It 'masks a query-string style password' {
             Protect-LogMessage -Message "url=https://tenant/api?user=bob&password=P@ssw0rd123" | Should -Not -Match "P@ssw0rd123"
         }

--- a/tests/Set-ShowLogButtonEnabled.Tests.ps1
+++ b/tests/Set-ShowLogButtonEnabled.Tests.ps1
@@ -2,6 +2,8 @@ BeforeAll {
     $ParentPath = Split-Path -Path $PSScriptRoot -Parent
     $Command = Join-Path $ParentPath -ChildPath "src\lib\functions\Private\Set-ShowLogButtonEnabled.ps1"
     . $Command
+    # The tracer preamble of the function under test redacts its bound parameters.
+    . (Join-Path $ParentPath -ChildPath "src\lib\functions\Private\ConvertTo-RedactedLogString.ps1")
     $Script:Tracer = [System.Diagnostics.Trace]
     $Script:RunTimeConfig = [PSCustomObject]@{ ApplicationName = "Test" }
 

--- a/tests/Test-TabCapacity.Tests.ps1
+++ b/tests/Test-TabCapacity.Tests.ps1
@@ -2,6 +2,8 @@ BeforeAll {
     $ParentPath = Split-Path -Path $PSScriptRoot -Parent
     $Command = Join-Path $ParentPath -ChildPath "src\lib\functions\Private\Test-TabCapacity.ps1"
     . $Command
+    # The tracer preamble of the function under test redacts its bound parameters.
+    . (Join-Path $ParentPath -ChildPath "src\lib\functions\Private\ConvertTo-RedactedLogString.ps1")
     $Script:Tracer = [System.Diagnostics.Trace]
     $Script:RunTimeConfig = [PSCustomObject]@{ ApplicationName = "Test" }
 }

--- a/tests/Test-Variable.Tests.ps1
+++ b/tests/Test-Variable.Tests.ps1
@@ -3,6 +3,8 @@ BeforeAll {
     $ParentPath = Split-Path -Path $PSScriptRoot -Parent
     $Command = Join-Path $ParentPath -ChildPath "src\lib\functions\Private\Test-Variable.ps1"
     . $Command
+    # The tracer preamble of the function under test redacts its bound parameters.
+    . (Join-Path $ParentPath -ChildPath "src\lib\functions\Private\ConvertTo-RedactedLogString.ps1")
     $Script:Tracer = [System.Diagnostics.Trace]
 }
 

--- a/tests/Update-SqlSchemaTreeFilter.Tests.ps1
+++ b/tests/Update-SqlSchemaTreeFilter.Tests.ps1
@@ -5,6 +5,8 @@ BeforeAll {
     . (Join-Path $ParentPath -ChildPath "src\lib\functions\Private\ConvertTo-WildcardFilterPattern.ps1")
     . (Join-Path $ParentPath -ChildPath "src\lib\functions\Private\Update-SqlSchemaTreeFilter.ps1")
 
+    # The tracer preamble of the function under test redacts its bound parameters.
+    . (Join-Path $ParentPath -ChildPath "src\lib\functions\Private\ConvertTo-RedactedLogString.ps1")
     $Script:Tracer = [System.Diagnostics.Trace]
     $Script:RunTimeConfig = [PSCustomObject]@{ ApplicationName = "Test" }
 

--- a/tests/Write-LogOutput.Tests.ps1
+++ b/tests/Write-LogOutput.Tests.ps1
@@ -1,0 +1,119 @@
+BeforeAll {
+    $ParentPath = Split-Path -Path $PSScriptRoot -Parent
+    $FunctionPath = Join-Path $ParentPath -ChildPath "src\lib\functions\Private"
+    . (Join-Path $FunctionPath -ChildPath "Write-LogOutput.ps1")
+    . (Join-Path $FunctionPath -ChildPath "Protect-LogMessage.ps1")
+    . (Join-Path $FunctionPath -ChildPath "ConvertTo-RedactedLogString.ps1")
+    . (Join-Path $FunctionPath -ChildPath "Get-LogResultShape.ps1")
+
+    $Script:Tracer = [System.Diagnostics.Trace]
+
+    # The secret material the acceptance criterion of issue #39 names explicitly.
+    $Script:SecretPassword = "Sup3rSecret!"
+    $Script:SecretBasicHeader = "b21hZGE6U3VwM3JTZWNyZXQh"
+    $Script:SecretBearerCookie = "bearercookievalue9876"
+    $Script:SecretSessionId = "sessionvalue1234"
+}
+
+Describe 'Write-LogOutput redaction' {
+
+    BeforeEach {
+        # Minimal stand-in for the ambient application state Write-LogOutput reads. VERBOSE2 is the
+        # loudest level, so everything the app can emit is in scope; VerboseParameterSet suppresses
+        # the Write-Verbose echo and LogToConsole the Write-Host echo, leaving AppLogObject as the
+        # subject.
+        $Script:RunTimeConfig = [PSCustomObject]@{
+            ApplicationName     = "Test"
+            VerboseParameterSet = $true
+            Logging             = [PSCustomObject]@{
+                LogLevelSetting = "VERBOSE2"
+                LogToConsole    = $false
+                AppLogObject    = [System.Collections.ObjectModel.ObservableCollection[string]]::new()
+            }
+        }
+        $Script:Tabs = @()
+        $Script:ActiveTabId = $null
+        $Script:TextBoxLog = $null
+    }
+
+    Context 'A full request parameter set (issue #39 acceptance criterion)' {
+
+        BeforeEach {
+            $Credential = [PSCredential]::new("omada\svc_sql", (ConvertTo-SecureString $Script:SecretPassword -AsPlainText -Force))
+            $RequestParameters = @{
+                Uri                = "https://tenant.omada.cloud/OData/BuiltIn/C_P_SQLTROUBLESHOOTING"
+                Method             = "POST"
+                AuthenticationType = "Basic"
+                Credential         = $Credential
+                Headers            = @{
+                    Authorization = "Basic {0}" -f $Script:SecretBasicHeader
+                    Cookie        = "OISSession={0}; ASP.NET_SessionId={1}" -f $Script:SecretBearerCookie, $Script:SecretSessionId
+                }
+                Body               = @{ query = "SELECT * FROM dbo.Identity"; page = 1 }
+            }
+
+            "Parameters: {0}" -f (ConvertTo-RedactedLogString -InputObject $RequestParameters) | Write-LogOutput -LogType VERBOSE
+            $Script:LogText = $Script:RunTimeConfig.Logging.AppLogObject -join "`r`n"
+        }
+
+        It 'actually logged something (guards against the test passing on an empty log)' {
+            $Script:LogText | Should -Not -BeNullOrEmpty
+            $Script:LogText | Should -Match "Parameters:"
+        }
+
+        It 'contains no part of the Basic authorization header' {
+            $Script:LogText | Should -Not -Match $Script:SecretBasicHeader
+        }
+
+        It 'contains no bearer session cookie' {
+            $Script:LogText | Should -Not -Match $Script:SecretBearerCookie
+            $Script:LogText | Should -Not -Match $Script:SecretSessionId
+        }
+
+        It 'contains no credential password' {
+            $Script:LogText | Should -Not -Match ([regex]::Escape($Script:SecretPassword))
+        }
+
+        It 'contains no request body content' {
+            $Script:LogText | Should -Not -Match "SELECT"
+        }
+
+        It 'still contains the information that makes the log worth keeping' {
+            $Script:LogText | Should -Match "tenant.omada.cloud"
+            $Script:LogText | Should -Match "POST"
+        }
+    }
+
+    Context 'The safety net' {
+
+        It 'masks a secret in free-form text that never went through ConvertTo-RedactedLogString' {
+            # E.g. an exception message from a third-party module quoting the request it made.
+            "Request failed. Authorization: Basic dW5yZWRhY3RlZFZhbHVl" | Write-LogOutput -LogType VERBOSE
+
+            $LogText = $Script:RunTimeConfig.Logging.AppLogObject -join "`r`n"
+            $LogText | Should -Not -Match "dW5yZWRhY3RlZFZhbHVl"
+            $LogText | Should -Match "Request failed"
+        }
+
+        It 'leaves an ordinary message untouched' {
+            "Retrieve query output, please wait..." | Write-LogOutput -LogType INFO
+
+            ($Script:RunTimeConfig.Logging.AppLogObject -join "`r`n") | Should -Match "Retrieve query output, please wait\.\.\."
+        }
+    }
+
+    Context 'Result sets' {
+
+        It 'logs a result set as a shape, with no cell values' {
+            $Rows = 1..25 | ForEach-Object { [PSCustomObject]@{ Id = $_; DisplayName = "Employee-$_"; Email = "user$_@contoso.com" } }
+
+            "Result: {0}" -f (Get-LogResultShape -InputObject $Rows) | Write-LogOutput -LogType VERBOSE2
+
+            $LogText = $Script:RunTimeConfig.Logging.AppLogObject -join "`r`n"
+            $LogText | Should -Match "25 row"
+            $LogText | Should -Match "DisplayName"
+            $LogText | Should -Not -Match "contoso.com"
+            $LogText | Should -Not -Match "Employee-"
+        }
+    }
+}

--- a/tests/Write-LogOutput.Tests.ps1
+++ b/tests/Write-LogOutput.Tests.ps1
@@ -82,6 +82,11 @@ Describe 'Write-LogOutput redaction' {
             $Script:LogText | Should -Match "tenant.omada.cloud"
             $Script:LogText | Should -Match "POST"
         }
+
+        It 'reports which account authenticated, end to end through both redaction layers' {
+            # The walker keeps the user name and the safety net must not strip it again.
+            $Script:LogText | Should -Match "svc_sql"
+        }
     }
 
     Context 'The safety net' {


### PR DESCRIPTION
Closes #39.

Verbose logging serialized live objects straight into the application log, and the log window can
export that to a file users attach to support tickets. `Invoke-OmadaPSWebRequestWrapper.ps1:34`
dumped the whole `RestMethodParam` splat — `Credential` included — before every REST call;
`:39` dumped the full response; `Invoke-ExecuteQuery.ps1:82` rendered every returned row through
`Format-Table | Out-String -Width 10000000`. Separately, ~92 functions opened by writing their full
bound parameter set to `System.Diagnostics.Trace` with AutoFlush on.

An exported log is now shareable by design: it never needs scrubbing, because nothing secret
enters it.

## What changed

Three new private helpers:

| Function | Role |
| --- | --- |
| `ConvertTo-RedactedLogString` | Structure-aware walker. Masks by property name (`authorization`, `cookie`, `token`, `password`, …) and by type (`PSCredential`, `SecureString`, `byte[]`, cookie containers). Collapses arrays over 3 elements to `Array[n] of T`. Keeps request-body keys and value shapes, not values. Capped on depth, string length and circular references. |
| `Get-LogResultShape` | Renders a result set as `120 row(s) x 3 column(s) [Id, DisplayName, Email]` — never a cell value. |
| `Protect-LogMessage` | Regex safety net over already-flattened text, for secrets in exception messages and third-party output that never passed through the walker. |

`Write-LogOutput` runs `Protect-LogMessage` over `$Message` before anything is derived from it, so
the log store, console echo, `Write-Verbose`, `Write-Error` and message-box paths all inherit it.

All nine serialization call sites are converted. No `ConvertTo-Json`, `Format-Table` or `Out-String`
now reaches `Write-LogOutput` anywhere in `src/Lib`. The tracer preamble's 98 occurrences across
92 files route through the walker too.

## Acceptance criteria

- [x] A single redaction helper is the only path by which request/response objects reach the log
- [x] `Authorization` headers, cookies, `PSCredential`/`SecureString` values and request bodies are masked
- [x] Result sets are logged as row/column counts — no sample rows at all
- [x] All listed call sites converted
- [x] Unit tests assert a request with a Basic header, a bearer cookie and a credential logs none of those values
- [x] An exported log from a full session contains no secret material (verified end to end)
- [x] Where the helper lives is decided: **per repo**, not shared via OmadaWeb.PS — see below

## Decisions worth reviewing

**Helper location: per repo.** OmadaWeb.PS ships from the PowerShell Gallery and its source is not in
this tree, so it cannot be edited from here. Its own call sites (`Invoke-OmadaRequest.ps1:78/94/157`,
`Set-RequestParameter.ps1:30`) are filed separately as Fortigi/OmadaWeb.PS#43.

**Tracer uses `-MaxDepth 1`.** These preambles run on the UI thread in WPF event handlers; at greater
depth the walker would traverse a control's property graph, which is expensive and can have side
effects. At depth 1 scalars still log in full and complex objects collapse to their type name —
roughly the information `Out-String` gave.

**The credential user name is kept** (`PSCredential(UserName=omada\svc_sql)`), the password never.
Knowing which account hit a 401 is the first thing you need. This required a lookahead in the safety
net so it does not strip what the walker deliberately emits.

**Request bodies lose their values**, so SQL query text no longer appears in the log. That follows the
acceptance criteria as written; the text remains in the editor and the SQL history window. Easy to
revisit if you would rather keep it.

## Verification

`./build/build.ps1 -Task TestBuildOnly` is green: PSScriptAnalyzer clean, **210/210 tests pass**.

End-to-end, driving a full session's worth of log lines through `Write-LogOutput` and exporting with
the same call the Export Log File button uses, then scanning the file:

```
=== must be ABSENT ===          === must be PRESENT ===
password        absent  OK      account name  present OK
basic blob      absent  OK      host          present OK
session cookie  absent  OK      method        present OK
session id      absent  OK      row count     present OK
result cells    absent  OK      column names  present OK
SQL text        absent  OK
```

A representative log line now reads:

```
Parameters: {
  "Uri": "https://tenant.omada.cloud/OData/BuiltIn/C_P_SQLTROUBLESHOOTING",
  "Credential": "PSCredential(UserName=omada\\svc_sql)",
  "Body": { "C_QUERY": "String(30)", "NAME": "String(5)" },
  "Headers": { "Cookie": "***REDACTED***", "Authorization": "***REDACTED***" },
  "Method": "POST"
}
Result: 120 row(s) x 3 column(s) [Id, DisplayName, Email]
```

## Notes for the reviewer

- The unit suite dot-sources one function file per test and stubs its dependencies. Because the tracer
  preamble now calls the walker, eight test files needed that dot-source added — otherwise the
  preamble throws and the function's own `catch` reaches for a missing `Write-LogOutput`. That is the
  whole content of `test: give the unit tests the redaction helper their subject now needs`.
- The README's data-handling section said the log records complete bodies "including full result-set
  rows" at `VERBOSE`/`VERBOSE2`. That is exactly what this PR removes, so it is updated.
- The tracer sweep is its own commit so the substantive diff stays readable. It is one mechanical line
  per file, verified as exactly one changed line in each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JJXt2rS8P98gdTtx5EYEXN
