### PR TITLE
Persist the log level chosen in the log viewer across restarts

### DIFF
--- a/src/Lib/Events/LogForm.Elements.ComboBoxSelectLogLevel.ps1
+++ b/src/Lib/Events/LogForm.Elements.ComboBoxSelectLogLevel.ps1
@@ -1,6 +1,15 @@
 $Script:LogForm.Elements.ComboBoxSelectLogLevel.Add_SelectionChanged({
         $_ | Show-EventInfo
+        # The combo box starts with no selection, so Open-LogForm can apply the stored level after
+        # this handler is wired without a preselected item storing a level nobody chose.
+        if ($null -eq $Script:LogForm.Elements.ComboBoxSelectLogLevel.SelectedItem) {
+            return
+        }
+
         $Script:LogForm.Elements.ComboBoxSelectLogLevel.SelectedItem.Content | Set-ConfigProperty -Property "LogLevel"
         $Script:RunTimeConfig.Logging.LogLevelSetting = $Script:LogForm.Elements.ComboBoxSelectLogLevel.SelectedItem.Content
+        # Keep the value Open-LogForm reads in step, so reopening the log viewer in the same session
+        # shows the level that is actually in effect.
+        $Script:RunTimeConfig.Logging.LogLevel = $Script:LogForm.Elements.ComboBoxSelectLogLevel.SelectedItem.Content
         "Logging set to {0}!" -f $Script:RunTimeConfig.Logging.LogLevelSetting | Write-LogOutput -LogType LOG
     })

--- a/src/Lib/Functions/Private/Get-ConfigSchemaDefault.ps1
+++ b/src/Lib/Functions/Private/Get-ConfigSchemaDefault.ps1
@@ -1,0 +1,51 @@
+function Get-ConfigSchemaDefault {
+    <#
+    .SYNOPSIS
+    Returns the default value declared for a property in the global configuration schema.
+
+    .DESCRIPTION
+    The schema is the single source of truth for a configuration default. Reading it here keeps
+    defaults out of the code, so a value such as the log level default is declared in exactly one
+    place instead of being repeated as a literal in every code path that needs a fallback.
+
+    .PARAMETER Property
+    The name of the global configuration property whose default is wanted.
+
+    .PARAMETER SchemaPath
+    An alternative schema file to read. Intended for tests; when omitted the module's own global
+    configuration schema is used and cached for the rest of the session.
+    #>
+    [CmdLetBinding()]
+    param(
+        [Parameter(Mandatory = $true, Position = 0)]
+        [string]$Property,
+        [Parameter(Mandatory = $false)]
+        [string]$SchemaPath
+    )
+
+    try {
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
+
+        if (![string]::IsNullOrWhiteSpace($SchemaPath)) {
+            $SchemaProperties = Get-Content $SchemaPath -Raw | ConvertFrom-Json
+        }
+        else {
+            # Reuses the cache Set-ConfigProperty fills, so the schema is read from disk once.
+            if ($null -eq $Script:GlobalConfigProperties) {
+                $Script:GlobalConfigProperties = Get-Content (Join-Path (Get-ModuleBaseFolder) -ChildPath "lib\schema\appGlobalConfigSchema.json") -Raw | ConvertFrom-Json
+            }
+            $SchemaProperties = $Script:GlobalConfigProperties
+        }
+
+        $PropertyDefinition = $SchemaProperties | Where-Object { $_.Name -eq $Property } | Select-Object -First 1
+        if ($null -eq $PropertyDefinition) {
+            "Property '{0}' was not found in the global config schema!" -f $Property | Write-LogOutput -LogType WARNING -SkipDialog
+            return $null
+        }
+
+        return $PropertyDefinition.DefaultValue
+    }
+    catch {
+        $_.Exception.Message | Write-LogOutput -LogType ERROR -ErrorObject $_
+    }
+}

