### PR TITLE
Stop the startup schema push from silently connecting a disconnected tab (#64)

### DIFF
--- a/src/Lib/Functions/Private/Complete-TabMaterialization.ps1
+++ b/src/Lib/Functions/Private/Complete-TabMaterialization.ps1
@@ -65,6 +65,16 @@ function Complete-TabMaterialization {
             }
             Test-ConnectionSettings
             Test-ConnectionButton
+
+            # Unlike the Connect button, this branch populates the data connection list BEFORE the
+            # connection is actually established, so the ComboBox SelectionChanged handler that
+            # normally fetches the schema runs while this tab still counts as disconnected - and
+            # Get-SqlSchemaObject now (correctly) refuses to request anything for a disconnected tab.
+            # Retrieve it here instead, once the tab really is connected, so an auto-connected
+            # restored tab still gets its IntelliSense schema.
+            if ($Script:ConnectionStatus) {
+                Get-SqlSchemaObject
+            }
         }
         else {
             Set-SqlConnectionState -Status $false

--- a/src/Lib/Functions/Private/Get-SqlSchema.ps1
+++ b/src/Lib/Functions/Private/Get-SqlSchema.ps1
@@ -9,6 +9,21 @@ function Get-SqlSchemaObject {
             return
         }
 
+        # Retrieving the schema is an authenticated round-trip, so it may only run for a tab that
+        # genuinely connected. $Script:ConnectionStatus is the active tab's own connection flag
+        # (Set-ActiveTabContext swaps it in and out per tab, Set-SqlConnectionState is its only
+        # writer), which is the state this guard must read. The checks below are not a substitute:
+        # $Script:RunTimeConfig.ReconnectStatus is process-global and is already 3 once any tab's
+        # editor has loaded, Test-ConnectionRequirements only verifies that a URL and an
+        # authentication option are filled in, and CurrentDataConnection.DoId is restored from
+        # config - a restored, deliberately disconnected tab satisfies all three. Without this the
+        # NavigationCompleted handler in Initialize-WebViewForTab.ps1 silently authenticated against
+        # the tenant, defeating -NoReconnect and a declined reconnect prompt alike.
+        if (-not $Script:ConnectionStatus) {
+            "Tab is not connected; skipping SQL schema retrieval." | Write-LogOutput -LogType DEBUG
+            return
+        }
+
         if (!(Test-ConnectionRequirements)) {
             "Connection not ready" | Write-LogOutput -LogType DEBUG
             return

--- a/src/Lib/Functions/Private/Initialize-WebViewForTab.ps1
+++ b/src/Lib/Functions/Private/Initialize-WebViewForTab.ps1
@@ -104,7 +104,19 @@ function Initialize-WebViewForTab {
                     }
 
                     Test-ConnectionButton
-                    Update-QueryList
+
+                    # Refreshing the query list is an authenticated round-trip AND it re-enables
+                    # ComboBoxSelectQuery / ButtonRefreshQueries / the "my queries" checkboxes
+                    # unconditionally at the end of Update-QueryList. Running it for a tab that was
+                    # deliberately left disconnected (a restored tab under -NoReconnect, or after a
+                    # declined reconnect prompt) therefore both connected to the tenant and undid the
+                    # Set-SqlQueryFunctionState -Status $false that Complete-TabMaterialization had
+                    # just applied - which is why such a tab showed an openable query dropdown next
+                    # to a Connect button. Only refresh it for a tab that genuinely connected.
+                    if ($Script:ConnectionStatus) {
+                        Update-QueryList
+                    }
+
                     Set-EditorValue
 
                     # These WebView2 event handlers fire independently, long after this completion
@@ -253,8 +265,11 @@ function Initialize-WebViewForTab {
                                     # duplicated tab, auto-connect) never received a setSchema push -
                                     # Invoke-ExecuteScriptAsync silently skips while the WebView is not
                                     # ready. Push it now so IntelliSense knows this database's tables and
-                                    # columns. Get-SqlSchemaObject returns early when the tab is not
-                                    # connected yet (the connect path pushes it instead) and serves the
+                                    # columns. Get-SqlSchemaObject checks $Script:ConnectionStatus and
+                                    # returns without any request when this tab is not connected (the
+                                    # guard the previous version of this comment claimed but that did
+                                    # not exist - the call authenticated against the tenant instead,
+                                    # even under -NoReconnect); for a connected tab it serves the
                                     # per-pool + per-database cache, so this is normally just the push.
                                     Get-SqlSchemaObject
 

--- a/src/Lib/Functions/Private/Set-SqlConnectionState.ps1
+++ b/src/Lib/Functions/Private/Set-SqlConnectionState.ps1
@@ -8,6 +8,16 @@ function Set-SqlConnectionState {
 
         Set-SqlQueryFunctionState -Status $Status
         if ($Status) {
+            # Flip the active tab's connection flag FIRST, before the dropdown refreshes below. Those
+            # refreshes are part of the connect sequence and reach connected-only work (for example
+            # Update-DataConnectionList selects an item, whose SelectionChanged handler calls
+            # Get-SqlSchemaObject), and Get-SqlSchemaObject now refuses to run for a tab that is not
+            # connected. Setting the flag at the end of this branch - as it used to be - would make
+            # the connect path look disconnected to its own follow-up work and silently drop the
+            # schema fetch. $Script:ConnectionStatus is not read by anything between here and its old
+            # position: the only handler that consults it is ComboBoxSelectQuery's DropDownOpened,
+            # which is a user gesture and never fires programmatically.
+            $Script:ConnectionStatus = $true
             $Script:MainForm.Elements.ButtonReset.IsEnabled = $true
             $Script:MainForm.Elements.ComboBoxSelectAuthenticationOption.IsEnabled = $false
             $Script:MainForm.Elements.TextBoxUserName.IsEnabled = $false
@@ -34,7 +44,6 @@ function Set-SqlConnectionState {
                     $ConnectingWindow.Close()
                 }
             }
-            $Script:ConnectionStatus = $true
             # The window title is refreshed from the active tab by Update-TabHeaderTitle below
             # (-> Update-ApplicationTitle), so it stays in the new "<name> - <connection> - <tenant>"
             # format instead of being set to the old app-title-plus-tenant string here.

--- a/tests/Get-SqlSchema.Tests.ps1
+++ b/tests/Get-SqlSchema.Tests.ps1
@@ -1,0 +1,152 @@
+#Requires -Version 7.0
+# Regression tests for issue #64: Get-SqlSchemaObject must not authenticate against the tenant for a
+# tab that is not connected. It runs from the WebView2 NavigationCompleted handler for EVERY tab that
+# loads its Monaco editor - including a restored tab that was deliberately left disconnected by
+# -NoReconnect or by a declined reconnect prompt - so an unguarded call there is a silent connect.
+#
+# The request path is exercised end to end through the REAL Invoke-OmadaPSWebRequestWrapper and the
+# mock transport shim against a running mock Omada instance, so "zero requests" means zero requests
+# actually reached the mock, not "a stub was not called".
+
+BeforeAll {
+    $ParentPath = Split-Path -Path $PSScriptRoot -Parent
+    $PrivatePath = Join-Path $ParentPath -ChildPath "src\Lib\Functions\Private"
+
+    . (Join-Path $PrivatePath -ChildPath "ConvertTo-RedactedLogString.ps1")
+    . (Join-Path $PrivatePath -ChildPath "Test-ConnectionRequirements.ps1")
+    . (Join-Path $PrivatePath -ChildPath "Invoke-OmadaPSWebRequestWrapper.ps1")
+    . (Join-Path $PrivatePath -ChildPath "Get-SqlSchema.ps1")
+
+    . (Join-Path $PSScriptRoot -ChildPath "mock\OmadaMockRouter.ps1")
+    . (Join-Path $PSScriptRoot -ChildPath "mock\OmadaMockServer.ps1")
+    . (Join-Path $PSScriptRoot -ChildPath "mock\Install-OmadaMockTransport.ps1")
+
+    $script:Handle = New-OmadaMockServerHandle -BindAddress "127.0.0.1" -Port 0
+    Install-OmadaMockTransport -MockBaseUrl $script:Handle.BaseUrl
+
+    # --- Stubs for everything outside the function under test --------------------------------------
+    $Script:Tracer = [System.Diagnostics.Trace]
+
+    function Write-LogOutput {
+        param(
+            [Parameter(ValueFromPipeline = $true)]$InputObject,
+            [string]$LogType,
+            $ErrorObject,
+            [switch]$SkipDialog
+        )
+        process { }
+    }
+
+    # The real wrapper suspends the WebView2 completion poll timer around every call; there is no
+    # timer here, so both ends are no-ops. Without them the wrapper would throw CommandNotFound and
+    # a "no request was made" assertion would pass for the wrong reason.
+    function Suspend-WebViewCompletionPolling { }
+
+    function Resume-WebViewCompletionPolling { }
+
+    # The editor push seam. Recorded rather than executed so the connected case can be proven to
+    # have reached setSchema(...).
+    $script:PushedEditorScripts = [System.Collections.Generic.List[string]]::new()
+
+    function Invoke-ExecuteScriptAsync {
+        param(
+            $ScriptToExecute,
+            $OnCompletedScriptBlock
+        )
+        $script:PushedEditorScripts.Add([string]$ScriptToExecute)
+    }
+
+    function Initialize-SchemaTestState {
+        <#
+        Puts the module-scope state into the shape a RESTORED tab has: a tenant URL and an
+        authentication option filled in, a data connection DoId carried over from config, and
+        ReconnectStatus already at 3 (the NavigationCompleted handler sets it there as soon as any
+        tab's editor has loaded). Every gate Get-SqlSchemaObject had BEFORE the fix is therefore
+        satisfied - the connection flag is the only thing that separates the two cases.
+        #>
+        param(
+            [bool]$Connected
+        )
+
+        $Script:RunTimeConfig = [PSCustomObject]@{ ApplicationName = "Test"; ReconnectStatus = 3 }
+        $Script:AppConfig = [PSCustomObject]@{
+            BaseUrl               = "https://tenant.omada.cloud"
+            CurrentDataConnection = [PSCustomObject]@{ DoId = "1001572"; FullName = "OISES - 1001572" }
+        }
+        $Script:RunTimeData = @{
+            SkipRetryRequest = $false
+            SqlQueryObject   = $null
+            RestMethodParam  = @{
+                SessionKey          = "pool-under-test"
+                AuthenticationType  = "Browser"
+                ForceAuthentication = $false
+            }
+        }
+        $Script:MainForm = @{
+            Elements = @{
+                TextBoxURL                          = [PSCustomObject]@{ Text = "https://tenant.omada.cloud" }
+                ComboBoxSelectAuthenticationOption  = [PSCustomObject]@{ SelectedItem = [PSCustomObject]@{ Content = "Browser" } }
+            }
+        }
+        # No schema window in these tests: Get-SqlSchemaObject must skip the TreeView/title work and
+        # still push to the editor.
+        $Script:SqlSchemaForm = $null
+        $Script:TreeViewSqlSchema = $null
+        $Script:SqlSchemaCache = @{}
+        $Script:ConnectionStatus = $Connected
+
+        $script:PushedEditorScripts.Clear()
+        Clear-OmadaMockRequestLog
+    }
+}
+
+AfterAll {
+    if ($null -ne $script:Handle) { Stop-OmadaMockServerHandle -Handle $script:Handle }
+}
+
+Describe "Get-SqlSchemaObject connection guard" {
+    It "makes no request at all when the tab is not connected" {
+        Initialize-SchemaTestState -Connected $false
+
+        Get-SqlSchemaObject
+
+        (Get-OmadaMockRequestLog).Count | Should -Be 0
+        $script:PushedEditorScripts.Count | Should -Be 0
+    }
+
+    It "does not connect even though every pre-fix gate is satisfied" {
+        Initialize-SchemaTestState -Connected $false
+
+        # Discriminating: these are exactly the three conditions the function used to rely on. All
+        # three say "go", and the request must still not happen.
+        $Script:RunTimeConfig.ReconnectStatus | Should -Not -Be 1
+        Test-ConnectionRequirements | Should -BeTrue
+        $Script:AppConfig.CurrentDataConnection.DoId | Should -Not -BeNullOrEmpty
+
+        Get-SqlSchemaObject
+
+        (Get-OmadaMockRequestLog -UriLike "*GetSqlSchema*").Count | Should -Be 0
+    }
+
+    It "retrieves the schema and pushes it to the editor when the tab is connected" {
+        Initialize-SchemaTestState -Connected $true
+
+        Get-SqlSchemaObject
+
+        (Get-OmadaMockRequestLog -UriLike "*GetSqlSchema*" -MethodLike "POST").Count | Should -Be 1
+
+        $SetSchema = $script:PushedEditorScripts | Where-Object { $_ -like "setSchema(*" } | Select-Object -Last 1
+        $SetSchema | Should -Not -BeNullOrEmpty
+        $SetSchema | Should -BeLike "*nvarchar*"
+    }
+
+    It "serves a second connected call from the per-pool cache without another request" {
+        Initialize-SchemaTestState -Connected $true
+
+        Get-SqlSchemaObject
+        Clear-OmadaMockRequestLog
+        Get-SqlSchemaObject
+
+        (Get-OmadaMockRequestLog).Count | Should -Be 0
+    }
+}

--- a/tests/e2e/Drivers.ps1
+++ b/tests/e2e/Drivers.ps1
@@ -59,6 +59,7 @@ function script:Reset-E2EScenario {
     $script:E2EConnectionProbeError = $null
     $script:E2EFixtureOverride = $null
     $script:E2EChoiceReturn = $null
+    $script:E2EChoices.Clear()
 }
 
 function script:Reset-E2EConnection {
@@ -169,6 +170,17 @@ function script:Get-E2ECallCount {
             $_.Method -like $MethodLike -and $_.Uri -like $UriLike -and
             ($null -eq $DataType -or $_.DataType -eq $DataType)
         }).Count
+}
+
+function script:Clear-E2EChoices {
+    $script:E2EChoices.Clear()
+}
+
+function script:Get-E2EChoices {
+    param(
+        [string]$TitleLike = "*"
+    )
+    return @($script:E2EChoices | Where-Object { $_.Title -like $TitleLike })
 }
 
 function script:Clear-E2EPopups {

--- a/tests/e2e/OmadaMocks.ps1
+++ b/tests/e2e/OmadaMocks.ps1
@@ -64,6 +64,10 @@ function script:Push-ToEditor {
 }
 
 # --- Popup neutralizers so nothing enters a nested WPF message pump --------------------------------
+# Every choice dialog the app would have shown is recorded, so a scenario can assert that the
+# reconnect prompt WAS shown (issue #64) as precisely as it asserts that it was not.
+$script:E2EChoices = [System.Collections.Generic.List[object]]::new()
+
 function script:Open-ChoiceForm {
     param(
         $Title,
@@ -73,6 +77,7 @@ function script:Open-ChoiceForm {
         $LeftButtonReturnValue = $true,
         $RightButtonReturnValue = $false
     )
+    $script:E2EChoices.Add([PSCustomObject]@{ Title = [string]$Title; Message = [string]$Message })
     if ($null -ne $script:E2EChoiceReturn) {
         return $script:E2EChoiceReturn
     }

--- a/tests/e2e/scenarios/NoReconnect.ps1
+++ b/tests/e2e/scenarios/NoReconnect.ps1
@@ -1,0 +1,144 @@
+# Issue #64: "-NoReconnect does not prevent connecting - the tab connects anyway via the unguarded
+# schema push". These scenarios drive the REAL startup restore path (Restore-TabSessions ->
+# New-TabSession -Deferred -> Complete-TabMaterialization -> Initialize-WebViewForTab) against a
+# persisted tab store, and assert on the call recorder that NOTHING reached the tenant.
+#
+# The Start menu shortcut keeping -NoReconnect is by design (see the maintainer's scope decision on
+# the issue), so what is under test here is only the second half: that -NoReconnect - and a declined
+# reconnect prompt - really means "no connection is made on startup at all".
+
+function script:New-E2EPersistedTabStore {
+    <#
+    Writes a tabs.clixml into the run's throwaway AppData folder, in exactly the shape
+    Save-TabSessions produces, so Restore-TabSessions restores real persisted tabs. Built here
+    rather than via Save-TabSessions so the store's contents are deterministic and independent of
+    whatever the previous scenario left in the live tabs.
+    #>
+    param(
+        [int]$TabCount = 1,
+        [string]$Url = "https://tenant.omada.cloud",
+        [string]$Auth = "Browser"
+    )
+
+    $TabConfigs = @(
+        1..$TabCount | ForEach-Object {
+            [PSCustomObject]@{
+                Id                    = ([guid]::NewGuid().Guid)
+                DisplayName           = "Persisted{0}" -f $_
+                BaseUrl               = $Url
+                CurrentSqlQuery       = [PSCustomObject]@{ DoId = 100; DisplayName = "TestQuery"; FullName = "TestQuery - 100" }
+                LastAuthentication    = $Auth
+                UserName              = $null
+                Password              = $null
+                EntraApplicationIdUri = $null
+                EntraIdTenantId       = $null
+                MyCreatedQueriesOnly  = $false
+                MyUpdatedQueriesOnly  = $false
+                SavePassword          = $false
+                IdentityUserName      = $null
+                CurrentDataConnection = [PSCustomObject]@{ DoId = 42; DisplayName = "OISES"; FullName = "OISES - 42" }
+            }
+        }
+    )
+
+    $TabsPath = Join-Path $Script:RunTimeConfig.AppDataFolder -ChildPath "config\tabs.clixml"
+    New-Item -Path (Split-Path $TabsPath) -ItemType Directory -Force -ErrorAction SilentlyContinue | Out-Null
+    [PSCustomObject]@{
+        Tabs        = $TabConfigs
+        ActiveTabId = $TabConfigs[0].Id
+    } | Export-Clixml -Path $TabsPath -Force
+
+    return $TabConfigs
+}
+
+function script:Initialize-E2ERestoreRun {
+    <#
+    Puts the process-global startup switches back to what a fresh launch has, so Restore-TabSessions
+    behaves as it does on startup rather than inheriting a previous scenario's state.
+    #>
+    param(
+        [bool]$NoReconnect
+    )
+    $Script:RunTimeConfig.ResetRequested = $false
+    $Script:RunTimeConfig.NoReconnect = $NoReconnect
+    $Script:RunTimeConfig.ReconnectStatus = 0
+    Clear-E2EChoices
+    $script:E2ECalls.Clear()
+}
+
+E2ESuite -Name "NoReconnectStartup" -Body {
+    E2ECase -Name "restoring a persisted tab with -NoReconnect makes no request and leaves the tab disconnected" -Body {
+        Reset-E2ETabsToOne
+        New-E2EPersistedTabStore -TabCount 1 | Out-Null
+        Initialize-E2ERestoreRun -NoReconnect $true
+
+        Restore-TabSessions
+
+        E2EAssertEqual 0 (Get-E2EChoices -TitleLike "Reconnect?").Count "-NoReconnect must suppress the reconnect prompt (this part is by design)"
+        E2EAssertEqual 0 (Get-E2ECallCount) "restoring under -NoReconnect must not issue a single request to the tenant"
+
+        $RestoredTab = Get-ActiveTabSession
+        E2EAssertTrue ($RestoredTab.DisplayName -like "Persisted*") "the persisted tab should be the active tab after restore"
+        E2EAssertTrue (-not $Script:ConnectionStatus) "the restored tab must be disconnected"
+        E2EAssertEqual "Disconnected" ([string]$Script:MainForm.Elements.TextBlockStatusBarConnectionStatus.Text) "the status bar must read Disconnected"
+    }
+
+    E2ECase -Name "the schema push that runs when Monaco finishes loading does not connect a restored tab" -Body {
+        # The discriminating case for issue #64. Restore-TabSessions itself was already quiet; the
+        # connection was established afterwards, from Initialize-WebViewForTab's NavigationCompleted
+        # handler, which calls Get-SqlSchemaObject for every tab whose editor has just loaded. That
+        # handler is driven by real WebView2 navigation, so it is invoked directly here to make the
+        # assertion deterministic rather than dependent on WebView2 timing.
+        Reset-E2ETabsToOne
+        New-E2EPersistedTabStore -TabCount 1 | Out-Null
+        Initialize-E2ERestoreRun -NoReconnect $true
+
+        Restore-TabSessions
+
+        # ReconnectStatus is process-global and the navigation handler sets it to 3 as soon as ANY
+        # tab's editor has loaded - so reproduce that, since it is precisely the value that made the
+        # old ReconnectStatus -eq 1 gate useless.
+        $Script:RunTimeConfig.ReconnectStatus = 3
+        $script:E2ECalls.Clear()
+
+        Get-SqlSchemaObject
+
+        E2EAssertEqual 0 (Get-E2ECallCount) "Get-SqlSchemaObject must not request anything for a tab that is not connected"
+        E2EAssertTrue (-not $Script:ConnectionStatus) "the tab must still be disconnected after the navigation-completed schema push"
+    }
+
+    E2ECase -Name "declining the reconnect prompt shows the prompt and still connects nothing" -Body {
+        Reset-E2ETabsToOne
+        New-E2EPersistedTabStore -TabCount 1 | Out-Null
+        Initialize-E2ERestoreRun -NoReconnect $false
+        # Restore-TabSessions maps the right-hand button (1) to "do not reconnect".
+        $script:E2EChoiceReturn = 1
+
+        Restore-TabSessions
+
+        E2EAssertEqual 1 (Get-E2EChoices -TitleLike "Reconnect?").Count "without -NoReconnect the reconnect prompt must be shown"
+        E2EAssertEqual 0 (Get-E2ECallCount) "answering 'no' to the reconnect prompt must not issue a single request"
+
+        $Script:RunTimeConfig.ReconnectStatus = 3
+        Get-SqlSchemaObject
+        E2EAssertEqual 0 (Get-E2ECallCount) "the navigation-completed schema push must stay quiet after a declined reconnect"
+        E2EAssertTrue (-not $Script:ConnectionStatus) "the tab must remain disconnected after declining the prompt"
+        E2EAssertEqual "Disconnected" ([string]$Script:MainForm.Elements.TextBlockStatusBarConnectionStatus.Text) "the status bar must read Disconnected"
+    }
+
+    E2ECase -Name "accepting the reconnect prompt still connects the tab and retrieves its schema" -Body {
+        # The guard must not be a blanket 'never fetch': the accepted-reconnect path is the one that
+        # legitimately connects, and it must keep working.
+        Reset-E2ETabsToOne
+        New-E2EPersistedTabStore -TabCount 1 | Out-Null
+        Initialize-E2ERestoreRun -NoReconnect $false
+        $script:E2EChoiceReturn = 2
+
+        Restore-TabSessions
+
+        E2EAssertEqual 1 (Get-E2EChoices -TitleLike "Reconnect?").Count "the reconnect prompt should be shown"
+        E2EAssertTrue ($Script:ConnectionStatus) "accepting the prompt must connect the restored tab"
+        E2EAssertTrue ((Get-E2ECallCount) -ge 1) "an accepted reconnect is expected to talk to the tenant"
+        E2EAssertTrue ((Get-E2ECallCount -MethodLike "POST" -UriLike "*getsqlschema*") -ge 1) "a connected tab must still retrieve its SQL schema (the guard must not block the connect path)"
+    }
+}

--- a/tests/mock/Install-OmadaMockTransport.ps1
+++ b/tests/mock/Install-OmadaMockTransport.ps1
@@ -18,10 +18,30 @@ shim reads $script:OmadaMockBaseUrl at call time, so setting it after dot-sourci
 # Marker string asserted by MockAppEntry.ps1 to confirm the shadow actually took effect.
 $script:OmadaMockBaseUrl = $null
 
+# Every request the app makes reaches the mock instance through the shim below, so recording them
+# here gives a test an exact, complete picture of what did (or did not) hit the tenant. Tests that
+# assert a code path performs NO authenticated request read this log.
+$script:OmadaMockRequestLog = [System.Collections.Generic.List[object]]::new()
+
 function Install-OmadaMockTransport {
     [CmdletBinding()]
     param([string]$MockBaseUrl)
     $script:OmadaMockBaseUrl = $MockBaseUrl
+}
+
+function Clear-OmadaMockRequestLog {
+    [CmdletBinding()]
+    param()
+    $script:OmadaMockRequestLog.Clear()
+}
+
+function Get-OmadaMockRequestLog {
+    [CmdletBinding()]
+    param(
+        [string]$UriLike = "*",
+        [string]$MethodLike = "*"
+    )
+    return @($script:OmadaMockRequestLog | Where-Object { $_.Uri -like $UriLike -and $_.Method -like $MethodLike })
 }
 
 function script:Invoke-OmadaRestMethod {
@@ -49,6 +69,15 @@ function script:Invoke-OmadaRestMethod {
     }
 
     $HttpMethod = if ([string]::IsNullOrWhiteSpace($Method)) { "GET" } else { $Method.ToUpperInvariant() }
+
+    # Recorded before the call goes out, so a request that fails still counts as "the app talked to
+    # the tenant" - which is exactly what a zero-request assertion has to catch.
+    $script:OmadaMockRequestLog.Add([PSCustomObject]@{
+            Uri    = $TargetUri
+            Method = $HttpMethod
+            Body   = $Body
+        })
+
     $RequestParams = @{
         Uri     = $TargetUri
         Method  = $HttpMethod


### PR DESCRIPTION
Closes #64

## What broke

`-NoReconnect` (and a declined reconnect prompt) suppressed the prompt and the auto-connect, but the tab still authenticated against the tenant a moment later.

`Complete-TabMaterialization` correctly took its `else` branch and called `Set-SqlConnectionState -Status $false` (`src/Lib/Functions/Private/Complete-TabMaterialization.ps1:68`). It then called `Initialize-WebViewForTab`, whose `NavigationCompleted` handler called `Get-SqlSchemaObject` (`src/Lib/Functions/Private/Initialize-WebViewForTab.ps1:259` before this change) on the stated assumption that it "returns early when the tab is not connected yet".

**That guard did not exist.** `Get-SqlSchemaObject` (`src/Lib/Functions/Private/Get-SqlSchema.ps1:8-19` before this change) checked only:

- `$Script:RunTimeConfig.ReconnectStatus -eq 1` — process-global, and already `3` because the same navigation handler sets it (`Initialize-WebViewForTab.ps1:289`);
- `Test-ConnectionRequirements` — only verifies a URL and an authentication option are filled in (`src/Lib/Functions/Private/Test-ConnectionRequirements.ps1:6-12`), both of which a restored tab has;
- `$Script:AppConfig.CurrentDataConnection.DoId` — also restored from config.

It never consulted `$Script:ConnectionStatus`, so it fell through to `Invoke-OmadaPSWebRequestWrapper` (`Get-SqlSchema.ps1:44` before this change) and performed a real authenticated request.

A second, independent silent request on the same path: the WebView2 completion block called `Update-QueryList` unconditionally (`Initialize-WebViewForTab.ps1:107` before this change). That is another authenticated round-trip, and its tail unconditionally re-enables `ComboBoxSelectQuery`, `ButtonRefreshQueries`, the "my queries" checkboxes and `ButtonShowSqlSchema` (`src/Lib/Functions/Private/Update-QueryList.ps1:119-123`) — undoing the `Set-SqlQueryFunctionState -Status $false` that `Complete-TabMaterialization` had just applied. Without gating it too, "zero requests" is unachievable.

## What changed

| File | Change |
|---|---|
| `src/Lib/Functions/Private/Get-SqlSchema.ps1` | Added the missing `if (-not $Script:ConnectionStatus) { return }` guard, with a comment explaining why the three existing gates are not substitutes. |
| `src/Lib/Functions/Private/Set-SqlConnectionState.ps1` | Moved `$Script:ConnectionStatus = $true` to the **start** of the connected branch. It used to be set after the dropdown refreshes that branch performs, and those refreshes reach `Get-SqlSchemaObject` through `ComboBoxSelectDataConnection`'s `SelectionChanged` handler — with the flag still `$false`, the new guard would have silently killed the schema fetch on every connect. |
| `src/Lib/Functions/Private/Complete-TabMaterialization.ps1` | The auto-connect branch populates the data connection list *before* the connection is established (unlike the Connect button), so its `SelectionChanged`-driven schema fetch happens while the tab is still disconnected. Retrieve the schema explicitly after `Test-ConnectionSettings`, guarded on `$Script:ConnectionStatus`. |
| `src/Lib/Functions/Private/Initialize-WebViewForTab.ps1` | Gated `Update-QueryList` on `$Script:ConnectionStatus`; corrected the false comment above `Get-SqlSchemaObject`. |
| `tests/mock/Install-OmadaMockTransport.ps1` | The shim now records every request (`Get-OmadaMockRequestLog` / `Clear-OmadaMockRequestLog`), so a test can assert that **zero** requests reached the mock instance. |
| `tests/e2e/OmadaMocks.ps1`, `tests/e2e/Drivers.ps1` | The mocked `Open-ChoiceForm` records the dialogs it would have shown (`Get-E2EChoices`), so "the prompt was shown" is asserted as precisely as "it was not". |
| `tests/Get-SqlSchema.Tests.ps1` (new) | 4 unit tests. |
| `tests/e2e/scenarios/NoReconnect.ps1` (new) | 4 E2E scenarios driving the real startup restore path. |

**The shortcut generator is untouched.** `src/Lib/Functions/Public/Set-OmadaSqlTroubleshooterShortcut.ps1` does not appear in this diff at all: `-NoReconnect` stays in the generated `Run.ps1` and in the pwsh arguments, per the maintainer's scope decision on the issue, and no shortcut regeneration was added to `Test-Shortcut`.

## Acceptance criteria (from the maintainer's scope-decision comment)

- [x] **`Get-SqlSchemaObject` makes no request when the tab it runs for is not connected, guarding on the actual connection state rather than the process-global `ReconnectStatus`** — `src/Lib/Functions/Private/Get-SqlSchema.ps1:8-27`; proven by `Get-SqlSchemaObject connection guard.does not connect even though every pre-fix gate is satisfied`, which asserts all three old gates say "go" and still requires zero requests.
- [x] **The false comment in `Initialize-WebViewForTab.ps1` is corrected** — `src/Lib/Functions/Private/Initialize-WebViewForTab.ps1:262-268`.
- [x] **Persisted tab + `-NoReconnect`: the mock server receives zero requests and the tab shows `Disconnected`** — E2E `NoReconnectStartup :: restoring a persisted tab with -NoReconnect makes no request and leaves the tab disconnected` and `... the schema push that runs when Monaco finishes loading does not connect a restored tab`.
- [x] **Persisted tab, no `-NoReconnect`: the prompt is shown, and answering "no" also produces zero requests** — E2E `NoReconnectStartup :: declining the reconnect prompt shows the prompt and still connects nothing`.
- [x] **The shortcut generator is unchanged** — see the diff; `Set-OmadaSqlTroubleshooterShortcut.ps1` is not modified.

## Decisions worth reviewing

1. **`$Script:ConnectionStatus` is set earlier in `Set-SqlConnectionState`.** Necessary, not cosmetic: without it the new guard breaks every connect, because `Update-DataConnectionList` runs inside that branch and its `SelectionChanged` handler is what fetches the schema on connect. Checked that nothing between the old and new position reads the flag — the only handler that consults it is `ComboBoxSelectQuery`'s `DropDownOpened` (`src/Lib/Events/MainFormTabContent.Elements.ComboBoxSelectQuery.ps1:11`), a user gesture that never fires programmatically. Covered by the existing `SchemaCache` E2E suite, which asserts the schema is warm right after a connect.

2. **`Update-QueryList` is gated in the WebView2 completion block.** Strictly this is the *other* issue's UI symptom (the openable query dropdown, #65), but it is also a second authenticated request on the same startup path, so the "zero requests" criterion cannot be met without it. Gated here; #65 asserts the resulting UI consistency.

3. **`Complete-TabMaterialization` now fetches the schema explicitly.** The alternative was to reorder that branch so it connects before populating the dropdowns (matching the Connect button). That is a larger behavioural change to a path the existing `RestoreReconnect` scenario pins, so the explicit, guarded call was preferred. The regression is covered by `NoReconnectStartup :: accepting the reconnect prompt still connects the tab and retrieves its schema`, which failed before this line was added.

4. **`ReconnectStatus` was NOT moved onto the tab session.** Named as a contributing design flaw by both issues and explicitly out of scope. The per-tab gate did not need it: `$Script:ConnectionStatus` is already per-tab (`Set-ActiveTabContext.ps1:25,35`). No change was required there.

5. **"Zero requests" is asserted at the mock transport, not by parsing a server-side log.** The mock server serves from a background runspace and exposes no request log; the shim in `tests/mock/Install-OmadaMockTransport.ps1` is the single point every request passes through, and it records before the call goes out so a failing request still counts.

## Verification

```
pwsh -NoProfile -File build/build.ps1 -Task TestBuildOnly -BuildVersion 0.0.0
  -> Tests Passed: 317, Failed: 0, Skipped: 0   (PSScriptAnalyzer clean, build succeeded)

pwsh -NoProfile -File tests/e2e/Invoke-E2ESuite.ps1
  -> E2E result: 36 test(s), 0 failure(s)       (32 pre-existing + 4 new)
```

`buildoutput/` was deleted before the build so no stale results were read.

The new unit tests are discriminating: with the guard in `Get-SqlSchema.ps1` reverted and everything else in place, the run is `Tests Passed: 2, Failed: 2` — both zero-request assertions report `Expected 0, but got 1`.

The E2E suite is local-only by design (it needs OmadaWeb.PS, the WebView2 runtime and an STA desktop — see `tests/e2e/README.md`), so the four new scenarios are not part of headless PR CI; the four new Pester tests in `tests/Get-SqlSchema.Tests.ps1` are, and they run in PR validation because `Get-SqlSchema.ps1` is in the changed-file set.

## Relationship to the sibling issue

Issue #65 ("Switching to a not-yet-connected tab connects silently and leaves the tab in an in-between state") shares the unguarded schema push as its root cause, so this PR removes the silent connect there too. Its UI-consistency half — the status bar written by the transport while the button is driven by the state machine — is delivered separately in the stacked PR that closes #65, branched off this branch.
