### PR TITLE
Fix the update check when the newest gallery package is a prerelease

### DIFF
--- a/src/Lib/Functions/Private/Compare-ModuleVersion.ps1
+++ b/src/Lib/Functions/Private/Compare-ModuleVersion.ps1
@@ -1,0 +1,45 @@
+function Compare-ModuleVersion {
+    <#
+        .SYNOPSIS
+        Compares two module version strings without ever throwing.
+
+        .DESCRIPTION
+        Returns -1 when the installed version is older than the gallery version, 0 when both
+        are the same and 1 when the installed version is the newer one. Returns $null when
+        either value cannot be parsed, so the caller can skip the comparison instead of
+        crashing on a cast.
+
+        Both values are first parsed as a SemanticVersion, which understands a prerelease
+        label such as '2026.8.22-nightly67'. A four part version such as '2026.6.26.4' is not
+        valid SemVer, so the pair falls back to System.Version. Casting a prerelease string to
+        System.Version is what broke the startup update check, so no cast is used anywhere.
+    #>
+    [CmdletBinding()]
+    [OutputType([System.Nullable[int]])]
+    param(
+        [string]$InstalledVersion,
+        [string]$GalleryVersion
+    )
+
+    $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
+
+    if ([string]::IsNullOrWhiteSpace($InstalledVersion) -or [string]::IsNullOrWhiteSpace($GalleryVersion)) {
+        "Cannot compare version '{0}' with version '{1}' because one of them is empty." -f $InstalledVersion, $GalleryVersion | Write-Verbose
+        return $null
+    }
+
+    $InstalledSemanticVersion = $null
+    $GallerySemanticVersion = $null
+    if ([System.Management.Automation.SemanticVersion]::TryParse($InstalledVersion, [ref]$InstalledSemanticVersion) -and [System.Management.Automation.SemanticVersion]::TryParse($GalleryVersion, [ref]$GallerySemanticVersion)) {
+        return $InstalledSemanticVersion.CompareTo($GallerySemanticVersion)
+    }
+
+    $InstalledSystemVersion = $null
+    $GallerySystemVersion = $null
+    if ([version]::TryParse($InstalledVersion, [ref]$InstalledSystemVersion) -and [version]::TryParse($GalleryVersion, [ref]$GallerySystemVersion)) {
+        return $InstalledSystemVersion.CompareTo($GallerySystemVersion)
+    }
+
+    "Cannot compare version '{0}' with version '{1}' because at least one of them is not a valid version." -f $InstalledVersion, $GalleryVersion | Write-Verbose
+    return $null
+}

