### PR TITLE
Single-source the tab connection state so the UI cannot disagree with itself (#65)

### DIFF
--- a/src/Lib/Functions/Private/Complete-TabMaterialization.ps1
+++ b/src/Lib/Functions/Private/Complete-TabMaterialization.ps1
@@ -65,6 +65,16 @@ function Complete-TabMaterialization {
             }
             Test-ConnectionSettings
             Test-ConnectionButton
+
+            # Unlike the Connect button, this branch populates the data connection list BEFORE the
+            # connection is actually established, so the ComboBox SelectionChanged handler that
+            # normally fetches the schema runs while this tab still counts as disconnected - and
+            # Get-SqlSchemaObject now (correctly) refuses to request anything for a disconnected tab.
+            # Retrieve it here instead, once the tab really is connected, so an auto-connected
+            # restored tab still gets its IntelliSense schema.
+            if ($Script:ConnectionStatus) {
+                Get-SqlSchemaObject
+            }
         }
         else {
             Set-SqlConnectionState -Status $false

--- a/src/Lib/Functions/Private/Get-SqlSchema.ps1
+++ b/src/Lib/Functions/Private/Get-SqlSchema.ps1
@@ -9,6 +9,21 @@ function Get-SqlSchemaObject {
             return
         }
 
+        # Retrieving the schema is an authenticated round-trip, so it may only run for a tab that
+        # genuinely connected. $Script:ConnectionStatus is the active tab's own connection flag
+        # (Set-ActiveTabContext swaps it in and out per tab, Set-SqlConnectionState is its only
+        # writer), which is the state this guard must read. The checks below are not a substitute:
+        # $Script:RunTimeConfig.ReconnectStatus is process-global and is already 3 once any tab's
+        # editor has loaded, Test-ConnectionRequirements only verifies that a URL and an
+        # authentication option are filled in, and CurrentDataConnection.DoId is restored from
+        # config - a restored, deliberately disconnected tab satisfies all three. Without this the
+        # NavigationCompleted handler in Initialize-WebViewForTab.ps1 silently authenticated against
+        # the tenant, defeating -NoReconnect and a declined reconnect prompt alike.
+        if (-not $Script:ConnectionStatus) {
+            "Tab is not connected; skipping SQL schema retrieval." | Write-LogOutput -LogType DEBUG
+            return
+        }
+
         if (!(Test-ConnectionRequirements)) {
             "Connection not ready" | Write-LogOutput -LogType DEBUG
             return

--- a/src/Lib/Functions/Private/Initialize-WebViewForTab.ps1
+++ b/src/Lib/Functions/Private/Initialize-WebViewForTab.ps1
@@ -104,7 +104,19 @@ function Initialize-WebViewForTab {
                     }
 
                     Test-ConnectionButton
-                    Update-QueryList
+
+                    # Refreshing the query list is an authenticated round-trip AND it re-enables
+                    # ComboBoxSelectQuery / ButtonRefreshQueries / the "my queries" checkboxes
+                    # unconditionally at the end of Update-QueryList. Running it for a tab that was
+                    # deliberately left disconnected (a restored tab under -NoReconnect, or after a
+                    # declined reconnect prompt) therefore both connected to the tenant and undid the
+                    # Set-SqlQueryFunctionState -Status $false that Complete-TabMaterialization had
+                    # just applied - which is why such a tab showed an openable query dropdown next
+                    # to a Connect button. Only refresh it for a tab that genuinely connected.
+                    if ($Script:ConnectionStatus) {
+                        Update-QueryList
+                    }
+
                     Set-EditorValue
 
                     # These WebView2 event handlers fire independently, long after this completion
@@ -253,8 +265,11 @@ function Initialize-WebViewForTab {
                                     # duplicated tab, auto-connect) never received a setSchema push -
                                     # Invoke-ExecuteScriptAsync silently skips while the WebView is not
                                     # ready. Push it now so IntelliSense knows this database's tables and
-                                    # columns. Get-SqlSchemaObject returns early when the tab is not
-                                    # connected yet (the connect path pushes it instead) and serves the
+                                    # columns. Get-SqlSchemaObject checks $Script:ConnectionStatus and
+                                    # returns without any request when this tab is not connected (the
+                                    # guard the previous version of this comment claimed but that did
+                                    # not exist - the call authenticated against the tenant instead,
+                                    # even under -NoReconnect); for a connected tab it serves the
                                     # per-pool + per-database cache, so this is normally just the push.
                                     Get-SqlSchemaObject
 

--- a/src/Lib/Functions/Private/Invoke-OmadaPSWebRequestWrapper.ps1
+++ b/src/Lib/Functions/Private/Invoke-OmadaPSWebRequestWrapper.ps1
@@ -33,9 +33,14 @@ function Invoke-OmadaPSWebRequestWrapper {
             }
             "Parameters: {0}" -f (ConvertTo-RedactedLogString -InputObject $Private:Parameters) | Write-LogOutput -LogType VERBOSE
             $Private:Result = Invoke-OmadaRestMethod @Parameters
-            if ($null -ne $Script:MainForm -and $null -ne $Script:MainForm.Definitions -and $Script:MainForm.Definitions.IsVisible) {
-                $Script:MainForm.Definitions.TextBlockStatusBarConnectionStatus | Set-TextBlockText -Text "Connected"
-            }
+            # Deliberately no status-bar write here. A successful request is not the same thing as a
+            # connected tab: this transport is also used by probes and by work that runs while a tab
+            # is being connected, so writing "Connected" from here put the status bar ahead of - and
+            # sometimes in contradiction with - the rest of the UI, which is all derived from
+            # $Script:ConnectionStatus (Test-ConnectionButton for the button text,
+            # Set-SqlQueryFunctionState for the dropdowns and Display name). Connection state is
+            # single-sourced: Set-SqlConnectionState is the only writer of both the flag and the
+            # status bar text.
             "Result: {0}" -f (ConvertTo-RedactedLogString -InputObject $Private:Result) | Write-LogOutput -LogType VERBOSE
             $Script:RunTimeData.RestMethodParam.ForceAuthentication = $false
             return $Private:Result
@@ -47,12 +52,13 @@ function Invoke-OmadaPSWebRequestWrapper {
     catch {
         if (![string]::IsNullOrWhiteSpace($_.ErrorDetails?.Message) -and $_.ErrorDetails.Message -like "*Resource not found for the segment 'C_P_SQLTROUBLESHOOTING'*") {
             $Message = "OData Endpoint for SQL Troubleshooting not enabled at tenant {0}.`n`r`n`rError returned by Omada:`n`r`n`r{1}" -f [system.uri]::New($Script:AppConfig.BaseUrl).Host, $_.ErrorDetails.Message
-            if ($null -ne $Script:MainForm -and $null -ne $Script:MainForm.Definitions -and $Script:MainForm.Definitions.IsVisible) {
-                $Script:MainForm.Elements.TextBlockStatusBarConnectionStatus | Set-TextBlockText -Text "Disconnected"
-                $Script:MainForm.Elements.TextBlockStatusBarDatabaseName | Set-TextBlockText -Text "-"
-                $Script:MainForm.Elements.TextBlockStatusBarUrl | Set-TextBlockText -Text "-"
-                $Script:MainForm.Elements.TextBlockStatusBarQueryTime | Set-TextBlockText -Text "00:00:00.0000000"
-            }
+            # Route the teardown through the state function, exactly as the Unauthorized branch below
+            # already does. This used to hand-write four status-bar fields while leaving
+            # $Script:ConnectionStatus untouched, so the button, the dropdowns and the Display name
+            # went on claiming the tab was connected. (The writes were in fact unreachable: the guard
+            # tested $Script:MainForm.Definitions, which does not exist - the member is Definition -
+            # so the status bar was never even updated on this error.)
+            Set-SqlConnectionState -Status $false
             $Message | Write-Error -ErrorAction Stop -TargetObject $_
             $Script:RunTimeData.SkipRetryRequest = $true
         }

--- a/src/Lib/Functions/Private/Set-SqlConnectionState.ps1
+++ b/src/Lib/Functions/Private/Set-SqlConnectionState.ps1
@@ -8,6 +8,16 @@ function Set-SqlConnectionState {
 
         Set-SqlQueryFunctionState -Status $Status
         if ($Status) {
+            # Flip the active tab's connection flag FIRST, before the dropdown refreshes below. Those
+            # refreshes are part of the connect sequence and reach connected-only work (for example
+            # Update-DataConnectionList selects an item, whose SelectionChanged handler calls
+            # Get-SqlSchemaObject), and Get-SqlSchemaObject now refuses to run for a tab that is not
+            # connected. Setting the flag at the end of this branch - as it used to be - would make
+            # the connect path look disconnected to its own follow-up work and silently drop the
+            # schema fetch. $Script:ConnectionStatus is not read by anything between here and its old
+            # position: the only handler that consults it is ComboBoxSelectQuery's DropDownOpened,
+            # which is a user gesture and never fires programmatically.
+            $Script:ConnectionStatus = $true
             $Script:MainForm.Elements.ButtonReset.IsEnabled = $true
             $Script:MainForm.Elements.ComboBoxSelectAuthenticationOption.IsEnabled = $false
             $Script:MainForm.Elements.TextBoxUserName.IsEnabled = $false
@@ -34,7 +44,6 @@ function Set-SqlConnectionState {
                     $ConnectingWindow.Close()
                 }
             }
-            $Script:ConnectionStatus = $true
             # The window title is refreshed from the active tab by Update-TabHeaderTitle below
             # (-> Update-ApplicationTitle), so it stays in the new "<name> - <connection> - <tenant>"
             # format instead of being set to the old app-title-plus-tenant string here.

--- a/src/Lib/Functions/Private/Update-QueryList.ps1
+++ b/src/Lib/Functions/Private/Update-QueryList.ps1
@@ -14,6 +14,20 @@ function Update-QueryList {
             return
         }
 
+        # This function ends by unconditionally enabling ComboBoxSelectQuery, ButtonRefreshQueries,
+        # the "my queries" checkboxes and ButtonShowSqlSchema - the exact controls
+        # Set-SqlQueryFunctionState -Status $false had just cleared and disabled for a disconnected
+        # tab. Called for such a tab it therefore both authenticated against the tenant and left the
+        # query dropdown openable next to a "Connect" button, which is the in-between state reported
+        # in issue #65. Connection state is single-sourced on $Script:ConnectionStatus (the active
+        # tab's own flag), so refuse here rather than relying on every call site to remember.
+        # Test-ConnectionRequirements below is not a substitute: it only checks that a URL and an
+        # authentication option are filled in, which stays true for a tab that never connected.
+        if (-not $Script:ConnectionStatus) {
+            "Tab is not connected; skipping query list refresh." | Write-LogOutput -LogType DEBUG
+            return
+        }
+
         if (!(Test-ConnectionRequirements)) {
             "Connection not ready" | Write-LogOutput -LogType DEBUG
             return

--- a/tests/Get-SqlSchema.Tests.ps1
+++ b/tests/Get-SqlSchema.Tests.ps1
@@ -1,0 +1,152 @@
+#Requires -Version 7.0
+# Regression tests for issue #64: Get-SqlSchemaObject must not authenticate against the tenant for a
+# tab that is not connected. It runs from the WebView2 NavigationCompleted handler for EVERY tab that
+# loads its Monaco editor - including a restored tab that was deliberately left disconnected by
+# -NoReconnect or by a declined reconnect prompt - so an unguarded call there is a silent connect.
+#
+# The request path is exercised end to end through the REAL Invoke-OmadaPSWebRequestWrapper and the
+# mock transport shim against a running mock Omada instance, so "zero requests" means zero requests
+# actually reached the mock, not "a stub was not called".
+
+BeforeAll {
+    $ParentPath = Split-Path -Path $PSScriptRoot -Parent
+    $PrivatePath = Join-Path $ParentPath -ChildPath "src\Lib\Functions\Private"
+
+    . (Join-Path $PrivatePath -ChildPath "ConvertTo-RedactedLogString.ps1")
+    . (Join-Path $PrivatePath -ChildPath "Test-ConnectionRequirements.ps1")
+    . (Join-Path $PrivatePath -ChildPath "Invoke-OmadaPSWebRequestWrapper.ps1")
+    . (Join-Path $PrivatePath -ChildPath "Get-SqlSchema.ps1")
+
+    . (Join-Path $PSScriptRoot -ChildPath "mock\OmadaMockRouter.ps1")
+    . (Join-Path $PSScriptRoot -ChildPath "mock\OmadaMockServer.ps1")
+    . (Join-Path $PSScriptRoot -ChildPath "mock\Install-OmadaMockTransport.ps1")
+
+    $script:Handle = New-OmadaMockServerHandle -BindAddress "127.0.0.1" -Port 0
+    Install-OmadaMockTransport -MockBaseUrl $script:Handle.BaseUrl
+
+    # --- Stubs for everything outside the function under test --------------------------------------
+    $Script:Tracer = [System.Diagnostics.Trace]
+
+    function Write-LogOutput {
+        param(
+            [Parameter(ValueFromPipeline = $true)]$InputObject,
+            [string]$LogType,
+            $ErrorObject,
+            [switch]$SkipDialog
+        )
+        process { }
+    }
+
+    # The real wrapper suspends the WebView2 completion poll timer around every call; there is no
+    # timer here, so both ends are no-ops. Without them the wrapper would throw CommandNotFound and
+    # a "no request was made" assertion would pass for the wrong reason.
+    function Suspend-WebViewCompletionPolling { }
+
+    function Resume-WebViewCompletionPolling { }
+
+    # The editor push seam. Recorded rather than executed so the connected case can be proven to
+    # have reached setSchema(...).
+    $script:PushedEditorScripts = [System.Collections.Generic.List[string]]::new()
+
+    function Invoke-ExecuteScriptAsync {
+        param(
+            $ScriptToExecute,
+            $OnCompletedScriptBlock
+        )
+        $script:PushedEditorScripts.Add([string]$ScriptToExecute)
+    }
+
+    function Initialize-SchemaTestState {
+        <#
+        Puts the module-scope state into the shape a RESTORED tab has: a tenant URL and an
+        authentication option filled in, a data connection DoId carried over from config, and
+        ReconnectStatus already at 3 (the NavigationCompleted handler sets it there as soon as any
+        tab's editor has loaded). Every gate Get-SqlSchemaObject had BEFORE the fix is therefore
+        satisfied - the connection flag is the only thing that separates the two cases.
+        #>
+        param(
+            [bool]$Connected
+        )
+
+        $Script:RunTimeConfig = [PSCustomObject]@{ ApplicationName = "Test"; ReconnectStatus = 3 }
+        $Script:AppConfig = [PSCustomObject]@{
+            BaseUrl               = "https://tenant.omada.cloud"
+            CurrentDataConnection = [PSCustomObject]@{ DoId = "1001572"; FullName = "OISES - 1001572" }
+        }
+        $Script:RunTimeData = @{
+            SkipRetryRequest = $false
+            SqlQueryObject   = $null
+            RestMethodParam  = @{
+                SessionKey          = "pool-under-test"
+                AuthenticationType  = "Browser"
+                ForceAuthentication = $false
+            }
+        }
+        $Script:MainForm = @{
+            Elements = @{
+                TextBoxURL                          = [PSCustomObject]@{ Text = "https://tenant.omada.cloud" }
+                ComboBoxSelectAuthenticationOption  = [PSCustomObject]@{ SelectedItem = [PSCustomObject]@{ Content = "Browser" } }
+            }
+        }
+        # No schema window in these tests: Get-SqlSchemaObject must skip the TreeView/title work and
+        # still push to the editor.
+        $Script:SqlSchemaForm = $null
+        $Script:TreeViewSqlSchema = $null
+        $Script:SqlSchemaCache = @{}
+        $Script:ConnectionStatus = $Connected
+
+        $script:PushedEditorScripts.Clear()
+        Clear-OmadaMockRequestLog
+    }
+}
+
+AfterAll {
+    if ($null -ne $script:Handle) { Stop-OmadaMockServerHandle -Handle $script:Handle }
+}
+
+Describe "Get-SqlSchemaObject connection guard" {
+    It "makes no request at all when the tab is not connected" {
+        Initialize-SchemaTestState -Connected $false
+
+        Get-SqlSchemaObject
+
+        (Get-OmadaMockRequestLog).Count | Should -Be 0
+        $script:PushedEditorScripts.Count | Should -Be 0
+    }
+
+    It "does not connect even though every pre-fix gate is satisfied" {
+        Initialize-SchemaTestState -Connected $false
+
+        # Discriminating: these are exactly the three conditions the function used to rely on. All
+        # three say "go", and the request must still not happen.
+        $Script:RunTimeConfig.ReconnectStatus | Should -Not -Be 1
+        Test-ConnectionRequirements | Should -BeTrue
+        $Script:AppConfig.CurrentDataConnection.DoId | Should -Not -BeNullOrEmpty
+
+        Get-SqlSchemaObject
+
+        (Get-OmadaMockRequestLog -UriLike "*GetSqlSchema*").Count | Should -Be 0
+    }
+
+    It "retrieves the schema and pushes it to the editor when the tab is connected" {
+        Initialize-SchemaTestState -Connected $true
+
+        Get-SqlSchemaObject
+
+        (Get-OmadaMockRequestLog -UriLike "*GetSqlSchema*" -MethodLike "POST").Count | Should -Be 1
+
+        $SetSchema = $script:PushedEditorScripts | Where-Object { $_ -like "setSchema(*" } | Select-Object -Last 1
+        $SetSchema | Should -Not -BeNullOrEmpty
+        $SetSchema | Should -BeLike "*nvarchar*"
+    }
+
+    It "serves a second connected call from the per-pool cache without another request" {
+        Initialize-SchemaTestState -Connected $true
+
+        Get-SqlSchemaObject
+        Clear-OmadaMockRequestLog
+        Get-SqlSchemaObject
+
+        (Get-OmadaMockRequestLog).Count | Should -Be 0
+    }
+}

--- a/tests/Invoke-OmadaPSWebRequestWrapper.Tests.ps1
+++ b/tests/Invoke-OmadaPSWebRequestWrapper.Tests.ps1
@@ -1,0 +1,142 @@
+#Requires -Version 7.0
+# Regression tests for issue #65: connection state must be single-sourced.
+#
+# The transport used to write the status bar to "Connected" on every successful request while
+# $Script:ConnectionStatus - which drives the Connect button (Test-ConnectionButton), the dropdowns
+# and the Display name (Set-SqlQueryFunctionState) - stayed $false. That is how a tab ended up
+# showing "Connected" in the status bar next to a "Connect" button.
+#
+# Note on the fixture below: the original guard tested $Script:MainForm.Definitions, a member that
+# does not exist anywhere in the app (the real member is Definition), so the write was unreachable
+# in practice. These tests deliberately expose BOTH spellings, backed by the same visible-window
+# stub, so the assertion is "this function writes the status bar through NO spelling of that path"
+# rather than "the typo is still there" - and so it fails against the pre-fix code.
+
+BeforeAll {
+    $ParentPath = Split-Path -Path $PSScriptRoot -Parent
+    $PrivatePath = Join-Path $ParentPath -ChildPath "src\Lib\Functions\Private"
+
+    . (Join-Path $PrivatePath -ChildPath "ConvertTo-RedactedLogString.ps1")
+    . (Join-Path $PrivatePath -ChildPath "Set-TextBlockText.ps1")
+    . (Join-Path $PrivatePath -ChildPath "Invoke-OmadaPSWebRequestWrapper.ps1")
+
+    $Script:Tracer = [System.Diagnostics.Trace]
+
+    function Write-LogOutput {
+        param(
+            [Parameter(ValueFromPipeline = $true)]$InputObject,
+            [string]$LogType,
+            $ErrorObject,
+            [switch]$SkipDialog
+        )
+        process { }
+    }
+
+    function Suspend-WebViewCompletionPolling { }
+
+    function Resume-WebViewCompletionPolling { }
+
+    # The single network seam. Behaviour per test is steered by $script:RestMethodBehaviour.
+    function Invoke-OmadaRestMethod {
+        [CmdletBinding()]
+        param(
+            [Parameter(ValueFromRemainingArguments = $true)]$IgnoredRest
+        )
+        if ($script:RestMethodBehaviour -eq "ODataMissing") {
+            $ErrorRecord = [System.Management.Automation.ErrorRecord]::new(
+                [System.Exception]::new("odata failure"), "OmadaODataMissing",
+                [System.Management.Automation.ErrorCategory]::InvalidOperation, $null)
+            $ErrorRecord.ErrorDetails = [System.Management.Automation.ErrorDetails]::new(
+                "Resource not found for the segment 'C_P_SQLTROUBLESHOOTING'.")
+            throw $ErrorRecord
+        }
+        return [PSCustomObject]@{ value = @([PSCustomObject]@{ Id = 100; DisplayName = "TestQuery" }) }
+    }
+
+    # Records how the state machine was driven, instead of touching a real WPF tree.
+    $script:ConnectionStateCalls = [System.Collections.Generic.List[object]]::new()
+
+    function Set-SqlConnectionState {
+        param(
+            [bool]$Status = $true
+        )
+        $script:ConnectionStateCalls.Add($Status)
+    }
+
+    function Initialize-WrapperTestState {
+        $Script:RunTimeConfig = [PSCustomObject]@{ ApplicationName = "Test"; UseWebView2Auth = $false }
+        $Script:AppConfig = [PSCustomObject]@{ BaseUrl = "https://tenant.omada.cloud" }
+        $Script:RunTimeData = @{
+            SkipRetryRequest = $false
+            RestMethodParam  = @{
+                Uri                 = "https://tenant.omada.cloud/odata/dataobjects/C_P_SQLTROUBLESHOOTING"
+                Method              = "GET"
+                Body                = $null
+                AuthenticationType  = "Browser"
+                ForceAuthentication = $false
+            }
+        }
+
+        $StatusBarElements = @{
+            TextBlockStatusBarConnectionStatus = [PSCustomObject]@{ Name = "TextBlockStatusBarConnectionStatus"; Text = "Disconnected" }
+            TextBlockStatusBarDatabaseName     = [PSCustomObject]@{ Name = "TextBlockStatusBarDatabaseName"; Text = "-" }
+            TextBlockStatusBarUrl              = [PSCustomObject]@{ Name = "TextBlockStatusBarUrl"; Text = "-" }
+            TextBlockStatusBarQueryTime        = [PSCustomObject]@{ Name = "TextBlockStatusBarQueryTime"; Text = "00:00:00.0000000" }
+        }
+        # Both spellings point at the same visible window/element bag - see the note at the top.
+        $VisibleWindow = [PSCustomObject]@{ IsVisible = $true }
+        $StatusBarElements.Keys | ForEach-Object {
+            $VisibleWindow | Add-Member -NotePropertyName $_ -NotePropertyValue $StatusBarElements[$_]
+        }
+        $Script:MainForm = @{
+            Definition  = $VisibleWindow
+            Definitions = $VisibleWindow
+            Elements    = $StatusBarElements
+        }
+
+        # The tab is NOT connected: the whole point is that a successful request must not change that.
+        $Script:ConnectionStatus = $false
+        $script:ConnectionStateCalls.Clear()
+        $script:RestMethodBehaviour = "Success"
+    }
+}
+
+Describe "Invoke-OmadaPSWebRequestWrapper connection state" {
+    It "returns the response of a successful request" {
+        Initialize-WrapperTestState
+
+        $Result = Invoke-OmadaPSWebRequestWrapper
+
+        $Result.value[0].DisplayName | Should -Be "TestQuery"
+    }
+
+    It "does not flip the status bar to Connected on a successful request" {
+        Initialize-WrapperTestState
+
+        Invoke-OmadaPSWebRequestWrapper | Out-Null
+
+        $Script:MainForm.Elements.TextBlockStatusBarConnectionStatus.Text | Should -Be "Disconnected"
+        $Script:MainForm.Definition.TextBlockStatusBarConnectionStatus.Text | Should -Be "Disconnected"
+    }
+
+    It "does not change the connection flag on a successful request" {
+        Initialize-WrapperTestState
+
+        Invoke-OmadaPSWebRequestWrapper | Out-Null
+
+        $Script:ConnectionStatus | Should -BeFalse
+        $script:ConnectionStateCalls.Count | Should -Be 0
+    }
+
+    It "tears a tab down through Set-SqlConnectionState when the OData endpoint is missing" {
+        Initialize-WrapperTestState
+        $script:RestMethodBehaviour = "ODataMissing"
+
+        { Invoke-OmadaPSWebRequestWrapper } | Should -Throw
+
+        # Not four hand-written status-bar fields with the flag left untouched: one call into the
+        # state machine, which updates button, status bar, dropdowns and Display name together.
+        $script:ConnectionStateCalls.Count | Should -Be 1
+        $script:ConnectionStateCalls[0] | Should -BeFalse
+    }
+}

--- a/tests/Update-QueryList.Tests.ps1
+++ b/tests/Update-QueryList.Tests.ps1
@@ -13,6 +13,13 @@
 # against a running mock instance, so "no request" is measured, not stubbed.
 
 BeforeAll {
+    # Update-QueryList builds real System.Windows.Controls.ComboBoxItem objects for each query it
+    # retrieves. That type lives in PresentationFramework, which a headless CI pwsh does not load on
+    # its own - without this the connected-path run throws inside the function's own catch and
+    # silently adds nothing (it passes locally, where the assembly is already loaded, and fails in
+    # CI). Mirrors the Add-Type in Update-SqlSchemaTreeFilter.Tests.ps1.
+    Add-Type -AssemblyName PresentationFramework
+
     $ParentPath = Split-Path -Path $PSScriptRoot -Parent
     $PrivatePath = Join-Path $ParentPath -ChildPath "src\Lib\Functions\Private"
 

--- a/tests/Update-QueryList.Tests.ps1
+++ b/tests/Update-QueryList.Tests.ps1
@@ -1,0 +1,154 @@
+#Requires -Version 7.0
+# Regression tests for issue #65's second half: the query dropdown was openable on a tab the UI
+# otherwise presented as disconnected.
+#
+# Pinned down rather than guessed: Update-QueryList ends by unconditionally setting
+# ComboBoxSelectQuery, ButtonRefreshQueries, both "my queries" checkboxes and ButtonShowSqlSchema to
+# IsEnabled = $true (src/Lib/Functions/Private/Update-QueryList.ps1, tail of the function). The
+# WebView2 completion block in Initialize-WebViewForTab called it for EVERY tab whose editor
+# finished loading, so for a restored tab it undid the Set-SqlQueryFunctionState -Status $false that
+# Complete-TabMaterialization had just applied - and issued an authenticated request on the way.
+#
+# The request path runs through the real Invoke-OmadaPSWebRequestWrapper and the mock transport
+# against a running mock instance, so "no request" is measured, not stubbed.
+
+BeforeAll {
+    $ParentPath = Split-Path -Path $PSScriptRoot -Parent
+    $PrivatePath = Join-Path $ParentPath -ChildPath "src\Lib\Functions\Private"
+
+    . (Join-Path $PrivatePath -ChildPath "ConvertTo-RedactedLogString.ps1")
+    . (Join-Path $PrivatePath -ChildPath "Test-ConnectionRequirements.ps1")
+    . (Join-Path $PrivatePath -ChildPath "Invoke-OmadaPSWebRequestWrapper.ps1")
+    . (Join-Path $PrivatePath -ChildPath "Update-QueryList.ps1")
+
+    . (Join-Path $PSScriptRoot -ChildPath "mock\OmadaMockRouter.ps1")
+    . (Join-Path $PSScriptRoot -ChildPath "mock\OmadaMockServer.ps1")
+    . (Join-Path $PSScriptRoot -ChildPath "mock\Install-OmadaMockTransport.ps1")
+
+    $script:Handle = New-OmadaMockServerHandle -BindAddress "127.0.0.1" -Port 0
+    Install-OmadaMockTransport -MockBaseUrl $script:Handle.BaseUrl
+
+    $Script:Tracer = [System.Diagnostics.Trace]
+
+    function Write-LogOutput {
+        param(
+            [Parameter(ValueFromPipeline = $true)]$InputObject,
+            [string]$LogType,
+            $ErrorObject,
+            [switch]$SkipDialog
+        )
+        process { }
+    }
+
+    function Suspend-WebViewCompletionPolling { }
+
+    function Resume-WebViewCompletionPolling { }
+
+    function Set-SqlConnectionState {
+        param([bool]$Status = $true)
+    }
+
+    function Set-EditorValue { }
+
+    function Show-PopupWindow {
+        param($Message)
+        return $null
+    }
+
+    function Get-SqlTroubleShooterView { return $null }
+
+    function New-QueryControlStub {
+        <#
+        The controls Set-SqlQueryFunctionState -Status $false leaves behind for a disconnected tab:
+        emptied and disabled. A plain object stands in for the WPF control so the test is
+        headless-safe; only Items/IsEnabled/Text are touched here.
+        #>
+        return [PSCustomObject]@{
+            IsEnabled = $false
+            Items     = [System.Collections.ArrayList]::new()
+            Text      = $null
+        }
+    }
+
+    function Initialize-QueryListTestState {
+        param(
+            [bool]$Connected
+        )
+
+        $Script:RunTimeConfig = [PSCustomObject]@{ ApplicationName = "Test"; ReconnectStatus = 3 }
+        $Script:AppConfig = [PSCustomObject]@{
+            BaseUrl              = "https://tenant.omada.cloud"
+            MyCreatedQueriesOnly = $false
+            MyUpdatedQueriesOnly = $false
+            IdentityUserName     = $null
+        }
+        $Script:RunTimeData = @{
+            SkipRetryRequest              = $false
+            QueryListCache                = @{ QueryList = @(); LastRefresh = [datetime]::MinValue; TTL = 300 }
+            CurrentSqlQuery               = [PSCustomObject]@{ DoId = $null; DisplayName = $null; FullName = $null }
+            DataobjdlgAspxAttributeMapping = [PSCustomObject]@{
+                SqlQueryCreatedBy = "CreatedBy"
+                SqlQueryChangedBy = "ChangedBy"
+                SqlQueryDoId      = "DoId"
+            }
+            RestMethodParam               = @{
+                SessionKey          = "pool-under-test"
+                AuthenticationType  = "Browser"
+                ForceAuthentication = $false
+            }
+        }
+        $Script:MainForm = @{
+            Elements = @{
+                TextBoxURL                         = [PSCustomObject]@{ Text = "https://tenant.omada.cloud" }
+                ComboBoxSelectAuthenticationOption = [PSCustomObject]@{ SelectedItem = [PSCustomObject]@{ Content = "Browser" } }
+                ComboBoxSelectQuery                = New-QueryControlStub
+                ButtonRefreshQueries               = New-QueryControlStub
+                CheckboxMyCreatedQueries           = New-QueryControlStub
+                CheckboxMyUpdatedQueries           = New-QueryControlStub
+                ButtonShowSqlSchema                = New-QueryControlStub
+                TextBoxDisplayName                 = New-QueryControlStub
+            }
+        }
+        $Script:ConnectionStatus = $Connected
+
+        Clear-OmadaMockRequestLog
+    }
+}
+
+AfterAll {
+    if ($null -ne $script:Handle) { Stop-OmadaMockServerHandle -Handle $script:Handle }
+}
+
+Describe "Update-QueryList connection guard" {
+    It "makes no request when the tab is not connected" {
+        Initialize-QueryListTestState -Connected $false
+
+        Update-QueryList
+
+        (Get-OmadaMockRequestLog).Count | Should -Be 0
+    }
+
+    It "leaves the query controls disabled for a tab that is not connected" {
+        Initialize-QueryListTestState -Connected $false
+
+        Update-QueryList
+
+        # The in-between state from issue #65: an openable query dropdown next to a Connect button.
+        $Script:MainForm.Elements.ComboBoxSelectQuery.IsEnabled | Should -BeFalse
+        $Script:MainForm.Elements.ButtonRefreshQueries.IsEnabled | Should -BeFalse
+        $Script:MainForm.Elements.CheckboxMyCreatedQueries.IsEnabled | Should -BeFalse
+        $Script:MainForm.Elements.CheckboxMyUpdatedQueries.IsEnabled | Should -BeFalse
+        $Script:MainForm.Elements.ButtonShowSqlSchema.IsEnabled | Should -BeFalse
+    }
+
+    It "refreshes and enables the query controls for a connected tab" {
+        Initialize-QueryListTestState -Connected $true
+
+        Update-QueryList
+
+        (Get-OmadaMockRequestLog -UriLike "*C_P_SQLTROUBLESHOOTING*").Count | Should -Be 1
+        $Script:MainForm.Elements.ComboBoxSelectQuery.Items.Count | Should -BeGreaterThan 0
+        $Script:MainForm.Elements.ComboBoxSelectQuery.IsEnabled | Should -BeTrue
+        $Script:MainForm.Elements.ButtonRefreshQueries.IsEnabled | Should -BeTrue
+    }
+}

--- a/tests/e2e/Drivers.ps1
+++ b/tests/e2e/Drivers.ps1
@@ -59,6 +59,7 @@ function script:Reset-E2EScenario {
     $script:E2EConnectionProbeError = $null
     $script:E2EFixtureOverride = $null
     $script:E2EChoiceReturn = $null
+    $script:E2EChoices.Clear()
 }
 
 function script:Reset-E2EConnection {
@@ -169,6 +170,17 @@ function script:Get-E2ECallCount {
             $_.Method -like $MethodLike -and $_.Uri -like $UriLike -and
             ($null -eq $DataType -or $_.DataType -eq $DataType)
         }).Count
+}
+
+function script:Clear-E2EChoices {
+    $script:E2EChoices.Clear()
+}
+
+function script:Get-E2EChoices {
+    param(
+        [string]$TitleLike = "*"
+    )
+    return @($script:E2EChoices | Where-Object { $_.Title -like $TitleLike })
 }
 
 function script:Clear-E2EPopups {

--- a/tests/e2e/OmadaMocks.ps1
+++ b/tests/e2e/OmadaMocks.ps1
@@ -64,6 +64,10 @@ function script:Push-ToEditor {
 }
 
 # --- Popup neutralizers so nothing enters a nested WPF message pump --------------------------------
+# Every choice dialog the app would have shown is recorded, so a scenario can assert that the
+# reconnect prompt WAS shown (issue #64) as precisely as it asserts that it was not.
+$script:E2EChoices = [System.Collections.Generic.List[object]]::new()
+
 function script:Open-ChoiceForm {
     param(
         $Title,
@@ -73,6 +77,7 @@ function script:Open-ChoiceForm {
         $LeftButtonReturnValue = $true,
         $RightButtonReturnValue = $false
     )
+    $script:E2EChoices.Add([PSCustomObject]@{ Title = [string]$Title; Message = [string]$Message })
     if ($null -ne $script:E2EChoiceReturn) {
         return $script:E2EChoiceReturn
     }

--- a/tests/e2e/scenarios/NoReconnect.ps1
+++ b/tests/e2e/scenarios/NoReconnect.ps1
@@ -1,0 +1,144 @@
+# Issue #64: "-NoReconnect does not prevent connecting - the tab connects anyway via the unguarded
+# schema push". These scenarios drive the REAL startup restore path (Restore-TabSessions ->
+# New-TabSession -Deferred -> Complete-TabMaterialization -> Initialize-WebViewForTab) against a
+# persisted tab store, and assert on the call recorder that NOTHING reached the tenant.
+#
+# The Start menu shortcut keeping -NoReconnect is by design (see the maintainer's scope decision on
+# the issue), so what is under test here is only the second half: that -NoReconnect - and a declined
+# reconnect prompt - really means "no connection is made on startup at all".
+
+function script:New-E2EPersistedTabStore {
+    <#
+    Writes a tabs.clixml into the run's throwaway AppData folder, in exactly the shape
+    Save-TabSessions produces, so Restore-TabSessions restores real persisted tabs. Built here
+    rather than via Save-TabSessions so the store's contents are deterministic and independent of
+    whatever the previous scenario left in the live tabs.
+    #>
+    param(
+        [int]$TabCount = 1,
+        [string]$Url = "https://tenant.omada.cloud",
+        [string]$Auth = "Browser"
+    )
+
+    $TabConfigs = @(
+        1..$TabCount | ForEach-Object {
+            [PSCustomObject]@{
+                Id                    = ([guid]::NewGuid().Guid)
+                DisplayName           = "Persisted{0}" -f $_
+                BaseUrl               = $Url
+                CurrentSqlQuery       = [PSCustomObject]@{ DoId = 100; DisplayName = "TestQuery"; FullName = "TestQuery - 100" }
+                LastAuthentication    = $Auth
+                UserName              = $null
+                Password              = $null
+                EntraApplicationIdUri = $null
+                EntraIdTenantId       = $null
+                MyCreatedQueriesOnly  = $false
+                MyUpdatedQueriesOnly  = $false
+                SavePassword          = $false
+                IdentityUserName      = $null
+                CurrentDataConnection = [PSCustomObject]@{ DoId = 42; DisplayName = "OISES"; FullName = "OISES - 42" }
+            }
+        }
+    )
+
+    $TabsPath = Join-Path $Script:RunTimeConfig.AppDataFolder -ChildPath "config\tabs.clixml"
+    New-Item -Path (Split-Path $TabsPath) -ItemType Directory -Force -ErrorAction SilentlyContinue | Out-Null
+    [PSCustomObject]@{
+        Tabs        = $TabConfigs
+        ActiveTabId = $TabConfigs[0].Id
+    } | Export-Clixml -Path $TabsPath -Force
+
+    return $TabConfigs
+}
+
+function script:Initialize-E2ERestoreRun {
+    <#
+    Puts the process-global startup switches back to what a fresh launch has, so Restore-TabSessions
+    behaves as it does on startup rather than inheriting a previous scenario's state.
+    #>
+    param(
+        [bool]$NoReconnect
+    )
+    $Script:RunTimeConfig.ResetRequested = $false
+    $Script:RunTimeConfig.NoReconnect = $NoReconnect
+    $Script:RunTimeConfig.ReconnectStatus = 0
+    Clear-E2EChoices
+    $script:E2ECalls.Clear()
+}
+
+E2ESuite -Name "NoReconnectStartup" -Body {
+    E2ECase -Name "restoring a persisted tab with -NoReconnect makes no request and leaves the tab disconnected" -Body {
+        Reset-E2ETabsToOne
+        New-E2EPersistedTabStore -TabCount 1 | Out-Null
+        Initialize-E2ERestoreRun -NoReconnect $true
+
+        Restore-TabSessions
+
+        E2EAssertEqual 0 (Get-E2EChoices -TitleLike "Reconnect?").Count "-NoReconnect must suppress the reconnect prompt (this part is by design)"
+        E2EAssertEqual 0 (Get-E2ECallCount) "restoring under -NoReconnect must not issue a single request to the tenant"
+
+        $RestoredTab = Get-ActiveTabSession
+        E2EAssertTrue ($RestoredTab.DisplayName -like "Persisted*") "the persisted tab should be the active tab after restore"
+        E2EAssertTrue (-not $Script:ConnectionStatus) "the restored tab must be disconnected"
+        E2EAssertEqual "Disconnected" ([string]$Script:MainForm.Elements.TextBlockStatusBarConnectionStatus.Text) "the status bar must read Disconnected"
+    }
+
+    E2ECase -Name "the schema push that runs when Monaco finishes loading does not connect a restored tab" -Body {
+        # The discriminating case for issue #64. Restore-TabSessions itself was already quiet; the
+        # connection was established afterwards, from Initialize-WebViewForTab's NavigationCompleted
+        # handler, which calls Get-SqlSchemaObject for every tab whose editor has just loaded. That
+        # handler is driven by real WebView2 navigation, so it is invoked directly here to make the
+        # assertion deterministic rather than dependent on WebView2 timing.
+        Reset-E2ETabsToOne
+        New-E2EPersistedTabStore -TabCount 1 | Out-Null
+        Initialize-E2ERestoreRun -NoReconnect $true
+
+        Restore-TabSessions
+
+        # ReconnectStatus is process-global and the navigation handler sets it to 3 as soon as ANY
+        # tab's editor has loaded - so reproduce that, since it is precisely the value that made the
+        # old ReconnectStatus -eq 1 gate useless.
+        $Script:RunTimeConfig.ReconnectStatus = 3
+        $script:E2ECalls.Clear()
+
+        Get-SqlSchemaObject
+
+        E2EAssertEqual 0 (Get-E2ECallCount) "Get-SqlSchemaObject must not request anything for a tab that is not connected"
+        E2EAssertTrue (-not $Script:ConnectionStatus) "the tab must still be disconnected after the navigation-completed schema push"
+    }
+
+    E2ECase -Name "declining the reconnect prompt shows the prompt and still connects nothing" -Body {
+        Reset-E2ETabsToOne
+        New-E2EPersistedTabStore -TabCount 1 | Out-Null
+        Initialize-E2ERestoreRun -NoReconnect $false
+        # Restore-TabSessions maps the right-hand button (1) to "do not reconnect".
+        $script:E2EChoiceReturn = 1
+
+        Restore-TabSessions
+
+        E2EAssertEqual 1 (Get-E2EChoices -TitleLike "Reconnect?").Count "without -NoReconnect the reconnect prompt must be shown"
+        E2EAssertEqual 0 (Get-E2ECallCount) "answering 'no' to the reconnect prompt must not issue a single request"
+
+        $Script:RunTimeConfig.ReconnectStatus = 3
+        Get-SqlSchemaObject
+        E2EAssertEqual 0 (Get-E2ECallCount) "the navigation-completed schema push must stay quiet after a declined reconnect"
+        E2EAssertTrue (-not $Script:ConnectionStatus) "the tab must remain disconnected after declining the prompt"
+        E2EAssertEqual "Disconnected" ([string]$Script:MainForm.Elements.TextBlockStatusBarConnectionStatus.Text) "the status bar must read Disconnected"
+    }
+
+    E2ECase -Name "accepting the reconnect prompt still connects the tab and retrieves its schema" -Body {
+        # The guard must not be a blanket 'never fetch': the accepted-reconnect path is the one that
+        # legitimately connects, and it must keep working.
+        Reset-E2ETabsToOne
+        New-E2EPersistedTabStore -TabCount 1 | Out-Null
+        Initialize-E2ERestoreRun -NoReconnect $false
+        $script:E2EChoiceReturn = 2
+
+        Restore-TabSessions
+
+        E2EAssertEqual 1 (Get-E2EChoices -TitleLike "Reconnect?").Count "the reconnect prompt should be shown"
+        E2EAssertTrue ($Script:ConnectionStatus) "accepting the prompt must connect the restored tab"
+        E2EAssertTrue ((Get-E2ECallCount) -ge 1) "an accepted reconnect is expected to talk to the tenant"
+        E2EAssertTrue ((Get-E2ECallCount -MethodLike "POST" -UriLike "*getsqlschema*") -ge 1) "a connected tab must still retrieve its SQL schema (the guard must not block the connect path)"
+    }
+}

--- a/tests/e2e/scenarios/TabStateConsistency.ps1
+++ b/tests/e2e/scenarios/TabStateConsistency.ps1
@@ -1,0 +1,101 @@
+# Issue #65: "Switching to a not-yet-connected tab connects silently and leaves the tab in an
+# in-between state". The silent connect itself is the shared root cause fixed for #64; what these
+# scenarios pin down is that the UI is consistent with the connection state in BOTH directions -
+# button text, status bar, both dropdowns and the Display name always telling the same story.
+#
+# New-E2EPersistedTabStore and Initialize-E2ERestoreRun come from scenarios/NoReconnect.ps1, which
+# Automation.Entry.ps1 dot-sources first (scenario files load in name order).
+
+function script:Get-E2EUiState {
+    <# One snapshot of every element the issue lists as disagreeing with the others. #>
+    $Elements = $Script:MainForm.Elements
+    return [PSCustomObject]@{
+        ConnectionFlag         = [bool]$Script:ConnectionStatus
+        ButtonText             = [string]$Elements.ButtonConnectText.Text
+        StatusBar              = [string]$Elements.TextBlockStatusBarConnectionStatus.Text
+        QueryDropdown          = [bool]$Elements.ComboBoxSelectQuery.IsEnabled
+        DataConnectionDropdown = [bool]$Elements.ComboBoxSelectDataConnection.IsEnabled
+        DisplayName            = [bool]$Elements.TextBoxDisplayName.IsEnabled
+    }
+}
+
+E2ESuite -Name "TabConnectionStateConsistency" -Body {
+    E2ECase -Name "switching to a restored tab after declining the reconnect prompt connects nothing and shows one consistent disconnected state" -Body {
+        Reset-E2ETabsToOne
+        New-E2EPersistedTabStore -TabCount 2 | Out-Null
+        Initialize-E2ERestoreRun -NoReconnect $false
+        $script:E2EChoiceReturn = 1   # decline the "Reconnect?" prompt
+
+        Restore-TabSessions
+
+        E2EAssertEqual 1 (Get-E2EChoices -TitleLike "Reconnect?").Count "the reconnect prompt should have been shown once for the whole batch"
+
+        $RestoredTabs = @($Script:Tabs | Where-Object { $_.DisplayName -like "Persisted*" })
+        E2EAssertEqual 2 $RestoredTabs.Count "both persisted tabs should have been restored"
+
+        $SecondTab = $RestoredTabs[1]
+        E2EAssertTrue ($SecondTab.Id -ne $Script:ActiveTabId) "the second persisted tab should still be a deferred background tab"
+
+        # The reported repro: selecting a tab that has not connected in this session.
+        $script:E2ECalls.Clear()
+        (Get-TabControlSessions).SelectedItem = $SecondTab.TabItem
+        Invoke-E2EFlushDispatcher
+
+        E2EAssertEqual 0 (Get-E2ECallCount) "switching to a not-yet-connected tab must not issue a single request"
+
+        # And the schema push that follows once that tab's Monaco editor finishes loading must be
+        # just as quiet. ReconnectStatus is process-global and is already 3 by now, which is exactly
+        # why it was never a usable per-tab gate.
+        $Script:RunTimeConfig.ReconnectStatus = 3
+        Get-SqlSchemaObject
+        E2EAssertEqual 0 (Get-E2ECallCount) "the navigation-completed schema push must not connect the tab either"
+
+        # The in-between state from the issue, element by element.
+        $UiState = Get-E2EUiState
+        E2EAssertTrue (-not $UiState.ConnectionFlag) "the tab must be disconnected"
+        E2EAssertEqual "_Connect" $UiState.ButtonText "the button must read Connect"
+        E2EAssertEqual "Disconnected" $UiState.StatusBar "the status bar must read Disconnected, not Connected next to a Connect button"
+        E2EAssertTrue (-not $UiState.DataConnectionDropdown) "the data connection dropdown must be disabled while disconnected"
+        # The re-enable itself came from Update-QueryList's tail, reached from the WebView2
+        # completion block; that is pinned down deterministically in tests/Update-QueryList.Tests.ps1
+        # (this harness does not reliably reach the completion block within a scenario's window).
+        E2EAssertTrue (-not $UiState.QueryDropdown) "the query dropdown must be disabled while disconnected"
+        E2EAssertTrue (-not $UiState.DisplayName) "Display name must be disabled while disconnected, consistent with the dropdowns"
+    }
+
+    E2ECase -Name "connecting that tab explicitly produces the complete connected UI, and Disconnect works" -Body {
+        Reset-E2ETabsToOne
+        New-E2EPersistedTabStore -TabCount 2 | Out-Null
+        Initialize-E2ERestoreRun -NoReconnect $false
+        $script:E2EChoiceReturn = 1
+
+        Restore-TabSessions
+
+        $RestoredTabs = @($Script:Tabs | Where-Object { $_.DisplayName -like "Persisted*" })
+        $SecondTab = $RestoredTabs[1]
+        (Get-TabControlSessions).SelectedItem = $SecondTab.TabItem
+        Invoke-E2EFlushDispatcher
+
+        # The user does what the in-between state made impossible: click Connect.
+        Invoke-E2EConnect
+
+        $ConnectedState = Get-E2EUiState
+        E2EAssertTrue $ConnectedState.ConnectionFlag "clicking Connect must connect the tab"
+        E2EAssertEqual "Dis_connect" $ConnectedState.ButtonText "the button must switch to Disconnect"
+        E2EAssertEqual "Connected" $ConnectedState.StatusBar "the status bar must read Connected"
+        E2EAssertTrue $ConnectedState.QueryDropdown "the query dropdown must be enabled once connected"
+        E2EAssertTrue $ConnectedState.DataConnectionDropdown "the data connection dropdown must be enabled once connected"
+        E2EAssertTrue $ConnectedState.DisplayName "Display name must be enabled once connected"
+
+        # ... and the tab can actually be disconnected again, which the in-between state prevented.
+        Invoke-E2EConnect
+
+        $DisconnectedState = Get-E2EUiState
+        E2EAssertTrue (-not $DisconnectedState.ConnectionFlag) "clicking Disconnect must disconnect the tab"
+        E2EAssertEqual "_Connect" $DisconnectedState.ButtonText "the button must return to Connect"
+        E2EAssertEqual "Disconnected" $DisconnectedState.StatusBar "the status bar must return to Disconnected"
+        E2EAssertTrue (-not $DisconnectedState.QueryDropdown) "the query dropdown must be disabled again after disconnecting"
+        E2EAssertTrue (-not $DisconnectedState.DataConnectionDropdown) "the data connection dropdown must be disabled again after disconnecting"
+        E2EAssertTrue (-not $DisconnectedState.DisplayName) "Display name must be disabled again after disconnecting"
+    }
+}

--- a/tests/mock/Install-OmadaMockTransport.ps1
+++ b/tests/mock/Install-OmadaMockTransport.ps1
@@ -18,10 +18,30 @@ shim reads $script:OmadaMockBaseUrl at call time, so setting it after dot-sourci
 # Marker string asserted by MockAppEntry.ps1 to confirm the shadow actually took effect.
 $script:OmadaMockBaseUrl = $null
 
+# Every request the app makes reaches the mock instance through the shim below, so recording them
+# here gives a test an exact, complete picture of what did (or did not) hit the tenant. Tests that
+# assert a code path performs NO authenticated request read this log.
+$script:OmadaMockRequestLog = [System.Collections.Generic.List[object]]::new()
+
 function Install-OmadaMockTransport {
     [CmdletBinding()]
     param([string]$MockBaseUrl)
     $script:OmadaMockBaseUrl = $MockBaseUrl
+}
+
+function Clear-OmadaMockRequestLog {
+    [CmdletBinding()]
+    param()
+    $script:OmadaMockRequestLog.Clear()
+}
+
+function Get-OmadaMockRequestLog {
+    [CmdletBinding()]
+    param(
+        [string]$UriLike = "*",
+        [string]$MethodLike = "*"
+    )
+    return @($script:OmadaMockRequestLog | Where-Object { $_.Uri -like $UriLike -and $_.Method -like $MethodLike })
 }
 
 function script:Invoke-OmadaRestMethod {
@@ -49,6 +69,15 @@ function script:Invoke-OmadaRestMethod {
     }
 
     $HttpMethod = if ([string]::IsNullOrWhiteSpace($Method)) { "GET" } else { $Method.ToUpperInvariant() }
+
+    # Recorded before the call goes out, so a request that fails still counts as "the app talked to
+    # the tenant" - which is exactly what a zero-request assertion has to catch.
+    $script:OmadaMockRequestLog.Add([PSCustomObject]@{
+            Uri    = $TargetUri
+            Method = $HttpMethod
+            Body   = $Body
+        })
+
     $RequestParams = @{
         Uri     = $TargetUri
         Method  = $HttpMethod


### PR DESCRIPTION
Closes #65

> **Stacked PR.** Based on `bugfix/no-reconnect-must-not-connect` (#69, which closes #64 and carries the shared root cause). GitHub retargets this at `main` automatically once #69 merges. **Review #69 first**; the diff below is only the #65 work.

## What broke

Two problems, one causing the connection and one causing the inconsistent UI. The **connection** — the unguarded `Get-SqlSchemaObject` on navigation completion — is the shared root cause and is fixed in #69. This PR is the **UI-consistency half**.

### The status bar was written by the transport, the button by the state machine

`Invoke-OmadaPSWebRequestWrapper` wrote the status bar on every successful request (`src/Lib/Functions/Private/Invoke-OmadaPSWebRequestWrapper.ps1:36-38` before this change):

```powershell
$Script:MainForm.Definitions.TextBlockStatusBarConnectionStatus | Set-TextBlockText -Text "Connected"
```

while `$Script:ConnectionStatus` — which `Test-ConnectionButton` uses for the button text (`src/Lib/Functions/Private/Test-ConnectionButton.ps1:26`) and `Set-SqlQueryFunctionState` for the dropdowns and Display name — stayed `$false`. Hence "Connected" next to a `Connect` button.

**Honest correction to the issue's analysis:** that particular write was in fact *unreachable*. Its guard tests `$Script:MainForm.Definitions`, a member that exists nowhere in the app — the real member is `Definition` (`grep -rn "MainForm\.Definitions" src/` returns only the three lines in this one file). So it is a latent bug rather than the source of the observed `Connected` text. I could not reproduce a live code path that writes `Connected` while `$Script:ConnectionStatus` is `$false`. It is removed anyway: it is exactly the split-brain the issue asks to eliminate, and a future rename of the typo'd member would have activated it.

The same typo made the "OData endpoint not enabled" error branch (`Invoke-OmadaPSWebRequestWrapper.ps1:50-55` before this change) dead as well — it hand-wrote four status-bar fields, guarded on `.Definitions.IsVisible` but writing to `.Elements`, and never touched the connection flag.

### The re-enabled query dropdown — pinned down, not guessed

`Update-QueryList` ends by unconditionally enabling the very controls `Set-SqlQueryFunctionState -Status $false` had just cleared and disabled (`src/Lib/Functions/Private/Update-QueryList.ps1:117-123`):

```powershell
$Script:MainForm.Elements.ComboBoxSelectQuery.IsEnabled = $true
$Script:MainForm.Elements.ButtonRefreshQueries.IsEnabled = $true
$Script:MainForm.Elements.CheckboxMyCreatedQueries.IsEnabled = $true
$Script:MainForm.Elements.CheckboxMyUpdatedQueries.IsEnabled = $true
$Script:MainForm.Elements.ButtonShowSqlSchema.IsEnabled = $true
```

and the WebView2 completion block in `Initialize-WebViewForTab` called it for **every** tab whose Monaco editor finished loading (`src/Lib/Functions/Private/Initialize-WebViewForTab.ps1:107` on `main`), regardless of connection state. That is what re-enabled the query dropdown — and it was a second authenticated request on the startup path, on top of the schema push. Its call site is gated in #69; here the function refuses at the choke point, which is what makes the finding testable.

Note the asymmetry the issue observed: the **data connection** dropdown stayed disabled because nothing re-enabled it on that path, while the **query** dropdown was re-enabled by this tail. `TextBoxDisplayName` stayed disabled for the same reason (`Update-DataConnectionList` is what re-enables it, and that was never called for a disconnected tab).

## What changed

| File | Change |
|---|---|
| `src/Lib/Functions/Private/Invoke-OmadaPSWebRequestWrapper.ps1` | Removed the direct status-bar write on success. Routed the "OData endpoint not enabled" branch through `Set-SqlConnectionState -Status $false`, matching the Unauthorized branch below it. |
| `src/Lib/Functions/Private/Update-QueryList.ps1` | Refuses to run for a tab that is not connected (`$Script:ConnectionStatus`). |
| `tests/Invoke-OmadaPSWebRequestWrapper.Tests.ps1` (new) | 4 unit tests. |
| `tests/Update-QueryList.Tests.ps1` (new) | 3 unit tests, request path through the mock transport against a running mock instance. |
| `tests/e2e/scenarios/TabStateConsistency.ps1` (new) | 2 E2E scenarios. |

## Acceptance criteria

- [x] **Connection state is single-sourced; the direct status-bar write in `Invoke-OmadaPSWebRequestWrapper` is removed or routed through `Set-SqlConnectionState`** — both: the success write is gone (`Invoke-OmadaPSWebRequestWrapper.ps1:35-43`), the error branch now calls `Set-SqlConnectionState -Status $false` (`:52-58`). Proven by `Invoke-OmadaPSWebRequestWrapper connection state.does not flip the status bar to Connected on a successful request` and `... tears a tab down through Set-SqlConnectionState when the OData endpoint is missing`.
- [x] **The openable query dropdown is pinned down, not guessed, and the exact end state is captured in a test** — cause identified as `Update-QueryList.ps1:117-123` reached from the WebView2 completion block; guarded at `Update-QueryList.ps1:19-29`; end state captured by `Update-QueryList connection guard.leaves the query controls disabled for a tab that is not connected` (all five controls) and by the E2E `TabConnectionStateConsistency` scenario's six-element UI snapshot.
- [x] **A successful request through `Invoke-OmadaPSWebRequestWrapper` does not by itself flip the status bar to `Connected`** — `tests/Invoke-OmadaPSWebRequestWrapper.Tests.ps1`, cases 2 and 3.
- [x] **Restore two tabs, decline the reconnect prompt, switch to the second tab → zero requests and a fully consistent disconnected UI (button `Connect`, status bar `Disconnected`, Display name per the disconnected contract)** — E2E `TabConnectionStateConsistency :: switching to a restored tab after declining the reconnect prompt connects nothing and shows one consistent disconnected state`. It asserts zero calls across the switch *and* across the subsequent schema push, then all six UI elements.
- [x] **Connect that tab explicitly → the complete connected UI, and Disconnect works** — E2E `TabConnectionStateConsistency :: connecting that tab explicitly produces the complete connected UI, and Disconnect works`.

## Decisions worth reviewing

1. **`Update-QueryList` guards itself, in addition to the call-site gate added in #69.** Deliberate belt-and-braces: the call-site gate is what makes the zero-request criterion hold for #64, but a function that silently re-enables the query controls is a trap for the next caller. Guarding at the choke point is also what the issue calls the "honest fix". Verified safe for every caller: `Set-SqlConnectionState`'s connected branch now sets the flag before calling it (#69), `ButtonConnect` calls it inside `if ($Script:ConnectionStatus)`, `ComboBoxSelectQuery`'s `DropDownOpened` already had the same guard, the two "my queries" checkbox handlers guard on it, and `Save-Query` / `Invoke-ExecuteQuery` only run on a connected tab. **This makes the guard depend on #69's reordering of `$Script:ConnectionStatus = $true` — do not merge this PR before #69.**

2. **The OData-error branch now calls `Set-SqlConnectionState -Status $false`.** This is a behaviour change on paper (that branch previously updated nothing, because of the `Definitions` typo). It brings the branch in line with the Unauthorized branch immediately below, which has always done exactly this and is covered by the existing `ConnectFailure` E2E scenario.

3. **The "a bare successful request does not flip the status bar" check is a unit test, not an E2E scenario.** The E2E harness replaces `Invoke-OmadaPSWebRequestWrapper` with a fixture mock (`tests/e2e/OmadaMocks.ps1`), so an E2E case for it would assert against the mock and pass regardless. The unit test drives the real function and fails against the pre-fix code.

4. **The E2E scenario's "query dropdown disabled" assertion is not, on its own, discriminating.** Measured, not assumed: with the call-site gate reverted the E2E suite still reported 38/38, because that harness does not reliably reach the WebView2 completion block within a scenario's window. The deterministic proof lives in `tests/Update-QueryList.Tests.ps1`, which does fail without the guard. The E2E scenario is kept because it is the only place the *whole* restore → decline → switch → connect → disconnect sequence runs against the real UI, and a comment in the file says exactly this.

5. **`ReconnectStatus` was NOT moved onto the tab session.** Named as a contributing design flaw, explicitly out of scope, and not needed: `$Script:ConnectionStatus` is already per-tab (`Set-ActiveTabContext.ps1:25,35`). Nothing in either PR touches it beyond the E2E scenarios setting it to `3` to reproduce the state that made the old gate useless.

## Verification

```
pwsh -NoProfile -File build/build.ps1 -Task TestBuildOnly -BuildVersion 0.0.0
  -> Tests Passed: 324, Failed: 0, Skipped: 0   (PSScriptAnalyzer clean, build succeeded)

pwsh -NoProfile -File tests/e2e/Invoke-E2ESuite.ps1
  -> E2E result: 38 test(s), 0 failure(s)       (32 on main + 4 from #69 + 2 here)
```

`buildoutput/` was deleted before the build so no stale results were read. 324 = 317 after #69, plus the 7 new unit tests here.

Both new unit files are discriminating against the pre-fix code:

- `Invoke-OmadaPSWebRequestWrapper.Tests.ps1` with the source change reverted: `Tests Passed: 2, Failed: 2` — `Expected: 'Disconnected' But was: 'Connected'`, and `Expected 1, but got 0` for the state-machine call. (The fixture deliberately exposes *both* `Definition` and `Definitions` backed by the same visible-window stub, so the test asserts "no spelling of this path writes the status bar" rather than "the typo is still there".)
- `Update-QueryList.Tests.ps1` with the source change reverted: `Tests Passed: 1, Failed: 2` — `Expected 0, but got 1` request, and `ComboBoxSelectQuery.IsEnabled` `Expected $false, but got $true`.

The E2E suite is local-only by design (`tests/e2e/README.md`), so the 2 new scenarios are not part of headless PR CI; the 7 new Pester tests are, and they run in PR validation because both changed source files are in the changed-file set.

## Relationship to the sibling issue

Issue #64 / PR #69 is the parent of this branch. It fixes the silent connect that both issues share (the unguarded `Get-SqlSchemaObject` in the `NavigationCompleted` handler) and gates the `Update-QueryList` call site; this PR makes the resulting UI state impossible to contradict itself. Neither PR touches `src/Lib/Functions/Public/Set-OmadaSqlTroubleshooterShortcut.ps1` — the Start menu shortcut keeps `-NoReconnect`, per the maintainer's scope decision on #64.