--- a/src/Lib/Functions/Private/Initialize-GlobalConfigSettings.ps1
+++ b/src/Lib/Functions/Private/Initialize-GlobalConfigSettings.ps1
@@ -40,7 +40,10 @@ function Initialize-GlobalConfigSettings {
         "Config: LogLevelSetting: {0}" -f $ResolvedLogLevel | Write-LogOutput -LogType DEBUG
 
         # Write back only when the caller asked for a specific level, when nothing is stored yet, or
-        # when the stored value is unusable. Anything else would overwrite the user's own choice.
+        # when the stored value differs from the resolved one - which covers both an unusable value
+        # and a usable but unnormalized one such as " debug ", rewritten once as "DEBUG" and stable
+        # from then on. A stored value that already matches is never rewritten, so the user's own
+        # choice survives every later start.
         if ($Script:RunTimeConfig.Logging.LogLevelExplicit -or [string]::IsNullOrWhiteSpace($PersistedLogLevel) -or $PersistedLogLevel -ne $ResolvedLogLevel) {
             "Config: Persisting LogLevel: {0}" -f $ResolvedLogLevel | Write-LogOutput -LogType DEBUG
             $ResolvedLogLevel | Set-ConfigProperty -Property "LogLevel"

--- a/src/Lib/Functions/Private/Initialize-GlobalConfigSettings.ps1
+++ b/src/Lib/Functions/Private/Initialize-GlobalConfigSettings.ps1
@@ -24,10 +24,26 @@ function Initialize-GlobalConfigSettings {
             $Script:MainForm.Definition.WindowStartupLocation = [System.Windows.WindowStartupLocation]::CenterScreen
         }
 
-        if ($null -ne $Script:RunTimeConfig.Logging.LogLevelSetting) {
-            $Script:RunTimeConfig.Logging.LogLevelSetting | Set-ConfigProperty -Property "LogLevel"
-            $Script:RunTimeConfig.Logging.LogLevel = $Script:RunTimeConfig.Logging.LogLevelSetting
-            "Config: LogLevelSetting: {0}" -f $Script:RunTimeConfig.Logging.LogLevelSetting | Write-LogOutput -LogType DEBUG
+        # The level a user picks in the log viewer is stored in the global config, so it has to be
+        # read back here - the previous code pushed the runtime value INTO the config on every
+        # start and overwrote it. An explicitly bound -LogLevel still wins for this session; with
+        # no parameter the persisted level is restored; with neither, the schema default applies.
+        $PersistedLogLevel = $Script:AppGlobalConfig.LogLevel
+        $BoundLogLevel = $null
+        if ($Script:RunTimeConfig.Logging.LogLevelExplicit) {
+            $BoundLogLevel = $Script:RunTimeConfig.Logging.LogLevelSetting
+        }
+
+        $ResolvedLogLevel = Resolve-LogLevel -BoundLogLevel $BoundLogLevel -PersistedLogLevel $PersistedLogLevel -SchemaDefault (Get-ConfigSchemaDefault -Property "LogLevel")
+        $Script:RunTimeConfig.Logging.LogLevel = $ResolvedLogLevel
+        $Script:RunTimeConfig.Logging.LogLevelSetting = $ResolvedLogLevel
+        "Config: LogLevelSetting: {0}" -f $ResolvedLogLevel | Write-LogOutput -LogType DEBUG
+
+        # Write back only when the caller asked for a specific level, when nothing is stored yet, or
+        # when the stored value is unusable. Anything else would overwrite the user's own choice.
+        if ($Script:RunTimeConfig.Logging.LogLevelExplicit -or [string]::IsNullOrWhiteSpace($PersistedLogLevel) -or $PersistedLogLevel -ne $ResolvedLogLevel) {
+            "Config: Persisting LogLevel: {0}" -f $ResolvedLogLevel | Write-LogOutput -LogType DEBUG
+            $ResolvedLogLevel | Set-ConfigProperty -Property "LogLevel"
         }
 
         if (![string]::IsNullOrWhiteSpace($Script:AppGlobalConfig.InstanceGuid)) {

--- a/src/Lib/Functions/Private/Open-LogForm.ps1
+++ b/src/Lib/Functions/Private/Open-LogForm.ps1
@@ -47,13 +47,16 @@ function Open-LogForm {
             $Script:RunTimeConfig.Logging.LogLevelSetting = $Script:RunTimeConfig.Logging.LogLevel
         }
         else {
-            "Set form log level to default because it was not set: INFO" | Write-LogOutput -LogType DEBUG
-            if (($LogForm.Elements.ComboBoxSelectLogLevel.Items | Measure-Object).count -le 0 -and !$LogForm.Elements.ComboBoxSelectLogLevel.Items.Content.Contains("INFO")) {
+            # The schema is the single source of truth for this default; it used to be a third,
+            # separate literal here.
+            $DefaultLogLevel = Get-ConfigSchemaDefault -Property "LogLevel"
+            "Set form log level to the schema default because it was not set: {0}" -f $DefaultLogLevel | Write-LogOutput -LogType DEBUG
+            if (($LogForm.Elements.ComboBoxSelectLogLevel.Items | Measure-Object).count -le 0 -and !$LogForm.Elements.ComboBoxSelectLogLevel.Items.Content.Contains($DefaultLogLevel)) {
                 $ComboBoxSelectLogLevelItem = New-Object System.Windows.Controls.ComboBoxItem
-                $ComboBoxSelectLogLevelItem.Content = "INFO"
+                $ComboBoxSelectLogLevelItem.Content = $DefaultLogLevel
                 $LogForm.Elements.ComboBoxSelectLogLevel.Items.Add($ComboBoxSelectLogLevelItem) | Out-Null
             }
-            $LogForm.Elements.ComboBoxSelectLogLevel.SelectedValue = $LogForm.Elements.ComboBoxSelectLogLevel.Items | Where-Object { $_.Content -eq "INFO" }
+            $LogForm.Elements.ComboBoxSelectLogLevel.SelectedValue = $LogForm.Elements.ComboBoxSelectLogLevel.Items | Where-Object { $_.Content -eq $DefaultLogLevel }
             $Script:RunTimeConfig.Logging.LogLevelSetting = $LogForm.Elements.ComboBoxSelectLogLevel.SelectedValue.Content
         }
 

--- a/src/Lib/Functions/Private/Resolve-LogLevel.ps1
+++ b/src/Lib/Functions/Private/Resolve-LogLevel.ps1
@@ -1,0 +1,62 @@
+function Resolve-LogLevel {
+    <#
+    .SYNOPSIS
+    Resolves the log level that a session should run with, from the three candidates that can supply one.
+
+    .DESCRIPTION
+    Precedence is: an explicitly bound -LogLevel parameter, then the level persisted in the global
+    configuration by the log viewer, then the default declared in the global configuration schema.
+    A candidate that is empty, or that names a level the application does not know, is skipped
+    rather than rejected, so a hand-edited or stale configuration file degrades to the default
+    instead of failing the start-up path.
+
+    .PARAMETER BoundLogLevel
+    The value of the -LogLevel parameter, but only when the caller actually bound it.
+
+    .PARAMETER PersistedLogLevel
+    The level stored in the global configuration file by an earlier session.
+
+    .PARAMETER SchemaDefault
+    The default declared for LogLevel in the global configuration schema.
+    #>
+    [CmdLetBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [string]$BoundLogLevel,
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [string]$PersistedLogLevel,
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [string]$SchemaDefault
+    )
+
+    try {
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
+
+        # The levels the log viewer offers and Write-LogOutput understands. LOG is included because
+        # the log viewer lets a user select it, so it is a legitimate persisted value.
+        $KnownLogLevel = @("LOG", "INFO", "WARNING", "ERROR", "FATAL", "DEBUG", "VERBOSE", "VERBOSE2")
+
+        foreach ($Candidate in @($BoundLogLevel, $PersistedLogLevel, $SchemaDefault)) {
+            if ([string]::IsNullOrWhiteSpace($Candidate)) {
+                continue
+            }
+
+            $NormalizedCandidate = $Candidate.Trim().ToUpperInvariant()
+            if ($KnownLogLevel -contains $NormalizedCandidate) {
+                return $NormalizedCandidate
+            }
+        }
+
+        return $null
+    }
+    catch {
+        $_.Exception.Message | Write-LogOutput -LogType ERROR -ErrorObject $_
+    }
+}

--- a/src/Lib/Functions/Public/Invoke-OmadaSqlTroubleshooter.ps1
+++ b/src/Lib/Functions/Public/Invoke-OmadaSqlTroubleshooter.ps1
@@ -70,7 +70,11 @@ function Invoke-OmadaSqlTroubleshooter {
             LogToConsole        = $LogToConsole.IsPresent -or $false
             LogLevel            = $null
             VerboseParameterSet = $PSCmdlet.MyInvocation.BoundParameters.Keys.Contains("Verbose")
-            LogLevelSetting     = $(if ([string]::IsNullOrWhiteSpace($LogLevel)) { "WARNING" } else { $LogLevel })
+            # Only a bound -LogLevel is authoritative. Leaving this flag unset lets
+            # Initialize-GlobalConfigSettings restore the level a previous session stored, instead
+            # of overwriting it with a value the caller never asked for.
+            LogLevelExplicit    = $PSCmdlet.MyInvocation.BoundParameters.ContainsKey("LogLevel")
+            LogLevelSetting     = $null
             AppLogObject        = [System.Collections.ObjectModel.ObservableCollection[string]]::new()
         }
         StopWatch          = $null
@@ -88,6 +92,12 @@ function Invoke-OmadaSqlTroubleshooter {
         ResetRequested     = $Reset.IsPresent -or $false
         NoReconnect        = $NoReconnect.IsPresent -or $false
     }
+
+    # Seed the level that filters log output before the configuration file has been read, so the
+    # handful of start-up lines emitted up to that point are filtered the same way as the rest of
+    # the session. Initialize-GlobalConfigSettings resolves this again once the persisted level is
+    # available.
+    $Script:RunTimeConfig.Logging.LogLevelSetting = Resolve-LogLevel -BoundLogLevel $LogLevel -SchemaDefault (Get-ConfigSchemaDefault -Property "LogLevel")
 
     Initialize-OmadaSqlTroubleShooter
 

--- a/src/Lib/schema/appGlobalConfigSchema.json
+++ b/src/Lib/schema/appGlobalConfigSchema.json
@@ -10,7 +10,7 @@
   {
     "Name": "LogLevel",
     "Type": "String",
-    "DefaultValue": "INFO"
+    "DefaultValue": "WARNING"
   },
   {
     "Name": "LogFormOpen",

--- a/src/Lib/ui/LogForm.xaml
+++ b/src/Lib/ui/LogForm.xaml
@@ -201,7 +201,6 @@
                        Width="Auto"/>
                 <Separator Width="10"/>
                 <ComboBox x:Name="ComboBoxSelectLogLevel"
-                          SelectedIndex="0"
                           ToolTip="Select log level"
                           Width="80">
                     <ComboBoxItem Content="LOG"/>

--- a/tests/Get-ConfigSchemaDefault.Tests.ps1
+++ b/tests/Get-ConfigSchemaDefault.Tests.ps1
@@ -1,0 +1,65 @@
+BeforeAll {
+    $ParentPath = Split-Path -Path $PSScriptRoot -Parent
+    $FunctionPath = Join-Path $ParentPath -ChildPath "src\lib\functions\Private"
+    . (Join-Path $FunctionPath -ChildPath "Get-ConfigSchemaDefault.ps1")
+    # The tracer preamble of the function under test redacts its bound parameters.
+    . (Join-Path $FunctionPath -ChildPath "ConvertTo-RedactedLogString.ps1")
+    $Script:Tracer = [System.Diagnostics.Trace]
+    $Script:RunTimeConfig = [PSCustomObject]@{ ApplicationName = "Test" }
+
+    $Script:GlobalSchemaPath = Join-Path $ParentPath -ChildPath "src\lib\schema\appGlobalConfigSchema.json"
+
+    # Keep the WARNING branch of the function under test out of the console and away from a dialog.
+    function Write-LogOutput {
+        param(
+            [parameter(Mandatory = $false, Position = 0, ValueFromPipeline = $true)]
+            [string]$Message,
+            $ErrorObject,
+            [string]$LogType = "INFO",
+            [switch]$SkipDialog
+        )
+    }
+}
+
+Describe 'Get-ConfigSchemaDefault' {
+
+    It 'returns the default declared in the global config schema' {
+        Get-ConfigSchemaDefault -Property "LogLevel" -SchemaPath $Script:GlobalSchemaPath | Should -BeExactly "WARNING"
+    }
+
+    It 'returns a non-string default unchanged' {
+        Get-ConfigSchemaDefault -Property "TabCapacity" -SchemaPath $Script:GlobalSchemaPath | Should -Be 8
+    }
+
+    It 'returns $null for a property that declares no default' {
+        Get-ConfigSchemaDefault -Property "LastOutputFolder" -SchemaPath $Script:GlobalSchemaPath | Should -BeNullOrEmpty
+    }
+
+    It 'returns $null for an unknown property instead of throwing' {
+        { Get-ConfigSchemaDefault -Property "NoSuchProperty" -SchemaPath $Script:GlobalSchemaPath } | Should -Not -Throw
+        Get-ConfigSchemaDefault -Property "NoSuchProperty" -SchemaPath $Script:GlobalSchemaPath | Should -BeNullOrEmpty
+    }
+
+    It 'declares Property as mandatory' {
+        $ParameterMetadata = (Get-Command Get-ConfigSchemaDefault).Parameters["Property"]
+        $Attribute = $ParameterMetadata.Attributes | Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] }
+        $Attribute.Mandatory | Should -Contain $true
+    }
+}
+
+Describe 'Global config schema log level default' {
+
+    BeforeAll {
+        $Script:GlobalSchema = Get-Content $Script:GlobalSchemaPath -Raw | ConvertFrom-Json
+        $Script:LogLevelDefinition = $Script:GlobalSchema | Where-Object { $_.Name -eq "LogLevel" }
+    }
+
+    It 'declares a default for LogLevel, so the schema can be the single source of truth' {
+        $Script:LogLevelDefinition | Should -Not -BeNullOrEmpty
+        $Script:LogLevelDefinition.DefaultValue | Should -Not -BeNullOrEmpty
+    }
+
+    It 'declares WARNING, matching the out-of-the-box behaviour the application has always had' {
+        $Script:LogLevelDefinition.DefaultValue | Should -BeExactly "WARNING"
+    }
+}

--- a/tests/Initialize-GlobalConfigSettings.Tests.ps1
+++ b/tests/Initialize-GlobalConfigSettings.Tests.ps1
@@ -180,6 +180,32 @@ Describe 'Initialize-GlobalConfigSettings log level resolution' {
         }
     }
 
+    Context 'The persisted value is usable but not normalized' {
+
+        BeforeEach {
+            $Script:AppGlobalConfig = New-PersistedConfig -LogLevel " debug "
+            $Script:RunTimeConfig = New-RuntimeConfig -LogLevelSetting "WARNING" -LogLevelExplicit $false
+            Initialize-GlobalConfigSettings
+        }
+
+        It 'still honours the level the user chose' {
+            $Script:RunTimeConfig.Logging.LogLevelSetting | Should -BeExactly "DEBUG"
+        }
+
+        It 'normalizes the stored value once' {
+            $Script:AppGlobalConfig.LogLevel | Should -BeExactly "DEBUG"
+        }
+
+        It 'leaves the normalized value alone on the next start' {
+            $Script:ConfigWrites = [System.Collections.Generic.List[object]]::new()
+            $Script:AppGlobalConfig = New-PersistedConfig -LogLevel "DEBUG"
+            $Script:RunTimeConfig = New-RuntimeConfig -LogLevelSetting "WARNING" -LogLevelExplicit $false
+            Initialize-GlobalConfigSettings
+
+            $Script:ConfigWrites | Where-Object { $_.Property -eq "LogLevel" } | Should -BeNullOrEmpty
+        }
+    }
+
     Context 'Round trip across a restart' {
 
         It 'keeps the level chosen in the log viewer, and leaves the stored value untouched' {

--- a/tests/Initialize-GlobalConfigSettings.Tests.ps1
+++ b/tests/Initialize-GlobalConfigSettings.Tests.ps1
@@ -1,0 +1,226 @@
+BeforeAll {
+    $ParentPath = Split-Path -Path $PSScriptRoot -Parent
+    $FunctionPath = Join-Path $ParentPath -ChildPath "src\lib\functions\Private"
+    . (Join-Path $FunctionPath -ChildPath "Initialize-GlobalConfigSettings.ps1")
+    . (Join-Path $FunctionPath -ChildPath "Resolve-LogLevel.ps1")
+    . (Join-Path $FunctionPath -ChildPath "Get-ConfigSchemaDefault.ps1")
+    # The tracer preamble of the functions under test redacts their bound parameters.
+    . (Join-Path $FunctionPath -ChildPath "ConvertTo-RedactedLogString.ps1")
+
+    $Script:Tracer = [System.Diagnostics.Trace]
+    $Script:ModuleSourceFolder = Join-Path $ParentPath -ChildPath "src"
+
+    # Stand-ins for the ambient application state Initialize-GlobalConfigSettings reaches into.
+    # They are deliberately plain functions rather than Pester mocks: Set-ConfigProperty takes
+    # pipeline input and has to mutate the simulated config file, which is easier to reason about
+    # here than mock parameter filters.
+    function Write-LogOutput {
+        param(
+            [parameter(Mandatory = $false, Position = 0, ValueFromPipeline = $true)]
+            [string]$Message,
+            $ErrorObject,
+            [string]$LogType = "INFO",
+            [switch]$SkipDialog
+        )
+    }
+
+    function Get-ModuleBaseFolder {
+        return $Script:ModuleSourceFolder
+    }
+
+    function Get-FormPositionConfig {
+        param(
+            [parameter(Mandatory = $false, Position = 0, ValueFromPipeline = $true)]
+            $Definition
+        )
+        # Non-null keeps Initialize-GlobalConfigSettings out of the WPF branch, which cannot be
+        # resolved on a headless test agent.
+        return "100x100"
+    }
+
+    function Set-ConfigProperty {
+        param(
+            [parameter(Mandatory = $false, Position = 0, ValueFromPipeline = $true)]
+            $Value,
+            [parameter(Mandatory = $false)]
+            [string]$Property,
+            [string]$JoinString = " - ",
+            [switch]$Reset
+        )
+        process {
+            if ($Reset) {
+                $Script:AppGlobalConfig = $null
+                return
+            }
+
+            if ([string]::IsNullOrWhiteSpace($Property)) {
+                return
+            }
+
+            $Script:ConfigWrites.Add([PSCustomObject]@{ Property = $Property; Value = $Value })
+            if ($null -ne $Script:AppGlobalConfig) {
+                $Script:AppGlobalConfig.$Property = $Value
+            }
+        }
+    }
+
+    function New-PersistedConfig {
+        param(
+            $LogLevel
+        )
+        return [PSCustomObject]@{
+            LogLevel           = $LogLevel
+            CheckboxConsoleLog = $false
+            InstanceGuid       = "11111111111111111111111111111111"
+        }
+    }
+
+    function New-RuntimeConfig {
+        param(
+            $LogLevelSetting,
+            [bool]$LogLevelExplicit
+        )
+        return [PSCustomObject]@{
+            ApplicationName = "Test"
+            InstanceGuid    = "11111111111111111111111111111111"
+            Logging         = [PSCustomObject]@{
+                LogToConsole     = $false
+                LogLevel         = $null
+                LogLevelSetting  = $LogLevelSetting
+                LogLevelExplicit = $LogLevelExplicit
+            }
+        }
+    }
+}
+
+Describe 'Initialize-GlobalConfigSettings log level resolution' {
+
+    BeforeEach {
+        $Script:ConfigWrites = [System.Collections.Generic.List[object]]::new()
+        $Script:MainForm = $null
+        $Script:GlobalConfigProperties = $null
+    }
+
+    Context 'A level was chosen in the log viewer during an earlier session' {
+
+        BeforeEach {
+            $Script:AppGlobalConfig = New-PersistedConfig -LogLevel "DEBUG"
+            $Script:RunTimeConfig = New-RuntimeConfig -LogLevelSetting "WARNING" -LogLevelExplicit $false
+            Initialize-GlobalConfigSettings
+        }
+
+        It 'restores the persisted level into the runtime configuration' {
+            $Script:RunTimeConfig.Logging.LogLevel | Should -BeExactly "DEBUG"
+        }
+
+        It 'applies the persisted level to the level that actually filters log output' {
+            $Script:RunTimeConfig.Logging.LogLevelSetting | Should -BeExactly "DEBUG"
+        }
+
+        It 'does not overwrite the persisted level in the config file' {
+            $Script:ConfigWrites | Where-Object { $_.Property -eq "LogLevel" } | Should -BeNullOrEmpty
+            $Script:AppGlobalConfig.LogLevel | Should -BeExactly "DEBUG"
+        }
+    }
+
+    Context 'An explicit -LogLevel parameter was supplied' {
+
+        BeforeEach {
+            $Script:AppGlobalConfig = New-PersistedConfig -LogLevel "DEBUG"
+            $Script:RunTimeConfig = New-RuntimeConfig -LogLevelSetting "ERROR" -LogLevelExplicit $true
+            Initialize-GlobalConfigSettings
+        }
+
+        It 'wins over the persisted level' {
+            $Script:RunTimeConfig.Logging.LogLevel | Should -BeExactly "ERROR"
+            $Script:RunTimeConfig.Logging.LogLevelSetting | Should -BeExactly "ERROR"
+        }
+
+        It 'is written back so it also becomes the level for the next session' {
+            $Write = $Script:ConfigWrites | Where-Object { $_.Property -eq "LogLevel" }
+            $Write | Should -Not -BeNullOrEmpty
+            $Write.Value | Should -BeExactly "ERROR"
+        }
+    }
+
+    Context 'Nothing has been persisted yet' {
+
+        BeforeEach {
+            $Script:AppGlobalConfig = New-PersistedConfig -LogLevel $null
+            $Script:RunTimeConfig = New-RuntimeConfig -LogLevelSetting "WARNING" -LogLevelExplicit $false
+            Initialize-GlobalConfigSettings
+        }
+
+        It 'falls back to the schema default' {
+            $Script:RunTimeConfig.Logging.LogLevel | Should -BeExactly "WARNING"
+            $Script:RunTimeConfig.Logging.LogLevelSetting | Should -BeExactly "WARNING"
+        }
+
+        It 'seeds the config file with the schema default' {
+            $Write = $Script:ConfigWrites | Where-Object { $_.Property -eq "LogLevel" }
+            $Write | Should -Not -BeNullOrEmpty
+            $Write.Value | Should -BeExactly "WARNING"
+        }
+    }
+
+    Context 'The persisted value is not a level the application knows' {
+
+        BeforeEach {
+            $Script:AppGlobalConfig = New-PersistedConfig -LogLevel "NOT_A_LEVEL"
+            $Script:RunTimeConfig = New-RuntimeConfig -LogLevelSetting "WARNING" -LogLevelExplicit $false
+            Initialize-GlobalConfigSettings
+        }
+
+        It 'falls back to the schema default instead of throwing' {
+            $Script:RunTimeConfig.Logging.LogLevelSetting | Should -BeExactly "WARNING"
+        }
+
+        It 'repairs the stored value' {
+            $Script:AppGlobalConfig.LogLevel | Should -BeExactly "WARNING"
+        }
+    }
+
+    Context 'Round trip across a restart' {
+
+        It 'keeps the level chosen in the log viewer, and leaves the stored value untouched' {
+            # Session one: the user picks VERBOSE in the log viewer, which stores it.
+            $Script:AppGlobalConfig = New-PersistedConfig -LogLevel $null
+            $Script:RunTimeConfig = New-RuntimeConfig -LogLevelSetting "WARNING" -LogLevelExplicit $false
+            Initialize-GlobalConfigSettings
+            "VERBOSE" | Set-ConfigProperty -Property "LogLevel"
+
+            $PersistedAfterFirstSession = $Script:AppGlobalConfig.LogLevel
+            $PersistedAfterFirstSession | Should -BeExactly "VERBOSE"
+
+            # Session two: a fresh start with no -LogLevel parameter reads the same config back.
+            $Script:ConfigWrites = [System.Collections.Generic.List[object]]::new()
+            $Script:AppGlobalConfig = New-PersistedConfig -LogLevel $PersistedAfterFirstSession
+            $Script:RunTimeConfig = New-RuntimeConfig -LogLevelSetting "WARNING" -LogLevelExplicit $false
+            Initialize-GlobalConfigSettings
+
+            $Script:RunTimeConfig.Logging.LogLevelSetting | Should -BeExactly "VERBOSE"
+            $Script:AppGlobalConfig.LogLevel | Should -BeExactly "VERBOSE"
+            $Script:ConfigWrites | Where-Object { $_.Property -eq "LogLevel" } | Should -BeNullOrEmpty
+        }
+    }
+}
+
+Describe 'Invoke-OmadaSqlTroubleshooter log level seeding' {
+
+    BeforeAll {
+        $ParentPath = Split-Path -Path $PSScriptRoot -Parent
+        $Script:EntryPointSource = Get-Content (Join-Path $ParentPath -ChildPath "src\lib\functions\Public\Invoke-OmadaSqlTroubleshooter.ps1") -Raw
+    }
+
+    It 'does not hardcode a log level default any more' {
+        $Script:EntryPointSource | Should -Not -Match 'IsNullOrWhiteSpace\(\$LogLevel\)\)\s*\{\s*"WARNING"'
+    }
+
+    It 'records whether -LogLevel was explicitly bound' {
+        $Script:EntryPointSource | Should -Match 'BoundParameters\.ContainsKey\("LogLevel"\)'
+    }
+
+    It 'seeds the runtime level through the shared resolver' {
+        $Script:EntryPointSource | Should -Match 'Resolve-LogLevel'
+    }
+}

--- a/tests/Open-LogForm.Tests.ps1
+++ b/tests/Open-LogForm.Tests.ps1
@@ -1,0 +1,58 @@
+BeforeAll {
+    $ParentPath = Split-Path -Path $PSScriptRoot -Parent
+    $Script:LogFormXamlPath = Join-Path $ParentPath -ChildPath "src\lib\ui\LogForm.xaml"
+    $Script:OpenLogFormSource = Get-Content (Join-Path $ParentPath -ChildPath "src\lib\functions\Private\Open-LogForm.ps1") -Raw
+    $Script:LogLevelEventSource = Get-Content (Join-Path $ParentPath -ChildPath "src\lib\Events\LogForm.Elements.ComboBoxSelectLogLevel.ps1") -Raw
+
+    # Parsed as plain XML, never loaded as WPF: a headless agent cannot resolve System.Windows types.
+    $Script:LogFormXaml = [xml](Get-Content $Script:LogFormXamlPath -Raw)
+    $Script:XamlNamespace = New-Object System.Xml.XmlNamespaceManager($Script:LogFormXaml.NameTable)
+    $Script:XamlNamespace.AddNamespace("w", "http://schemas.microsoft.com/winfx/2006/xaml/presentation")
+    $Script:XamlNamespace.AddNamespace("x", "http://schemas.microsoft.com/winfx/2006/xaml")
+    $Script:LogLevelComboBox = $Script:LogFormXaml.SelectSingleNode("//w:ComboBox[@x:Name='ComboBoxSelectLogLevel']", $Script:XamlNamespace)
+}
+
+Describe 'LogForm.xaml log level combo box' {
+
+    It 'is present in the log form' {
+        $Script:LogLevelComboBox | Should -Not -BeNullOrEmpty
+    }
+
+    It 'does not preselect an item, so its SelectionChanged handler cannot store a level before the stored one is applied' {
+        # SelectedIndex="0" selected LOG while Import-EventObjects had already wired
+        # SelectionChanged, so LOG was written to the config before Open-LogForm restored the
+        # intended level (issue #63).
+        $Script:LogLevelComboBox.Attributes["SelectedIndex"] | Should -BeNullOrEmpty
+        $Script:LogLevelComboBox.Attributes["SelectedItem"] | Should -BeNullOrEmpty
+        $Script:LogLevelComboBox.Attributes["SelectedValue"] | Should -BeNullOrEmpty
+    }
+
+    It 'still offers every level the application can filter on' {
+        $Items = $Script:LogLevelComboBox.ChildNodes | Where-Object { $_.LocalName -eq "ComboBoxItem" }
+        $Contents = $Items | ForEach-Object { $_.GetAttribute("Content") }
+
+        foreach ($Level in @("LOG", "INFO", "WARNING", "ERROR", "FATAL", "DEBUG", "VERBOSE", "VERBOSE2")) {
+            $Contents | Should -Contain $Level
+        }
+    }
+}
+
+Describe 'ComboBoxSelectLogLevel SelectionChanged handler' {
+
+    It 'ignores a selection change that carries no selected item' {
+        # Without the guard an empty selection stores $null as the log level.
+        $Script:LogLevelEventSource | Should -Match 'SelectedItem'
+        $Script:LogLevelEventSource | Should -Match '(?s)if\s*\(\s*\$null\s*-eq.*SelectedItem'
+    }
+}
+
+Describe 'Open-LogForm log level fallback' {
+
+    It 'does not hardcode a log level default any more' {
+        $Script:OpenLogFormSource | Should -Not -Match '"INFO"'
+    }
+
+    It 'reads the default from the config schema instead' {
+        $Script:OpenLogFormSource | Should -Match 'Get-ConfigSchemaDefault -Property "LogLevel"'
+    }
+}

--- a/tests/Resolve-LogLevel.Tests.ps1
+++ b/tests/Resolve-LogLevel.Tests.ps1
@@ -1,0 +1,91 @@
+BeforeAll {
+    $ParentPath = Split-Path -Path $PSScriptRoot -Parent
+    $FunctionPath = Join-Path $ParentPath -ChildPath "src\lib\functions\Private"
+    . (Join-Path $FunctionPath -ChildPath "Resolve-LogLevel.ps1")
+    # The tracer preamble of the function under test redacts its bound parameters.
+    . (Join-Path $FunctionPath -ChildPath "ConvertTo-RedactedLogString.ps1")
+    $Script:Tracer = [System.Diagnostics.Trace]
+    $Script:RunTimeConfig = [PSCustomObject]@{ ApplicationName = "Test" }
+}
+
+Describe 'Resolve-LogLevel' {
+
+    It 'lets an explicitly bound parameter win over a persisted value' {
+        Resolve-LogLevel -BoundLogLevel "ERROR" -PersistedLogLevel "DEBUG" -SchemaDefault "WARNING" | Should -BeExactly "ERROR"
+    }
+
+    It 'lets an explicitly bound parameter win over the schema default when nothing is persisted' {
+        Resolve-LogLevel -BoundLogLevel "ERROR" -PersistedLogLevel $null -SchemaDefault "WARNING" | Should -BeExactly "ERROR"
+    }
+
+    It 'lets a persisted value win over the schema default' {
+        Resolve-LogLevel -BoundLogLevel $null -PersistedLogLevel "DEBUG" -SchemaDefault "WARNING" | Should -BeExactly "DEBUG"
+    }
+
+    It 'treats an empty bound parameter as not supplied' {
+        Resolve-LogLevel -BoundLogLevel "" -PersistedLogLevel "VERBOSE" -SchemaDefault "WARNING" | Should -BeExactly "VERBOSE"
+    }
+
+    It 'treats a whitespace-only bound parameter as not supplied' {
+        Resolve-LogLevel -BoundLogLevel "   " -PersistedLogLevel "VERBOSE" -SchemaDefault "WARNING" | Should -BeExactly "VERBOSE"
+    }
+
+    It 'falls back to the schema default when neither a parameter nor a persisted value is set' {
+        Resolve-LogLevel -BoundLogLevel $null -PersistedLogLevel $null -SchemaDefault "WARNING" | Should -BeExactly "WARNING"
+    }
+
+    It 'falls back to the schema default when the persisted value is empty' {
+        Resolve-LogLevel -BoundLogLevel $null -PersistedLogLevel "" -SchemaDefault "INFO" | Should -BeExactly "INFO"
+    }
+
+    It 'falls back to the schema default when the persisted value is unknown, instead of throwing' {
+        { Resolve-LogLevel -BoundLogLevel $null -PersistedLogLevel "NOT_A_LEVEL" -SchemaDefault "WARNING" } | Should -Not -Throw
+        Resolve-LogLevel -BoundLogLevel $null -PersistedLogLevel "NOT_A_LEVEL" -SchemaDefault "WARNING" | Should -BeExactly "WARNING"
+    }
+
+    It 'falls back to the schema default when the bound value is unknown, instead of throwing' {
+        Resolve-LogLevel -BoundLogLevel "GIBBERISH" -PersistedLogLevel $null -SchemaDefault "WARNING" | Should -BeExactly "WARNING"
+    }
+
+    It 'prefers a valid persisted value over the schema default even when the bound value is unknown' {
+        Resolve-LogLevel -BoundLogLevel "GIBBERISH" -PersistedLogLevel "DEBUG" -SchemaDefault "WARNING" | Should -BeExactly "DEBUG"
+    }
+
+    It 'normalizes the casing of a persisted value' {
+        Resolve-LogLevel -BoundLogLevel $null -PersistedLogLevel "debug" -SchemaDefault "WARNING" | Should -BeExactly "DEBUG"
+    }
+
+    It 'trims surrounding whitespace from a persisted value' {
+        Resolve-LogLevel -BoundLogLevel $null -PersistedLogLevel " DEBUG " -SchemaDefault "WARNING" | Should -BeExactly "DEBUG"
+    }
+
+    It 'accepts every level the log viewer offers' -ForEach @(
+        @{ Level = "LOG" }
+        @{ Level = "INFO" }
+        @{ Level = "WARNING" }
+        @{ Level = "ERROR" }
+        @{ Level = "FATAL" }
+        @{ Level = "DEBUG" }
+        @{ Level = "VERBOSE" }
+        @{ Level = "VERBOSE2" }
+    ) {
+        Resolve-LogLevel -BoundLogLevel $null -PersistedLogLevel $Level -SchemaDefault "WARNING" | Should -BeExactly $Level
+    }
+
+    It 'returns $null when no candidate at all is usable, instead of throwing' {
+        { Resolve-LogLevel -BoundLogLevel $null -PersistedLogLevel $null -SchemaDefault $null } | Should -Not -Throw
+        Resolve-LogLevel -BoundLogLevel $null -PersistedLogLevel $null -SchemaDefault $null | Should -BeNullOrEmpty
+    }
+
+    It 'always returns a string when it resolves a level' {
+        Resolve-LogLevel -BoundLogLevel "DEBUG" -PersistedLogLevel $null -SchemaDefault "WARNING" | Should -BeOfType [string]
+    }
+
+    It 'declares no mandatory parameters, so a caller may omit any candidate' {
+        $ParameterMetadata = (Get-Command Resolve-LogLevel).Parameters
+        foreach ($ParameterName in @("BoundLogLevel", "PersistedLogLevel", "SchemaDefault")) {
+            $Attribute = $ParameterMetadata[$ParameterName].Attributes | Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] }
+            $Attribute.Mandatory | Should -Not -Contain $true -Because "$ParameterName must be optional"
+        }
+    }
+}


### PR DESCRIPTION
Closes #63

## What broke

The log level chosen in the log viewer was written to the global config but never read back, and the runtime value was pushed *into* the config on every start, so the stored value was overwritten before anything could use it.

- `src/Lib/Functions/Public/Invoke-OmadaSqlTroubleshooter.ps1:73` seeded `LogLevelSetting` from the `-LogLevel` parameter with a hardcoded `WARNING` fallback, so it was never `$null`.
- `src/Lib/Functions/Private/Initialize-GlobalConfigSettings.ps1:27-30` guarded on `$null -ne ...LogLevelSetting` — a condition that could never be false — and wrote that runtime value into the config with `Set-ConfigProperty -Property "LogLevel"`. No code path ever read `$Script:AppGlobalConfig.LogLevel` back.
- `src/Lib/Functions/Private/Open-LogForm.ps1:56` used a third, separate default (`INFO`), while `src/Lib/schema/appGlobalConfigSchema.json` declared `INFO` and the code used `WARNING`.
- `src/Lib/ui/LogForm.xaml:204` declared the combo box with `SelectedIndex="0"` (= `LOG`). `Import-EventObjects -ClassName "LogForm"` wires `SelectionChanged` before `Open-LogForm` applies the stored level, so the XAML default could fire the handler and write `LOG` to the config before the intended value was restored.

## What changed

**New pure helpers (unit-testable, in line with the existing suites)**

- `src/Lib/Functions/Private/Resolve-LogLevel.ps1` — resolves `explicit parameter -> persisted value -> schema default`. A candidate that is empty or names a level the application does not know is skipped rather than rejected, so a hand-edited or stale config degrades to the default instead of throwing on the start-up path. Values are trimmed and upper-cased.
- `src/Lib/Functions/Private/Get-ConfigSchemaDefault.ps1` — reads a property's `DefaultValue` from the global config schema (reusing the `$Script:GlobalConfigProperties` cache `Set-ConfigProperty` already fills). Accepts an optional `-SchemaPath` for tests.

**Start-up path**

- `Invoke-OmadaSqlTroubleshooter` now records `Logging.LogLevelExplicit = $PSCmdlet.MyInvocation.BoundParameters.ContainsKey("LogLevel")` and seeds `LogLevelSetting` through `Resolve-LogLevel` with the schema default, so the handful of lines emitted before the config file is read are still filtered.
- `Initialize-GlobalConfigSettings` resolves the effective level from the bound parameter, `$Script:AppGlobalConfig.LogLevel` and the schema default, assigns both `Logging.LogLevel` and `Logging.LogLevelSetting`, and writes back **only** when the parameter was explicitly supplied, when nothing is stored yet, or when the stored value is unusable.

**Single source of truth**

- `appGlobalConfigSchema.json` now declares `"DefaultValue": "WARNING"` for `LogLevel`; the hardcoded `WARNING` in the entry point and the hardcoded `INFO` in `Open-LogForm` are gone and read from the schema.

**Log viewer**

- `LogForm.xaml` no longer sets `SelectedIndex` on `ComboBoxSelectLogLevel`.
- `LogForm.Elements.ComboBoxSelectLogLevel.ps1` returns early when `SelectedItem` is `$null`, and keeps `Logging.LogLevel` in step with `Logging.LogLevelSetting` so reopening the log viewer in the same session shows the level in effect.

## Acceptance criteria (issue "Regression test" section)

- [x] Explicit parameter wins over a persisted value — `tests/Resolve-LogLevel.Tests.ps1` "lets an explicitly bound parameter win over a persisted value"; `tests/Initialize-GlobalConfigSettings.Tests.ps1` "wins over the persisted level".
- [x] Persisted value wins over the schema default — `tests/Resolve-LogLevel.Tests.ps1` "lets a persisted value win over the schema default"; `tests/Initialize-GlobalConfigSettings.Tests.ps1` "restores the persisted level into the runtime configuration".
- [x] Schema default applies when neither is set — `tests/Resolve-LogLevel.Tests.ps1` "falls back to the schema default when neither a parameter nor a persisted value is set"; `tests/Initialize-GlobalConfigSettings.Tests.ps1` "falls back to the schema default".
- [x] An invalid/unknown persisted value falls back instead of throwing — `tests/Resolve-LogLevel.Tests.ps1` "falls back to the schema default when the persisted value is unknown, instead of throwing"; `tests/Initialize-GlobalConfigSettings.Tests.ps1` "falls back to the schema default instead of throwing" and "repairs the stored value".
- [x] Round trip: set level, persist, restart, same level, config not overwritten — `tests/Initialize-GlobalConfigSettings.Tests.ps1` "keeps the level chosen in the log viewer, and leaves the stored value untouched", plus "does not overwrite the persisted level in the config file".
- [x] Secondary defect: the XAML `SelectedIndex` default — `tests/Open-LogForm.Tests.ps1` "does not preselect an item, so its SelectionChanged handler cannot store a level before the stored one is applied" and "ignores a selection change that carries no selected item".
- [x] One default from one place — `tests/Get-ConfigSchemaDefault.Tests.ps1` "declares WARNING, matching the out-of-the-box behaviour the application has always had"; `tests/Open-LogForm.Tests.ps1` "does not hardcode a log level default any more"; `tests/Initialize-GlobalConfigSettings.Tests.ps1` "does not hardcode a log level default any more".

## Decisions worth reviewing

- **The schema default becomes `WARNING`, not `INFO`.** The issue notes three disagreeing defaults. Making the schema the single source of truth means one of them has to win, and picking `INFO` would have changed the observable out-of-the-box log level for every user on the next launch. `WARNING` is what the application has actually been doing since the code fallback always applied, so this fix changes the persistence bug and nothing else. `Add-ConfigProperty` also seeds a fresh config from this default, so a first run is unchanged too.
- **`LogLevelSetting` is still seeded before the config is read.** Leaving it `$null` until `Initialize-GlobalConfigSettings` runs would have silenced every start-up warning (`Write-LogOutput`'s level switch falls through to `Show = $false` on `$null`). It is seeded from the bound parameter or the schema default, then re-resolved once the persisted value is available.
- **A separate `Logging.LogLevelExplicit` flag** rather than inferring "explicit" from a non-empty `LogLevelSetting` — after seeding, that value is non-empty either way, so the intent has to be recorded at the point where `$PSCmdlet.MyInvocation.BoundParameters` is available.
- **The write-back also fires when the stored value differs from the resolved one**, not only on an explicit parameter or an empty store. That covers both an unusable stored value and a usable but unnormalized one such as `" debug "`: it is rewritten once as `"DEBUG"` and is stable from then on, so the file self-heals instead of being re-resolved on every launch. A stored value that already matches is never rewritten.
- **`Resolve-LogLevel` accepts `LOG`** as well as the `-LogLevel` parameter's `ValidateSet`. `LOG` is selectable in the log viewer and understood by `Write-LogOutput`, so it is a legitimate persisted value; rejecting it would have thrown away a user's own choice.
- **`Resolve-LogLevel` returns `$null` when no candidate is usable** rather than falling back to yet another literal — that state is only reachable if the schema itself loses its default, and inventing a default there would recreate the problem this PR removes.
- **The `SelectionChanged` handler now also updates `Logging.LogLevel`.** `Open-LogForm` reads that property, so without it, closing and reopening the log viewer in the same session showed a stale level. Small, but it is the same defect one layer up.
- **Test file naming.** `Initialize-GlobalConfigSettings.Tests.ps1` and `Open-LogForm.Tests.ps1` are named after their source files so the PR-validation change filter (`psakeBuild.ps1` Test task) picks them up automatically whenever those sources change.
- **Headless-safe tests.** No `System.Windows.*` type is touched: `LogForm.xaml` is parsed as plain XML, and the `Initialize-GlobalConfigSettings` suite stubs `Get-FormPositionConfig` to return a non-null value so the `[System.Windows.WindowStartupLocation]` branch is never entered.

## Verification

```
pwsh -NoProfile -File build/build.ps1 -Task TestBuildOnly
```

- `Analyze` (PSScriptAnalyzer, Error + Warning): clean.
- `Test`: **Tests Passed: 365, Failed: 0, Skipped: 0, Inconclusive: 0, NotRun: 0** (baseline on unmodified `origin/main`: 313 passed / 0 failed; the 52 new tests are the difference).
- `Build`: succeeded.