--- a/src/Lib/Functions/Private/Compare-ModuleVersion.ps1
+++ b/src/Lib/Functions/Private/Compare-ModuleVersion.ps1
@@ -4,8 +4,8 @@ function Compare-ModuleVersion {
         Compares two module version strings without ever throwing.
 
         .DESCRIPTION
-        Returns -1 when the installed version is older than the gallery version, 0 when both
-        are the same and 1 when the installed version is the newer one. Returns $null when
+        Returns exactly -1 when the installed version is older than the gallery version, 0 when
+        both are the same and 1 when the installed version is the newer one. Returns $null when
         either value cannot be parsed, so the caller can skip the comparison instead of
         crashing on a cast.
 
@@ -31,13 +31,15 @@ function Compare-ModuleVersion {
     $InstalledSemanticVersion = $null
     $GallerySemanticVersion = $null
     if ([System.Management.Automation.SemanticVersion]::TryParse($InstalledVersion, [ref]$InstalledSemanticVersion) -and [System.Management.Automation.SemanticVersion]::TryParse($GalleryVersion, [ref]$GallerySemanticVersion)) {
-        return $InstalledSemanticVersion.CompareTo($GallerySemanticVersion)
+        # CompareTo only promises a negative, zero or positive number. Normalize it, because
+        # the documented contract of this function is -1, 0 or 1.
+        return [Math]::Sign($InstalledSemanticVersion.CompareTo($GallerySemanticVersion))
     }
 
     $InstalledSystemVersion = $null
     $GallerySystemVersion = $null
     if ([version]::TryParse($InstalledVersion, [ref]$InstalledSystemVersion) -and [version]::TryParse($GalleryVersion, [ref]$GallerySystemVersion)) {
-        return $InstalledSystemVersion.CompareTo($GallerySystemVersion)
+        return [Math]::Sign($InstalledSystemVersion.CompareTo($GallerySystemVersion))
     }
 
     "Cannot compare version '{0}' with version '{1}' because at least one of them is not a valid version." -f $InstalledVersion, $GalleryVersion | Write-Verbose

--- a/src/Lib/Functions/Private/Get-GalleryModuleVersion.ps1
+++ b/src/Lib/Functions/Private/Get-GalleryModuleVersion.ps1
@@ -1,4 +1,14 @@
-﻿function Get-GalleryModuleVersion {
+function Get-GalleryModuleVersion {
+    <#
+        .SYNOPSIS
+        Returns the highest stable version of a module that is published on the PowerShell Gallery.
+
+        .DESCRIPTION
+        FindPackagesById() returns every package of a module, prereleases included. Prereleases
+        are filtered out, because a nightly is never something the update check should push a
+        user towards. The remaining packages are ordered by their parsed version, not by their
+        publication date: a republished older package would otherwise come out as the latest one.
+    #>
     [CmdletBinding()]
     param(
         [string]$ModuleName
@@ -8,26 +18,63 @@
         $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
         $ApiEndpoint = "https://www.powershellgallery.com/api/v2/FindPackagesById()?id='{0}'" -f $ModuleName
         $Parameters = @{
-            Uri             = $ApiEndpoint
-            Method          = "Get"
-            Headers         = @{
+            Uri                      = $ApiEndpoint
+            Method                   = "Get"
+            Headers                  = @{
                 "Accept" = "application/xml"
             }
             ConnectionTimeoutSeconds = 1
         }
         $Response = Invoke-RestMethod @Parameters
-        $Response = $Response | Select-Object *,@{Name='Published';Expression={($_.Properties.Published.'#text') }}
 
-        if ($null -ne $Response) {
-            $LatestVersion = $Response | Sort-Object Published -Descending | Select-Object -First 1
-            return $LatestVersion.Properties.version
-        }
-        else {
+        if ($null -eq $Response) {
             return $null
         }
+
+        $StablePackages = @()
+        foreach ($Package in @($Response)) {
+            $VersionText = "{0}" -f $Package.Properties.version
+            if ([string]::IsNullOrWhiteSpace($VersionText)) {
+                continue
+            }
+
+            # The IsPrerelease property carries an m:type attribute, so Invoke-RestMethod hands
+            # it over as an XML element whose value lives in the '#text' child.
+            $IsPrereleaseText = "{0}" -f $Package.Properties.IsPrerelease.'#text'
+            if ([string]::IsNullOrWhiteSpace($IsPrereleaseText)) {
+                $IsPrereleaseText = "{0}" -f $Package.Properties.IsPrerelease
+            }
+
+            if ($IsPrereleaseText -eq "true") {
+                "Skipping prerelease package '{0}' of module '{1}'." -f $VersionText, $ModuleName | Write-Verbose
+                continue
+            }
+
+            # A prerelease label makes the version invalid for System.Version, which is exactly
+            # the value the caller must never receive. It also catches a prerelease that the feed
+            # forgot to flag, and any version string the gallery could not normalize.
+            $ParsedVersion = $null
+            if (-not [version]::TryParse($VersionText, [ref]$ParsedVersion)) {
+                "Skipping package '{0}' of module '{1}' because its version is not a stable version." -f $VersionText, $ModuleName | Write-Verbose
+                continue
+            }
+
+            $StablePackages += [PSCustomObject]@{
+                ParsedVersion = $ParsedVersion
+                VersionText   = $VersionText
+            }
+        }
+
+        if ($StablePackages.Count -eq 0) {
+            "No stable package of module '{0}' was found on the PowerShell Gallery." -f $ModuleName | Write-Verbose
+            return $null
+        }
+
+        $LatestPackage = $StablePackages | Sort-Object -Property ParsedVersion -Descending | Select-Object -First 1
+        return $LatestPackage.VersionText
     }
     catch {
+        "Could not read the published versions of module '{0}' from the PowerShell Gallery: {1}" -f $ModuleName, $_.Exception.Message | Write-Verbose
         return $null
     }
 }
-

--- a/src/Lib/Functions/Private/Get-GalleryModuleVersion.ps1
+++ b/src/Lib/Functions/Private/Get-GalleryModuleVersion.ps1
@@ -28,6 +28,7 @@ function Get-GalleryModuleVersion {
         $Response = Invoke-RestMethod @Parameters
 
         if ($null -eq $Response) {
+            "The PowerShell Gallery returned no packages for module '{0}'." -f $ModuleName | Write-Verbose
             return $null
         }
 

--- a/src/Lib/Functions/Private/Show-ModuleUpdateNotification.ps1
+++ b/src/Lib/Functions/Private/Show-ModuleUpdateNotification.ps1
@@ -1,0 +1,57 @@
+function Show-ModuleUpdateNotification {
+    <#
+        .SYNOPSIS
+        Warns the user when a newer stable release of the module is published on the PowerShell Gallery.
+
+        .DESCRIPTION
+        Runs at module import. Every reason to skip the check is reported as a single verbose
+        line: an empty catch used to hide the failure, which silently disabled the update
+        notification for as long as a nightly was the most recently published package.
+    #>
+    [CmdletBinding()]
+    param(
+        [string]$ModuleName
+    )
+
+    try {
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
+        $InstalledModule = Get-InstalledModuleInfo -ModuleName $ModuleName
+
+        if (-not $InstalledModule) {
+            "Could not determine the installed version of '{0}'. Skipping the version check." -f $ModuleName | Write-Verbose
+            return
+        }
+
+        if (-not $InstalledModule.RepositorySource -or $InstalledModule.RepositorySource -notlike "*powershellgallery.com*") {
+            "Module '{0}' was not sourced from the PowerShell Gallery. Skipping version check." -f $ModuleName | Write-Verbose
+            return
+        }
+
+        $GalleryVersion = Get-GalleryModuleVersion -ModuleName $ModuleName
+
+        if (-not $GalleryVersion) {
+            "Could not determine the latest published version of '{0}' on the PowerShell Gallery. Skipping the version check." -f $ModuleName | Write-Verbose
+            return
+        }
+
+        $VersionComparison = Compare-ModuleVersion -InstalledVersion $InstalledModule.Version -GalleryVersion $GalleryVersion
+
+        if ($null -eq $VersionComparison) {
+            "Could not compare the installed version '{0}' of '{1}' with the gallery version '{2}'. Skipping the version check." -f $($InstalledModule.Version), $ModuleName, $GalleryVersion | Write-Verbose
+            return
+        }
+
+        if ($VersionComparison -lt 0) {
+            "The installed version {0} of '{1}' is outdated. Latest version: {2}. Execute Update-Module {1} to update to the latest version!" -f $($InstalledModule.Version), $ModuleName, $GalleryVersion | Write-Warning
+        }
+        elseif ($VersionComparison -eq 0) {
+            "The installed version {0} of '{1}' is up-to-date." -f $($InstalledModule.Version), $ModuleName | Write-Verbose
+        }
+        else {
+            "The installed version {0} of '{1}' is newer than the gallery version {2}." -f $($InstalledModule.Version), $ModuleName, $GalleryVersion | Write-Warning
+        }
+    }
+    catch {
+        "The version check for '{0}' could not be completed: {1}" -f $ModuleName, $_.Exception.Message | Write-Verbose
+    }
+}

--- a/src/Lib/Functions/Private/Show-ModuleUpdateNotification.ps1
+++ b/src/Lib/Functions/Private/Show-ModuleUpdateNotification.ps1
@@ -4,9 +4,15 @@ function Show-ModuleUpdateNotification {
         Warns the user when a newer stable release of the module is published on the PowerShell Gallery.
 
         .DESCRIPTION
-        Runs at module import. Every reason to skip the check is reported as a single verbose
-        line: an empty catch used to hide the failure, which silently disabled the update
-        notification for as long as a nightly was the most recently published package.
+        Runs at module import. Every reason to skip the check is reported on the verbose
+        stream instead of being discarded: an empty catch used to hide the failure, which
+        silently disabled the update notification for as long as a nightly was the most
+        recently published package.
+
+        Verbose output from Get-GalleryModuleVersion and Compare-ModuleVersion is deliberately
+        left in place. Those functions know which package or which version string was rejected,
+        which is the detail that makes a skipped check diagnosable; this function only knows
+        that the step returned nothing usable.
     #>
     [CmdletBinding()]
     param(

--- a/src/OmadaSqlTroubleShooter.psm1
+++ b/src/OmadaSqlTroubleShooter.psm1
@@ -113,32 +113,7 @@ try {
     }
 
     "Validate version" | Write-Verbose
-    try {
-        $InstalledModule = Get-InstalledModuleInfo -ModuleName $ModuleName
-
-        if (-not $InstalledModule.RepositorySource -or $InstalledModule.RepositorySource -notlike "*powershellgallery.com*") {
-            "Module '{0}' was not sourced from the PowerShell Gallery. Skipping version check." -f $ModuleName | Write-Verbose
-        }
-        else {
-            $GalleryVersion = Get-GalleryModuleVersion -ModuleName $ModuleName
-
-            if (-not $GalleryVersion) {
-            }
-            else {
-                if ([version]$InstalledModule.Version -lt [version]$GalleryVersion) {
-                    "The installed version {0} of '{1}' is outdated. Latest version: {2}. Execute Update-Module {1} to update to the latest version!" -f ($($InstalledModule.Version)), $ModuleName, $GalleryVersion | Write-Warning
-                }
-                elseif ([version]$InstalledModule.Version -eq [version]$GalleryVersion) {
-                    "The installed version {0} of '{1}' is up-to-date." -f ($($InstalledModule.Version)) , $ModuleName | Write-Verbose
-                }
-                else {
-                    "The installed version {0} of '{1}' is newer than the gallery version {2}." -f ($($InstalledModule.Version)), $ModuleName, $GalleryVersion | Write-Warning
-                }
-            }
-        }
-
-    }
-    catch {}
+    Show-ModuleUpdateNotification -ModuleName $ModuleName
 
     #Check shortcuts
     Test-Shortcut

--- a/tests/Compare-ModuleVersion.Tests.ps1
+++ b/tests/Compare-ModuleVersion.Tests.ps1
@@ -1,0 +1,69 @@
+BeforeAll {
+    $ParentPath = Split-Path -Path $PSScriptRoot -Parent
+    $Command = Join-Path $ParentPath -ChildPath "src\lib\functions\Private\Compare-ModuleVersion.ps1"
+    . $Command
+    # The tracer preamble of the function under test redacts its bound parameters.
+    . (Join-Path $ParentPath -ChildPath "src\lib\functions\Private\ConvertTo-RedactedLogString.ps1")
+    $Script:Tracer = [System.Diagnostics.Trace]
+    $Script:RunTimeConfig = [PSCustomObject]@{ ApplicationName = "Test" }
+}
+
+Describe 'Compare-ModuleVersion' -Tag 'Unit' {
+    Context 'Stable versions' {
+        It 'Should return -1 when the installed version is older than the gallery version' {
+            Compare-ModuleVersion -InstalledVersion '2026.6.26.4' -GalleryVersion '2026.8.22.1' | Should -Be -1
+        }
+
+        It 'Should return 1 when the installed version is newer than the gallery version' {
+            Compare-ModuleVersion -InstalledVersion '2026.8.22.1' -GalleryVersion '2026.6.26.4' | Should -Be 1
+        }
+
+        It 'Should return 0 when both versions are equal' {
+            Compare-ModuleVersion -InstalledVersion '2026.6.26.4' -GalleryVersion '2026.6.26.4' | Should -Be 0
+        }
+
+        It 'Should compare a four part installed version with a three part gallery version' {
+            Compare-ModuleVersion -InstalledVersion '2026.6.26.4' -GalleryVersion '2026.8.22' | Should -Be -1
+        }
+    }
+
+    Context 'Prerelease versions' {
+        It 'Should rank a stable release above the prerelease that carries the same numbers' {
+            Compare-ModuleVersion -InstalledVersion '2026.8.22' -GalleryVersion '2026.8.22-nightly67' | Should -Be 1
+        }
+
+        It 'Should rank a prerelease below the stable release that carries the same numbers' {
+            Compare-ModuleVersion -InstalledVersion '2026.8.22-nightly67' -GalleryVersion '2026.8.22' | Should -Be -1
+        }
+
+        It 'Should compare two prereleases of the same version by their label' {
+            Compare-ModuleVersion -InstalledVersion '2026.8.22-nightly66' -GalleryVersion '2026.8.22-nightly67' | Should -Be -1
+        }
+
+        It 'Should not throw when a prerelease is compared with a four part version' {
+            { Compare-ModuleVersion -InstalledVersion '2026.6.26.4' -GalleryVersion '2026.8.22-nightly67' } | Should -Not -Throw
+        }
+    }
+
+    Context 'Unparsable input' {
+        It 'Should return $null instead of throwing when the gallery version cannot be parsed' {
+            Compare-ModuleVersion -InstalledVersion '2026.6.26.4' -GalleryVersion 'not-a-version' | Should -BeNullOrEmpty
+        }
+
+        It 'Should return $null instead of throwing when the installed version cannot be parsed' {
+            Compare-ModuleVersion -InstalledVersion 'not-a-version' -GalleryVersion '2026.6.26.4' | Should -BeNullOrEmpty
+        }
+
+        It 'Should return $null when a version is empty' {
+            Compare-ModuleVersion -InstalledVersion '' -GalleryVersion '2026.6.26.4' | Should -BeNullOrEmpty
+        }
+
+        It 'Should return $null when a version is $null' {
+            Compare-ModuleVersion -InstalledVersion $null -GalleryVersion $null | Should -BeNullOrEmpty
+        }
+
+        It 'Should never throw for an unparsable value' {
+            { Compare-ModuleVersion -InstalledVersion 'abc' -GalleryVersion 'def' } | Should -Not -Throw
+        }
+    }
+}

--- a/tests/Get-GalleryModuleVersion.Tests.ps1
+++ b/tests/Get-GalleryModuleVersion.Tests.ps1
@@ -6,28 +6,100 @@ BeforeAll {
     . (Join-Path $ParentPath -ChildPath "src\lib\functions\Private\ConvertTo-RedactedLogString.ps1")
     $Script:Tracer = [System.Diagnostics.Trace]
     $Script:RunTimeConfig = [PSCustomObject]@{ ApplicationName = "Test" }
+
+    # Mirrors the shape of a single OData entry returned by FindPackagesById(): every
+    # property that carries an m:type attribute arrives as an XML element with a '#text'
+    # child, while the plain version string arrives as a bare string.
+    function New-GalleryPackageEntry {
+        param(
+            [string]$Version,
+            [string]$IsPrerelease = 'false',
+            [datetime]$Published = (Get-Date)
+        )
+
+        return [PSCustomObject]@{
+            Properties = [PSCustomObject]@{
+                version      = $Version
+                IsPrerelease = [PSCustomObject]@{ '#text' = $IsPrerelease }
+                Published    = [PSCustomObject]@{ '#text' = $Published }
+            }
+        }
+    }
 }
 
 Describe 'Get-GalleryModuleVersion' -Tag 'Unit' {
-    It 'Should return the version of the most recently updated package' {
+    It 'Should return the highest stable version' {
         Mock Invoke-RestMethod {
             @(
-                [PSCustomObject]@{
-                    Properties = [PSCustomObject]@{
-                        version   = '1.0.0'
-                        Published = [PSCustomObject]@{ '#text' = (Get-Date).AddDays(-5) }
-                    }
-                }
-                [PSCustomObject]@{
-                    Properties = [PSCustomObject]@{
-                        version   = '2.0.0'
-                        Published = [PSCustomObject]@{ '#text' = (Get-Date) }
-                    }
-                }
+                New-GalleryPackageEntry -Version '1.0.0' -Published (Get-Date).AddDays(-5)
+                New-GalleryPackageEntry -Version '2.0.0' -Published (Get-Date)
             )
         }
 
         Get-GalleryModuleVersion -ModuleName 'OmadaWeb.PS' | Should -Be '2.0.0'
+    }
+
+    It 'Should ignore a prerelease that is the most recently published package' {
+        Mock Invoke-RestMethod {
+            @(
+                New-GalleryPackageEntry -Version '2026.6.26.4' -Published (Get-Date).AddDays(-30)
+                New-GalleryPackageEntry -Version '2026.8.22-nightly67' -IsPrerelease 'true' -Published (Get-Date)
+            )
+        }
+
+        Get-GalleryModuleVersion -ModuleName 'OmadaSqlTroubleShooter' | Should -Be '2026.6.26.4'
+    }
+
+    It 'Should ignore a prerelease even when the feed does not flag it as one' {
+        Mock Invoke-RestMethod {
+            @(
+                New-GalleryPackageEntry -Version '2026.6.26.4' -Published (Get-Date).AddDays(-30)
+                New-GalleryPackageEntry -Version '2026.8.22-nightly67' -IsPrerelease 'false' -Published (Get-Date)
+            )
+        }
+
+        Get-GalleryModuleVersion -ModuleName 'OmadaSqlTroubleShooter' | Should -Be '2026.6.26.4'
+    }
+
+    It 'Should return the highest version rather than the most recently published version' {
+        Mock Invoke-RestMethod {
+            @(
+                New-GalleryPackageEntry -Version '2026.8.22.1' -Published (Get-Date).AddDays(-10)
+                New-GalleryPackageEntry -Version '2026.6.26.4' -Published (Get-Date)
+            )
+        }
+
+        Get-GalleryModuleVersion -ModuleName 'OmadaSqlTroubleShooter' | Should -Be '2026.8.22.1'
+    }
+
+    It 'Should return $null when the feed contains only prereleases' {
+        Mock Invoke-RestMethod {
+            @(
+                New-GalleryPackageEntry -Version '2026.8.18-nightly62' -IsPrerelease 'true' -Published (Get-Date).AddDays(-4)
+                New-GalleryPackageEntry -Version '2026.8.22-nightly67' -IsPrerelease 'true' -Published (Get-Date)
+            )
+        }
+
+        Get-GalleryModuleVersion -ModuleName 'OmadaSqlTroubleShooter' | Should -BeNullOrEmpty
+    }
+
+    It 'Should skip an entry whose version cannot be parsed' {
+        Mock Invoke-RestMethod {
+            @(
+                New-GalleryPackageEntry -Version '2026.6.26.4' -Published (Get-Date).AddDays(-30)
+                New-GalleryPackageEntry -Version 'not-a-version' -Published (Get-Date)
+            )
+        }
+
+        Get-GalleryModuleVersion -ModuleName 'OmadaSqlTroubleShooter' | Should -Be '2026.6.26.4'
+    }
+
+    It 'Should return a single stable version when the feed holds only one package' {
+        Mock Invoke-RestMethod {
+            New-GalleryPackageEntry -Version '2026.6.26.4' -Published (Get-Date)
+        }
+
+        Get-GalleryModuleVersion -ModuleName 'OmadaSqlTroubleShooter' | Should -Be '2026.6.26.4'
     }
 
     It 'Should return $null when the gallery response is empty' {
@@ -52,4 +124,3 @@ Describe 'Get-GalleryModuleVersion' -Tag 'Unit' {
         }
     }
 }
-

--- a/tests/Get-GalleryModuleVersion.Tests.ps1
+++ b/tests/Get-GalleryModuleVersion.Tests.ps1
@@ -36,7 +36,7 @@ Describe 'Get-GalleryModuleVersion' -Tag 'Unit' {
             )
         }
 
-        Get-GalleryModuleVersion -ModuleName 'OmadaWeb.PS' | Should -Be '2.0.0'
+        Get-GalleryModuleVersion -ModuleName 'OmadaSqlTroubleShooter' | Should -Be '2.0.0'
     }
 
     It 'Should ignore a prerelease that is the most recently published package' {
@@ -105,22 +105,30 @@ Describe 'Get-GalleryModuleVersion' -Tag 'Unit' {
     It 'Should return $null when the gallery response is empty' {
         Mock Invoke-RestMethod { $null }
 
-        Get-GalleryModuleVersion -ModuleName 'OmadaWeb.PS' | Should -BeNullOrEmpty
+        Get-GalleryModuleVersion -ModuleName 'OmadaSqlTroubleShooter' | Should -BeNullOrEmpty
+    }
+
+    It 'Should log a verbose line when the gallery response is empty' {
+        Mock Invoke-RestMethod { $null }
+
+        $Verbose = Get-GalleryModuleVersion -ModuleName 'OmadaSqlTroubleShooter' -Verbose 4>&1
+
+        "$Verbose" | Should -BeLike '*returned no packages*'
     }
 
     It 'Should return $null when the request fails' {
         Mock Invoke-RestMethod { throw 'network error' }
 
-        Get-GalleryModuleVersion -ModuleName 'OmadaWeb.PS' | Should -BeNullOrEmpty
+        Get-GalleryModuleVersion -ModuleName 'OmadaSqlTroubleShooter' | Should -BeNullOrEmpty
     }
 
     It 'Should request the correct PowerShell Gallery API endpoint' {
         Mock Invoke-RestMethod { $null }
 
-        Get-GalleryModuleVersion -ModuleName 'OmadaWeb.PS' | Out-Null
+        Get-GalleryModuleVersion -ModuleName 'OmadaSqlTroubleShooter' | Out-Null
 
         Should -Invoke Invoke-RestMethod -ParameterFilter {
-            $Uri -eq "https://www.powershellgallery.com/api/v2/FindPackagesById()?id='OmadaWeb.PS'"
+            $Uri -eq "https://www.powershellgallery.com/api/v2/FindPackagesById()?id='OmadaSqlTroubleShooter'"
         }
     }
 }

--- a/tests/Get-GalleryModuleVersion.Tests.ps1
+++ b/tests/Get-GalleryModuleVersion.Tests.ps1
@@ -50,6 +50,17 @@ Describe 'Get-GalleryModuleVersion' -Tag 'Unit' {
         Get-GalleryModuleVersion -ModuleName 'OmadaSqlTroubleShooter' | Should -Be '2026.6.26.4'
     }
 
+    It 'Should ignore a prerelease whose flag is not lower case' {
+        Mock Invoke-RestMethod {
+            @(
+                New-GalleryPackageEntry -Version '2026.6.26.4' -Published (Get-Date).AddDays(-30)
+                New-GalleryPackageEntry -Version '2026.8.22' -IsPrerelease 'True' -Published (Get-Date)
+            )
+        }
+
+        Get-GalleryModuleVersion -ModuleName 'OmadaSqlTroubleShooter' | Should -Be '2026.6.26.4'
+    }
+
     It 'Should ignore a prerelease even when the feed does not flag it as one' {
         Mock Invoke-RestMethod {
             @(

--- a/tests/Show-ModuleUpdateNotification.Tests.ps1
+++ b/tests/Show-ModuleUpdateNotification.Tests.ps1
@@ -1,0 +1,139 @@
+BeforeAll {
+    $ParentPath = Split-Path -Path $PSScriptRoot -Parent
+    $PrivatePath = Join-Path $ParentPath -ChildPath "src\lib\functions\Private"
+    . (Join-Path $PrivatePath -ChildPath "Show-ModuleUpdateNotification.ps1")
+    . (Join-Path $PrivatePath -ChildPath "Get-GalleryModuleVersion.ps1")
+    . (Join-Path $PrivatePath -ChildPath "Compare-ModuleVersion.ps1")
+    # Dot-sourced so that Pester has a real command to mock.
+    . (Join-Path $PrivatePath -ChildPath "Get-InstalledModuleInfo.ps1")
+    # The tracer preamble of the functions under test redacts their bound parameters.
+    . (Join-Path $PrivatePath -ChildPath "ConvertTo-RedactedLogString.ps1")
+    $Script:Tracer = [System.Diagnostics.Trace]
+    $Script:RunTimeConfig = [PSCustomObject]@{ ApplicationName = "Test" }
+
+    # Mirrors the shape of a single OData entry returned by FindPackagesById().
+    function New-GalleryPackageEntry {
+        param(
+            [string]$Version,
+            [string]$IsPrerelease = 'false',
+            [datetime]$Published = (Get-Date)
+        )
+
+        return [PSCustomObject]@{
+            Properties = [PSCustomObject]@{
+                version      = $Version
+                IsPrerelease = [PSCustomObject]@{ '#text' = $IsPrerelease }
+                Published    = [PSCustomObject]@{ '#text' = $Published }
+            }
+        }
+    }
+}
+
+Describe 'Show-ModuleUpdateNotification' -Tag 'Unit' {
+    BeforeEach {
+        Mock Get-InstalledModuleInfo {
+            @{
+                Name             = 'OmadaSqlTroubleShooter'
+                Version          = '2026.6.26.4'
+                RepositorySource = 'https://www.powershellgallery.com/api/v2'
+            }
+        }
+    }
+
+    It 'Should warn that the module is outdated when the newest published package is a prerelease' {
+        Mock Invoke-RestMethod {
+            @(
+                New-GalleryPackageEntry -Version '2026.8.22.1' -Published (Get-Date).AddDays(-30)
+                New-GalleryPackageEntry -Version '2026.8.22-nightly67' -IsPrerelease 'true' -Published (Get-Date)
+            )
+        }
+
+        $Warnings = Show-ModuleUpdateNotification -ModuleName 'OmadaSqlTroubleShooter' 3>&1
+
+        $Warnings | Should -Not -BeNullOrEmpty
+        "$Warnings" | Should -BeLike '*is outdated*2026.8.22.1*'
+    }
+
+    It 'Should not throw when the newest published package is a prerelease' {
+        Mock Invoke-RestMethod {
+            @(
+                New-GalleryPackageEntry -Version '2026.8.22.1' -Published (Get-Date).AddDays(-30)
+                New-GalleryPackageEntry -Version '2026.8.22-nightly67' -IsPrerelease 'true' -Published (Get-Date)
+            )
+        }
+
+        { Show-ModuleUpdateNotification -ModuleName 'OmadaSqlTroubleShooter' -WarningAction SilentlyContinue } | Should -Not -Throw
+    }
+
+    It 'Should not warn when the installed version matches the highest stable version' {
+        Mock Invoke-RestMethod {
+            New-GalleryPackageEntry -Version '2026.6.26.4' -Published (Get-Date)
+        }
+
+        $Warnings = Show-ModuleUpdateNotification -ModuleName 'OmadaSqlTroubleShooter' 3>&1
+
+        $Warnings | Should -BeNullOrEmpty
+    }
+
+    It 'Should warn when the installed version is newer than the highest stable version' {
+        Mock Invoke-RestMethod {
+            New-GalleryPackageEntry -Version '2025.1.10.1' -Published (Get-Date)
+        }
+
+        $Warnings = Show-ModuleUpdateNotification -ModuleName 'OmadaSqlTroubleShooter' 3>&1
+
+        "$Warnings" | Should -BeLike '*is newer than the gallery version*'
+    }
+
+    It 'Should skip the check when the module was not installed from the PowerShell Gallery' {
+        Mock Get-InstalledModuleInfo {
+            @{
+                Name             = 'OmadaSqlTroubleShooter'
+                Version          = '2026.6.26.4'
+                RepositorySource = $null
+            }
+        }
+        Mock Invoke-RestMethod { throw 'the gallery must not be queried' }
+
+        $Verbose = Show-ModuleUpdateNotification -ModuleName 'OmadaSqlTroubleShooter' -Verbose 4>&1
+
+        "$Verbose" | Should -BeLike '*not sourced from the PowerShell Gallery*'
+        Should -Invoke Invoke-RestMethod -Times 0
+    }
+
+    It 'Should log a single verbose line when the gallery version cannot be determined' {
+        Mock Invoke-RestMethod { throw 'network error' }
+
+        $Warnings = Show-ModuleUpdateNotification -ModuleName 'OmadaSqlTroubleShooter' 3>&1
+        $Verbose = Show-ModuleUpdateNotification -ModuleName 'OmadaSqlTroubleShooter' -Verbose 4>&1
+
+        $Warnings | Should -BeNullOrEmpty
+        "$Verbose" | Should -BeLike '*Could not determine the latest published version*'
+    }
+
+    It 'Should log a verbose line and not warn when the versions cannot be compared' {
+        Mock Get-InstalledModuleInfo {
+            @{
+                Name             = 'OmadaSqlTroubleShooter'
+                Version          = 'not-a-version'
+                RepositorySource = 'https://www.powershellgallery.com/api/v2'
+            }
+        }
+        Mock Invoke-RestMethod {
+            New-GalleryPackageEntry -Version '2026.6.26.4' -Published (Get-Date)
+        }
+
+        $Warnings = Show-ModuleUpdateNotification -ModuleName 'OmadaSqlTroubleShooter' 3>&1
+        $Verbose = Show-ModuleUpdateNotification -ModuleName 'OmadaSqlTroubleShooter' -Verbose 4>&1
+
+        $Warnings | Should -BeNullOrEmpty
+        "$Verbose" | Should -BeLike '*Could not compare the installed version*'
+    }
+
+    It 'Should not throw when the installed module cannot be determined' {
+        Mock Get-InstalledModuleInfo { $null }
+        Mock Invoke-RestMethod { throw 'the gallery must not be queried' }
+
+        { Show-ModuleUpdateNotification -ModuleName 'OmadaSqlTroubleShooter' } | Should -Not -Throw
+    }
+}


### PR DESCRIPTION
Closes #66

## What broke

The startup update check silently stopped working as soon as a nightly became the most recently published package on the PowerShell Gallery.

- `src/Lib/Functions/Private/Get-GalleryModuleVersion.ps1:22` (before this PR) picked the newest package with `Sort-Object Published -Descending`. `FindPackagesById()` returns prereleases too, so it happily returned `2026.8.22-nightly67`. Sorting on `Published` was wrong on its own as well: a republished older package would come out as "latest". The live feed for this module currently holds 31 packages, the eight most recent of which are nightlies, and several stable entries carry a `Published` date of `1900-01-01`.
- `src/OmadaSqlTroubleShooter.psm1:128` (before this PR; the issue quotes line 115 from the *installed* 2026.8.22 package) then did `if ([version]$InstalledModule.Version -lt [version]$GalleryVersion)`. `System.Version` cannot parse a SemVer prerelease suffix, so the cast threw a `PSInvalidCastException`.
- `src/OmadaSqlTroubleShooter.psm1:141` (before this PR) was an empty `catch {}`. It discarded the exception together with the rest of the `else` block, including the "outdated" warning. There was also an empty `if (-not $GalleryVersion) { }` branch. Net effect: no error, no warning, and the only trace was a stray record in `$Error`.

## What changed

**`src/Lib/Functions/Private/Get-GalleryModuleVersion.ps1`** — returns the highest **stable** version.

- Skips any package the feed flags with `IsPrerelease` (`true`), read from the `'#text'` child of the XML element, matching how the existing code already reads `Published`.
- Also skips any remaining version that `[version]::TryParse` rejects, which catches a prerelease the feed forgot to flag and any version string the gallery could not normalise.
- Sorts the survivors on the **parsed** version, not on `Published`.
- Logs a verbose line when there is no usable package, and when the request fails, instead of returning `$null` in silence.

**`src/Lib/Functions/Private/Compare-ModuleVersion.ps1`** (new) — the comparison helper.

- Parses both values with `[System.Management.Automation.SemanticVersion]::TryParse`, so a prerelease sorts below the stable release with the same numbers.
- Falls back to `[version]::TryParse` for the four-part versions this module actually publishes (`2026.6.26.4` is not valid SemVer).
- Returns `-1` / `0` / `1`, or `$null` when either value is unparsable. No cast anywhere, so it cannot throw.

**`src/Lib/Functions/Private/Show-ModuleUpdateNotification.ps1`** (new) — the version-check block, moved out of the psm1.

- Same three user-facing messages as before (outdated warning, up-to-date verbose, newer-than-gallery warning).
- Every reason to skip is now one verbose line: no installed module, not sourced from the gallery, no gallery version, versions not comparable.
- The remaining `catch` logs `$_.Exception.Message` instead of discarding it.

**`src/OmadaSqlTroubleShooter.psm1`** — the 27-line inline block plus its empty `catch {}` is replaced by `Show-ModuleUpdateNotification -ModuleName $ModuleName`.

## Acceptance criteria

The "Regression test (TDD)" list from the issue:

- [x] `Get-GalleryModuleVersion` returns the highest **stable** version when the feed contains a newer prerelease — `tests/Get-GalleryModuleVersion.Tests.ps1`, `Should ignore a prerelease that is the most recently published package` (plus `Should ignore a prerelease even when the feed does not flag it as one` and `Should return $null when the feed contains only prereleases`).
- [x] It returns the highest version, not the most recently published, when an older version is republished — `tests/Get-GalleryModuleVersion.Tests.ps1`, `Should return the highest version rather than the most recently published version`.
- [x] The comparison helper handles stable vs stable — `tests/Compare-ModuleVersion.Tests.ps1`, context `Stable versions` (4 tests).
- [x] … stable vs prerelease — same file, context `Prerelease versions` (4 tests).
- [x] … equal versions — same file, `Should return 0 when both versions are equal`.
- [x] … an unparsable value, skipped without throwing — same file, context `Unparsable input` (5 tests).
- [x] End to end: with a prerelease as the newest feed entry and an older installed version, the "outdated" warning is still emitted — `tests/Show-ModuleUpdateNotification.Tests.ps1`, `Should warn that the module is outdated when the newest published package is a prerelease`.
- [x] A skipped check is a single VERBOSE line, not a swallowed exception — `tests/Show-ModuleUpdateNotification.Tests.ps1`, `Should log a single verbose line when the gallery version cannot be determined` and `Should log a verbose line and not warn when the versions cannot be compared`.

## Decisions worth reviewing

1. **No `-AllowPrerelease` switch.** The issue suggested an opt-in switch. Nothing in the module wants to be told about a nightly at import time, and an unused parameter is a rule violation waiting to happen, so the function is stable-only. Easy to add later if a caller ever appears.
2. **The version check moved into its own private function.** The alternative was to fix the comparison in place in the psm1. The psm1 body cannot be exercised in a headless test — it installs the WebView2 runtime — so the end-to-end criterion from the issue could not have been covered without this seam. Behaviour and message text are unchanged.
3. **Two-tier parsing rather than SemanticVersion alone.** `[SemanticVersion]::TryParse('2026.6.26.4', …)` returns `$false`, and its `[version]` constructor rejects a four-part version outright. Since this module publishes four-part stable versions, SemVer-only would have made the helper return `$null` for every real comparison. Both values are therefore parsed as SemVer first, then both as `System.Version`. A mixed pair (four-part installed, prerelease gallery) parses under neither tier and is skipped with a verbose line — acceptable, because `Get-GalleryModuleVersion` no longer hands out prereleases.
4. **Sorting on `[version]`, not on `SemanticVersion`.** Legitimate after the prerelease filter: everything left is a stable version, and `[version]` is the only type that handles the four-part form this module uses.
5. **Prereleases are filtered twice** — the explicit `IsPrerelease` flag *and* the parse check. Belt and braces: the live feed does set the flag, but a version such as `2026.703.12-nightly` must not slip through if the flag is ever absent or the feed shape changes.
6. **Missing/unknown `IsPrerelease` is treated as "not a prerelease".** Only the literal string `true` excludes a package, so a feed-shape change cannot silently drop every package and disable the check all over again. The parse check is the second line of defence.
7. **`Show-` verb.** The function writes to the warning and verbose streams, not to a UI. `Show-` is an approved verb and reads correctly for "surface a notification"; `Test-` would have implied a boolean return.
8. **`ConnectionTimeoutSeconds = 1` was left alone.** Out of scope for this issue, but worth flagging: one second is tight for a cold gallery call, and a timeout is now a verbose line rather than nothing at all.

## Verification

```
pwsh -NoProfile -File build/build.ps1 -Task TestBuildOnly
```

- Baseline on unmodified `origin/main` (`88bd47b`): **313 passed, 0 failed, 0 skipped**.
- This branch (head `bddf867`, after the review round): **342 passed, 0 failed, 0 skipped** (+29: 13 new in `Compare-ModuleVersion.Tests.ps1`, 8 in `Show-ModuleUpdateNotification.Tests.ps1`, 8 added to `Get-GalleryModuleVersion.Tests.ps1`).
- psake `TestBuildOnly` — `VerifyDependencyLock`, `Analyze`, `Test`, `Build` — all green; PSScriptAnalyzer reports nothing on the four changed/added source files under the repository's own profile.
- The three new test files were committed first and confirmed red (5 passed, 26 failed) before the implementation landed — see `d5032a1`.

## Related

`Fortigi/OmadaWeb.PS#75` is the twin of this bug in the sibling repository: the same `Sort-Object Published -Descending`, the same cast to `[System.Version]` and the same empty `catch {}`. It was filed as the open twin of this issue and closed as completed on 2026-09-01, while this PR was being prepared — the two fixes should mirror each other, and this one is the shape proposed here. Worth a cross-check that the sibling fix filters on `IsPrerelease`, sorts on the parsed version, and logs the skip reason in the same way, so the two modules do not drift.


