### PR TITLE
Add an opt-in option to log the request body unredacted

### DIFF
--- a/src/Lib/Events/LogForm.Elements.CheckboxShowRequestBody.ps1
+++ b/src/Lib/Events/LogForm.Elements.CheckboxShowRequestBody.ps1
@@ -1,0 +1,12 @@
+$Script:LogForm.Elements.CheckboxShowRequestBody.Add_Checked({
+        $_ | Show-EventInfo
+        Set-BodyRedactionState -Enabled $true
+        $true | Set-ConfigProperty -Property "SkipBodyRedaction"
+    })
+
+$Script:LogForm.Elements.CheckboxShowRequestBody.Add_UnChecked({
+        $_ | Show-EventInfo
+        Set-BodyRedactionState -Enabled $false
+        $false | Set-ConfigProperty -Property "SkipBodyRedaction"
+
+    })

--- a/src/Lib/Functions/Private/ConvertTo-RedactedLogString.ps1
+++ b/src/Lib/Functions/Private/ConvertTo-RedactedLogString.ps1
@@ -13,6 +13,11 @@ function ConvertTo-RedactedLogString {
         Write-LogOutput. The tracer preamble in every other function routes through this one, and
         Write-LogOutput routes through Protect-LogMessage - instrumenting the helpers would make them
         call themselves.
+
+        The one rule a user can lift is the request-body rule, through the log window's
+        "Show request body" checkbox or -SkipBodyRedaction. That state is read from module scope
+        ($Script:SkipBodyRedaction), exactly as OmadaWeb.PS does it, so no call site and no step of
+        the recursion has to thread a parameter through.
     #>
     [CmdLetBinding()]
     param(
@@ -27,7 +32,11 @@ function ConvertTo-RedactedLogString {
     )
 
     try {
-        $Redacted = ConvertTo-RedactedLogValue -Value $InputObject -Depth 0 -MaxDepth $MaxDepth -MaxStringLength $MaxStringLength -Visited ([System.Collections.Generic.List[object]]::new()) -MaskValues ([bool]$ShapeOnly)
+        # -ShapeOnly says "this object IS the body", so the user's choice has to reach it here as
+        # well. Without this the "Body:" line would keep showing String(24) while the "Parameters:"
+        # line from the same request showed the query - one log contradicting itself.
+        $MaskBodyValues = [bool]$ShapeOnly -and -not $Script:SkipBodyRedaction
+        $Redacted = ConvertTo-RedactedLogValue -Value $InputObject -Depth 0 -MaxDepth $MaxDepth -MaxStringLength $MaxStringLength -Visited ([System.Collections.Generic.List[object]]::new()) -MaskValues $MaskBodyValues
         if ($null -eq $Redacted) {
             return "null"
         }
@@ -214,8 +223,13 @@ function Get-RedactedMemberValue {
     }
 
     # Request bodies keep their keys and value shapes - enough to tell what was sent - but no values.
+    # "Show request body" / -SkipBodyRedaction lifts that one rule, because in a SQL troubleshooter
+    # the body IS the query. Only this rule: everything above still applies inside the body, so a
+    # member named for a secret, a credential and a secure string stay masked, and Protect-LogMessage
+    # still sweeps the finished line. Read from module scope so no call site and no step of the
+    # recursion has to pass it along.
     $ChildMaskValues = $MaskValues
-    if ($Name -eq "Body") {
+    if ($Name -eq "Body" -and -not $Script:SkipBodyRedaction) {
         $ChildMaskValues = $true
     }
 

--- a/src/Lib/Functions/Private/Initialize-GlobalConfigSettings.ps1
+++ b/src/Lib/Functions/Private/Initialize-GlobalConfigSettings.ps1
@@ -20,10 +20,13 @@ function Initialize-GlobalConfigSettings {
             "Console logging is enabled" | Write-LogOutput -LogType LOG
         }
 
-        # Same shape as console logging above: an explicit -SkipBodyRedaction wins, otherwise the
-        # setting the user last chose in the log viewer is restored. Resolving it here - before the
-        # first request - is what makes -SkipBodyRedaction unredact the very first body, rather than
-        # only from the moment the log window happens to be opened.
+        # Deliberately the same shape as console logging above: either source can turn the option
+        # on - -SkipBodyRedaction for this session, or the setting the user last chose in the log
+        # viewer - and neither can turn it off. Turning it off is the checkbox's job (or -Reset),
+        # not a parameter's, exactly as for console logging; -SkipBodyRedaction:$false does not
+        # override a persisted "on". Resolving it here - before the first request - is what makes
+        # -SkipBodyRedaction unredact the very first body, rather than only from the moment the log
+        # window happens to be opened.
         if ($Script:RunTimeConfig.Logging.SkipBodyRedaction -or $Script:AppGlobalConfig.SkipBodyRedaction) {
             Set-BodyRedactionState -Enabled $true
             $true | Set-ConfigProperty -Property "SkipBodyRedaction"

--- a/src/Lib/Functions/Private/Initialize-GlobalConfigSettings.ps1
+++ b/src/Lib/Functions/Private/Initialize-GlobalConfigSettings.ps1
@@ -20,6 +20,18 @@ function Initialize-GlobalConfigSettings {
             "Console logging is enabled" | Write-LogOutput -LogType LOG
         }
 
+        # Same shape as console logging above: an explicit -SkipBodyRedaction wins, otherwise the
+        # setting the user last chose in the log viewer is restored. Resolving it here - before the
+        # first request - is what makes -SkipBodyRedaction unredact the very first body, rather than
+        # only from the moment the log window happens to be opened.
+        if ($Script:RunTimeConfig.Logging.SkipBodyRedaction -or $Script:AppGlobalConfig.SkipBodyRedaction) {
+            Set-BodyRedactionState -Enabled $true
+            $true | Set-ConfigProperty -Property "SkipBodyRedaction"
+        }
+        else {
+            Set-BodyRedactionState -Enabled $false
+        }
+
         if ($null -eq ($Script:MainForm.Definition | Get-FormPositionConfig)) {
             $Script:MainForm.Definition.WindowStartupLocation = [System.Windows.WindowStartupLocation]::CenterScreen
         }

--- a/src/Lib/Functions/Private/Invoke-OmadaPSWebRequestWrapper.ps1
+++ b/src/Lib/Functions/Private/Invoke-OmadaPSWebRequestWrapper.ps1
@@ -31,6 +31,22 @@ function Invoke-OmadaPSWebRequestWrapper {
 
                 #$Private:Parameters.Body = $Private:Parameters.Body | ConvertTo-Json
             }
+
+            # Keep the module's own verbose stream in step with this application's log, so the two
+            # do not contradict each other on the same request. Passed only when the installed
+            # OmadaWeb.PS actually declares the parameter: -SkipBodyRedaction is newer than the
+            # pinned minimum version, and splatting a parameter a cmdlet does not have is a
+            # terminating error. Capability-checked rather than version-gated, so this works the day
+            # the switch ships without forcing everyone onto a release that does not exist yet.
+            $Private:RestMethodCommand = Get-Command -Name Invoke-OmadaRestMethod -ErrorAction SilentlyContinue
+            if ($null -ne $Private:RestMethodCommand -and $Private:RestMethodCommand.Parameters.ContainsKey("SkipBodyRedaction")) {
+                $Private:Parameters.SkipBodyRedaction = [bool]$Script:SkipBodyRedaction
+            }
+            elseif ($Private:Parameters.ContainsKey("SkipBodyRedaction")) {
+                # The installed module was downgraded mid-session; drop the key rather than fail.
+                $Private:Parameters.Remove("SkipBodyRedaction")
+            }
+
             "Parameters: {0}" -f (ConvertTo-RedactedLogString -InputObject $Private:Parameters) | Write-LogOutput -LogType VERBOSE
             $Private:Result = Invoke-OmadaRestMethod @Parameters
             # Deliberately no status-bar write here. A successful request is not the same thing as a

--- a/src/Lib/Functions/Private/Open-LogForm.ps1
+++ b/src/Lib/Functions/Private/Open-LogForm.ps1
@@ -35,6 +35,17 @@ function Open-LogForm {
             $false | Set-ConfigProperty -Property "CheckboxConsoleLog"
         }
 
+        # The state was already resolved once by Initialize-GlobalConfigSettings (parameter, then
+        # persisted setting), so this only reflects it in the checkbox. Setting IsChecked fires the
+        # Checked/UnChecked handler, which is the single writer of both the runtime flag and the
+        # persisted value - hence no Set-ConfigProperty call of its own here.
+        if ($Script:RunTimeConfig.Logging.SkipBodyRedaction) {
+            $Script:LogForm.Elements.CheckboxShowRequestBody.IsChecked = $true
+        }
+        else {
+            $Script:LogForm.Elements.CheckboxShowRequestBody.IsChecked = $false
+        }
+
         #Set log level to show
         if (![string]::IsNullOrWhiteSpace($Script:RunTimeConfig.Logging.LogLevel)) {
             "Set form log level to: {0}" -f $Script:RunTimeConfig.Logging.LogLevel | Write-LogOutput -LogType DEBUG

--- a/src/Lib/Functions/Private/Set-BodyRedactionState.ps1
+++ b/src/Lib/Functions/Private/Set-BodyRedactionState.ps1
@@ -1,0 +1,51 @@
+function Set-BodyRedactionState {
+    <#
+    .SYNOPSIS
+        Single writer of the "show request body" option.
+
+    .DESCRIPTION
+        Three places can turn the option on - the -SkipBodyRedaction parameter at start-up, the
+        persisted setting restored when the log viewer opens, and the "Show request body" checkbox -
+        and all three have to end up in the same state, so they all come through here.
+
+        The authoritative value lives in $Script:SkipBodyRedaction, which ConvertTo-RedactedLogString
+        reads from module scope (the same shape OmadaWeb.PS uses for its own -SkipBodyRedaction), and
+        is mirrored into $Script:RunTimeConfig.Logging so the rest of the application can read it the
+        way it reads every other logging setting.
+
+        Switching the option on writes one WARNING, once per session: from that point the query text
+        is in the log window and in anything exported from it, and a user attaching a log to a support
+        ticket should not have to discover that afterwards.
+    #>
+    [CmdLetBinding()]
+    param(
+        [Parameter(Mandatory = $true, Position = 0)]
+        [bool]$Enabled
+    )
+
+    try {
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
+
+        $Script:SkipBodyRedaction = $Enabled
+        if ($null -ne $Script:RunTimeConfig -and $null -ne $Script:RunTimeConfig.Logging) {
+            $Script:RunTimeConfig.Logging.SkipBodyRedaction = $Enabled
+        }
+
+        if ($Enabled) {
+            if (-not $Script:SkipBodyRedactionWarned) {
+                $Script:SkipBodyRedactionWarned = $true
+                # -SkipDialog on purpose: this is a heads-up that belongs in the log the user is
+                # looking at, not a modal box in front of the query they are trying to run.
+                "Request body logging is enabled: query text is now written to this log in full, and to any log file exported from it." | Write-LogOutput -LogType WARNING -SkipDialog
+            }
+
+            "Request body logging is enabled" | Write-LogOutput -LogType LOG
+        }
+        else {
+            "Request body logging is disabled" | Write-LogOutput -LogType LOG
+        }
+    }
+    catch {
+        $_.Exception.Message | Write-LogOutput -LogType ERROR -ErrorObject $_
+    }
+}

--- a/src/Lib/Functions/Private/Set-BodyRedactionState.ps1
+++ b/src/Lib/Functions/Private/Set-BodyRedactionState.ps1
@@ -26,6 +26,7 @@ function Set-BodyRedactionState {
     try {
         $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
 
+        $PreviousState = [bool]$Script:SkipBodyRedaction
         $Script:SkipBodyRedaction = $Enabled
         if ($null -ne $Script:RunTimeConfig -and $null -ne $Script:RunTimeConfig.Logging) {
             $Script:RunTimeConfig.Logging.SkipBodyRedaction = $Enabled
@@ -41,7 +42,10 @@ function Set-BodyRedactionState {
 
             "Request body logging is enabled" | Write-LogOutput -LogType LOG
         }
-        else {
+        elseif ($PreviousState) {
+            # Only when it was actually on. Initialize-GlobalConfigSettings resolves this state on
+            # every start, so an unconditional line here would put "Request body logging is
+            # disabled" in the log of every session that never touches the option.
             "Request body logging is disabled" | Write-LogOutput -LogType LOG
         }
     }

--- a/src/Lib/Functions/Private/Set-BodyRedactionState.ps1
+++ b/src/Lib/Functions/Private/Set-BodyRedactionState.ps1
@@ -37,7 +37,7 @@ function Set-BodyRedactionState {
                 $Script:SkipBodyRedactionWarned = $true
                 # -SkipDialog on purpose: this is a heads-up that belongs in the log the user is
                 # looking at, not a modal box in front of the query they are trying to run.
-                "Request body logging is enabled: query text is now written to this log in full, and to any log file exported from it." | Write-LogOutput -LogType WARNING -SkipDialog
+                "Request body logging is enabled: query text is now written to this log, and to any log file exported from it. A very long value is still truncated." | Write-LogOutput -LogType WARNING -SkipDialog
             }
 
             "Request body logging is enabled" | Write-LogOutput -LogType LOG

--- a/src/Lib/Functions/Public/Invoke-OmadaSqlTroubleshooter.ps1
+++ b/src/Lib/Functions/Public/Invoke-OmadaSqlTroubleshooter.ps1
@@ -24,6 +24,12 @@ Uses the WebView2 for browser-based authentication.
 .PARAMETER NoReconnect
 Prevents the application from attempting to reconnect to the Omada Identity Suite using the stored connection information.
 
+.PARAMETER SkipBodyRedaction
+Logs the request body - the query as it was sent - instead of its shape, and starts the application with the log viewer's "Show request body" checkbox already checked.
+Only the body rule is lifted: a body member named for a secret, a credential and a secure string are still masked, and headers, credentials and session cookies are unaffected.
+The query text does end up in the log window and in any log file exported from it.
+The name matches the OmadaWeb.PS switch it drives.
+
 .EXAMPLE
 Invoke-OmadaSqlTroubleshooter
 
@@ -39,6 +45,11 @@ Invoke-OmadaSqlTroubleshooter -Reset
 
 Resets the stored configuration to default and starts the Omada SQL Troubleshooter application.
 
+.EXAMPLE
+Invoke-OmadaSqlTroubleshooter -LogLevel VERBOSE -SkipBodyRedaction
+
+Starts the Omada SQL Troubleshooter application logging the executed query text in full, from the first request onwards.
+
 .NOTES
 Requires PowerShell 7.0 or higher and the OmadaWeb.PS module.
 
@@ -53,7 +64,8 @@ function Invoke-OmadaSqlTroubleshooter {
         [switch]$Reset,
         [switch]$LogToConsole,
         [switch]$UseWebView2Auth,
-        [switch]$NoReconnect
+        [switch]$NoReconnect,
+        [switch]$SkipBodyRedaction
     )
     $Error.Clear()
     #region Initialize
@@ -75,6 +87,9 @@ function Invoke-OmadaSqlTroubleshooter {
             # of overwriting it with a value the caller never asked for.
             LogLevelExplicit    = $PSCmdlet.MyInvocation.BoundParameters.ContainsKey("LogLevel")
             LogLevelSetting     = $null
+            # Seeded here so the option is in effect before the first request; a persisted setting
+            # is folded in by Initialize-GlobalConfigSettings, which is also what checks the box.
+            SkipBodyRedaction   = $SkipBodyRedaction.IsPresent -or $false
             AppLogObject        = [System.Collections.ObjectModel.ObservableCollection[string]]::new()
         }
         StopWatch          = $null
@@ -98,6 +113,11 @@ function Invoke-OmadaSqlTroubleshooter {
     # the session. Initialize-GlobalConfigSettings resolves this again once the persisted level is
     # available.
     $Script:RunTimeConfig.Logging.LogLevelSetting = Resolve-LogLevel -BoundLogLevel $LogLevel -SchemaDefault (Get-ConfigSchemaDefault -Property "LogLevel")
+
+    # The flag ConvertTo-RedactedLogString reads. Set before anything can log a body, so a bound
+    # -SkipBodyRedaction covers the whole session and not just the part after the configuration file
+    # has been read; Initialize-GlobalConfigSettings resolves it again against the persisted setting.
+    $Script:SkipBodyRedaction = $SkipBodyRedaction.IsPresent
 
     Initialize-OmadaSqlTroubleShooter
 

--- a/src/Lib/Functions/Public/Invoke-OmadaSqlTroubleshooter.ps1
+++ b/src/Lib/Functions/Public/Invoke-OmadaSqlTroubleshooter.ps1
@@ -118,6 +118,10 @@ function Invoke-OmadaSqlTroubleshooter {
     # -SkipBodyRedaction covers the whole session and not just the part after the configuration file
     # has been read; Initialize-GlobalConfigSettings resolves it again against the persisted setting.
     $Script:SkipBodyRedaction = $SkipBodyRedaction.IsPresent
+    # The "your query text is now in the log" warning is once per application session, not once per
+    # PowerShell session: the module stays imported between runs, so without this reset a second
+    # Invoke-OmadaSqlTroubleshooter in the same console would enable body logging silently.
+    $Script:SkipBodyRedactionWarned = $false
 
     Initialize-OmadaSqlTroubleShooter
 

--- a/src/Lib/Functions/Public/Invoke-OmadaSqlTroubleshooter.ps1
+++ b/src/Lib/Functions/Public/Invoke-OmadaSqlTroubleshooter.ps1
@@ -25,8 +25,8 @@ Uses the WebView2 for browser-based authentication.
 Prevents the application from attempting to reconnect to the Omada Identity Suite using the stored connection information.
 
 .PARAMETER SkipBodyRedaction
-Logs the request body - the query as it was sent - instead of its shape, and starts the application with the log viewer's "Show request body" checkbox already checked.
-Only the body rule is lifted: a body member named for a secret, a credential and a secure string are still masked, and headers, credentials and session cookies are unaffected.
+Logs the request body - the query that was sent - instead of its shape, and starts the application with the log viewer's "Show request body" checkbox already checked.
+Only the body rule is lifted: a body member named for a secret, a credential and a secure string are still masked, headers, credentials and session cookies are unaffected, and a very long value is still truncated by the log's own length limit.
 The query text does end up in the log window and in any log file exported from it.
 The name matches the OmadaWeb.PS switch it drives.
 
@@ -48,7 +48,7 @@ Resets the stored configuration to default and starts the Omada SQL Troubleshoot
 .EXAMPLE
 Invoke-OmadaSqlTroubleshooter -LogLevel VERBOSE -SkipBodyRedaction
 
-Starts the Omada SQL Troubleshooter application logging the executed query text in full, from the first request onwards.
+Starts the Omada SQL Troubleshooter application logging the executed query text, from the first request onwards.
 
 .NOTES
 Requires PowerShell 7.0 or higher and the OmadaWeb.PS module.

--- a/src/Lib/schema/appGlobalConfigSchema.json
+++ b/src/Lib/schema/appGlobalConfigSchema.json
@@ -65,6 +65,10 @@
     "Type": "Bool"
   },
   {
+    "Name": "SkipBodyRedaction",
+    "Type": "Bool"
+  },
+  {
     "Name": "UseWebView2Auth",
     "Type": "Bool"
   },

--- a/src/Lib/ui/LogForm.xaml
+++ b/src/Lib/ui/LogForm.xaml
@@ -222,6 +222,11 @@
                           Content="Console Log"
                           VerticalAlignment="Center"
                           ToolTip="Log output in console"/>
+                <Separator Width="20"/>
+                <CheckBox x:Name="CheckboxShowRequestBody"
+                          Content="Show request body"
+                          VerticalAlignment="Center"
+                          ToolTip="Log the request body (your query) as it was sent, instead of its shape - the same as starting with -SkipBodyRedaction. Secrets are still masked, but the query text ends up in this window and in any exported log file."/>
             </StackPanel>
         </StackPanel>
     </Grid>

--- a/src/Lib/ui/LogForm.xaml
+++ b/src/Lib/ui/LogForm.xaml
@@ -226,7 +226,7 @@
                 <CheckBox x:Name="CheckboxShowRequestBody"
                           Content="Show request body"
                           VerticalAlignment="Center"
-                          ToolTip="Log the request body (your query) as it was sent, instead of its shape - the same as starting with -SkipBodyRedaction. Secrets are still masked, but the query text ends up in this window and in any exported log file."/>
+                          ToolTip="Log the request body (your query) instead of its shape - the same as starting with -SkipBodyRedaction. Secrets are still masked and a very long value is still truncated, but the query text ends up in this window and in any exported log file."/>
             </StackPanel>
         </StackPanel>
     </Grid>

--- a/tests/ConvertTo-RedactedLogString.Tests.ps1
+++ b/tests/ConvertTo-RedactedLogString.Tests.ps1
@@ -202,3 +202,154 @@ Describe 'ConvertTo-RedactedLogString' {
         }
     }
 }
+
+Describe 'ConvertTo-RedactedLogString with the body redaction lifted' {
+
+    BeforeEach {
+        # The flag is module state, exactly as in OmadaWeb.PS, so every test starts from "off" and
+        # nothing a previous test set can leak into the next one.
+        $Script:SkipBodyRedaction = $false
+    }
+
+    AfterEach {
+        $Script:SkipBodyRedaction = $false
+    }
+
+    Context 'Option off' {
+
+        It 'produces byte-for-byte the output it produced before the option existed' {
+            $Parameters = [ordered]@{
+                Uri    = "https://tenant.omada.cloud/odata"
+                Method = "POST"
+                Body   = [ordered]@{ C_QUERY = "SELECT TOP 10 * FROM x" }
+            }
+
+            $Expected = @"
+{
+  "Uri": "https://tenant.omada.cloud/odata",
+  "Method": "POST",
+  "Body": {
+    "C_QUERY": "String(22)"
+  }
+}
+"@
+
+            $Result = ConvertTo-RedactedLogString -InputObject $Parameters
+
+            $Result | Should -BeExactly $Expected
+        }
+
+        It 'still reduces a body passed on its own via -ShapeOnly to its shape' {
+            $Result = ConvertTo-RedactedLogString -InputObject @{ C_QUERY = "SELECT * FROM dbo.Identity" } -ShapeOnly
+
+            $Result | Should -Not -Match "SELECT"
+        }
+    }
+
+    Context 'Option on' {
+
+        It 'shows the executed query text instead of its shape' {
+            $Script:SkipBodyRedaction = $true
+
+            $Result = ConvertTo-RedactedLogString -InputObject @{
+                Uri  = "https://tenant.omada.cloud/odata"
+                Body = @{ C_QUERY = "SELECT * FROM dbo.Identity" }
+            }
+
+            $Result | Should -Match "SELECT \* FROM dbo.Identity"
+        }
+
+        It 'shows the body of a request logged through -ShapeOnly as well' {
+            # The "Body: ..." call sites hand over the body itself, so -ShapeOnly is the only signal
+            # the walker gets. The option has to reach that path too, or the log contradicts itself.
+            $Script:SkipBodyRedaction = $true
+
+            $Result = ConvertTo-RedactedLogString -InputObject @{ C_QUERY = "SELECT * FROM dbo.Identity" } -ShapeOnly
+
+            $Result | Should -Match "SELECT \* FROM dbo.Identity"
+        }
+
+        It 'still masks a body member whose name names a secret' {
+            $Script:SkipBodyRedaction = $true
+
+            $Result = ConvertTo-RedactedLogString -InputObject @{
+                Body = @{ C_QUERY = "SELECT 1"; Password = "body-password-value" }
+            }
+
+            $Result | Should -Match "SELECT 1"
+            $Result | Should -Not -Match "body-password-value"
+            $Result | Should -Match "REDACTED"
+        }
+
+        It 'still masks a credential inside the body by type' {
+            $Script:SkipBodyRedaction = $true
+
+            $Result = ConvertTo-RedactedLogString -InputObject @{
+                Body = @{ Identity = $Script:TestCredential }
+            }
+
+            $Result | Should -Not -Match ([regex]::Escape($Script:TestPassword))
+            $Result | Should -Match "serviceaccount"
+        }
+
+        It 'still masks a secure string inside the body by type' {
+            $Script:SkipBodyRedaction = $true
+            $Secure = ConvertTo-SecureString "body-secure-string-secret" -AsPlainText -Force
+
+            $Result = ConvertTo-RedactedLogString -InputObject @{ Body = @{ Value = $Secure } }
+
+            $Result | Should -Not -Match "body-secure-string-secret"
+            $Result | Should -Match "REDACTED"
+        }
+
+        It 'still lets the free-form safety net catch a token inside a body value' {
+            # Protect-LogMessage is the last gate before AppLogObject, so a bearer token riding
+            # inside an otherwise legitimate body value is caught even though the body is now shown.
+            $ParentPath = Split-Path -Path $PSScriptRoot -Parent
+            . (Join-Path $ParentPath -ChildPath "src\lib\functions\Private\Protect-LogMessage.ps1")
+            $Script:SkipBodyRedaction = $true
+
+            $Redacted = ConvertTo-RedactedLogString -InputObject @{
+                Body = @{ C_QUERY = "SELECT 1 -- Bearer abcdefghijklmnop1234567890" }
+            }
+            $Result = Protect-LogMessage -Message $Redacted
+
+            $Result | Should -Match "SELECT 1"
+            $Result | Should -Not -Match "abcdefghijklmnop1234567890"
+        }
+
+        It 'leaves everything outside the body alone' {
+            $Script:SkipBodyRedaction = $true
+
+            $Result = ConvertTo-RedactedLogString -InputObject @{
+                Headers = @{ Authorization = "Basic outside-the-body-secret" }
+                Body    = @{ C_QUERY = "SELECT 1" }
+            }
+
+            $Result | Should -Not -Match "outside-the-body-secret"
+            $Result | Should -Match "SELECT 1"
+        }
+    }
+
+    Context 'State isolation' {
+
+        It 'does not let a request with the option on affect the next request with it off' {
+            $Parameters = [ordered]@{
+                Uri  = "https://tenant.omada.cloud/odata"
+                Body = [ordered]@{ C_QUERY = "SELECT TOP 10 * FROM x" }
+            }
+
+            $Before = ConvertTo-RedactedLogString -InputObject $Parameters
+
+            $Script:SkipBodyRedaction = $true
+            $During = ConvertTo-RedactedLogString -InputObject $Parameters
+
+            $Script:SkipBodyRedaction = $false
+            $After = ConvertTo-RedactedLogString -InputObject $Parameters
+
+            $During | Should -Match "SELECT TOP 10"
+            $Before | Should -Not -Match "SELECT TOP 10"
+            $After | Should -BeExactly $Before
+        }
+    }
+}

--- a/tests/Initialize-GlobalConfigSettings.Tests.ps1
+++ b/tests/Initialize-GlobalConfigSettings.Tests.ps1
@@ -28,6 +28,16 @@ BeforeAll {
         return $Script:ModuleSourceFolder
     }
 
+    # The single writer of the "show request body" state (issue #62). Recorded rather than executed,
+    # so these tests stay about log level resolution while still proving the state is resolved here.
+    function Set-BodyRedactionState {
+        param(
+            [Parameter(Mandatory = $true, Position = 0)]
+            [bool]$Enabled
+        )
+        $Script:BodyRedactionStateCalls.Add($Enabled)
+    }
+
     function Get-FormPositionConfig {
         param(
             [parameter(Mandatory = $false, Position = 0, ValueFromPipeline = $true)]
@@ -78,16 +88,18 @@ BeforeAll {
     function New-RuntimeConfig {
         param(
             $LogLevelSetting,
-            [bool]$LogLevelExplicit
+            [bool]$LogLevelExplicit,
+            [bool]$SkipBodyRedaction
         )
         return [PSCustomObject]@{
             ApplicationName = "Test"
             InstanceGuid    = "11111111111111111111111111111111"
             Logging         = [PSCustomObject]@{
-                LogToConsole     = $false
-                LogLevel         = $null
-                LogLevelSetting  = $LogLevelSetting
-                LogLevelExplicit = $LogLevelExplicit
+                LogToConsole      = $false
+                LogLevel          = $null
+                LogLevelSetting   = $LogLevelSetting
+                LogLevelExplicit  = $LogLevelExplicit
+                SkipBodyRedaction = $SkipBodyRedaction
             }
         }
     }
@@ -97,6 +109,7 @@ Describe 'Initialize-GlobalConfigSettings log level resolution' {
 
     BeforeEach {
         $Script:ConfigWrites = [System.Collections.Generic.List[object]]::new()
+        $Script:BodyRedactionStateCalls = [System.Collections.Generic.List[object]]::new()
         $Script:MainForm = $null
         $Script:GlobalConfigProperties = $null
     }
@@ -248,5 +261,44 @@ Describe 'Invoke-OmadaSqlTroubleshooter log level seeding' {
 
     It 'seeds the runtime level through the shared resolver' {
         $Script:EntryPointSource | Should -Match 'Resolve-LogLevel'
+    }
+}
+
+Describe 'Initialize-GlobalConfigSettings show request body resolution' {
+
+    BeforeEach {
+        $Script:ConfigWrites = [System.Collections.Generic.List[object]]::new()
+        $Script:BodyRedactionStateCalls = [System.Collections.Generic.List[object]]::new()
+        $Script:MainForm = $null
+        $Script:GlobalConfigProperties = $null
+        $Script:AppGlobalConfig = New-PersistedConfig -LogLevel "DEBUG"
+    }
+
+    It 'leaves the option off when neither the parameter nor the stored setting asks for it' {
+        $Script:RunTimeConfig = New-RuntimeConfig -LogLevelSetting "WARNING" -LogLevelExplicit $false -SkipBodyRedaction $false
+
+        Initialize-GlobalConfigSettings
+
+        $Script:BodyRedactionStateCalls | Should -Contain $false
+        $Script:BodyRedactionStateCalls | Should -Not -Contain $true
+    }
+
+    It 'turns the option on for -SkipBodyRedaction, before the first request' {
+        $Script:RunTimeConfig = New-RuntimeConfig -LogLevelSetting "WARNING" -LogLevelExplicit $false -SkipBodyRedaction $true
+
+        Initialize-GlobalConfigSettings
+
+        $Script:BodyRedactionStateCalls | Should -Contain $true
+        # ...and stored, so the log viewer opens with the checkbox already checked.
+        ($Script:ConfigWrites | Where-Object { $_.Property -eq "SkipBodyRedaction" }).Value | Should -BeTrue
+    }
+
+    It 'restores the option a previous session stored' {
+        $Script:AppGlobalConfig | Add-Member -NotePropertyName "SkipBodyRedaction" -NotePropertyValue $true -Force
+        $Script:RunTimeConfig = New-RuntimeConfig -LogLevelSetting "WARNING" -LogLevelExplicit $false -SkipBodyRedaction $false
+
+        Initialize-GlobalConfigSettings
+
+        $Script:BodyRedactionStateCalls | Should -Contain $true
     }
 }

--- a/tests/Invoke-OmadaPSWebRequestWrapper.Tests.ps1
+++ b/tests/Invoke-OmadaPSWebRequestWrapper.Tests.ps1
@@ -147,13 +147,24 @@ Describe "Invoke-OmadaPSWebRequestWrapper body redaction pass-through" {
         $Script:SkipBodyRedaction = $false
     }
 
+    # Each test declares the module it is about, so none of them depends on the order they run in
+    # or on which stub a previous test left behind, and each asserts the capability it assumes
+    # before asserting the behaviour that follows from it.
     It "does not pass SkipBodyRedaction to an OmadaWeb.PS that does not declare it" {
         # The pinned minimum version predates the switch, and splatting a parameter a cmdlet does
         # not have is a terminating error - so the capability check has to keep the key out.
         Initialize-WrapperTestState
         $Script:SkipBodyRedaction = $true
 
-        # The BeforeAll mock takes only remaining arguments, standing in for an older module.
+        function Invoke-OmadaRestMethod {
+            [CmdletBinding()]
+            param(
+                [Parameter(ValueFromRemainingArguments = $true)]$IgnoredRest
+            )
+            return [PSCustomObject]@{ value = @() }
+        }
+
+        (Get-Command Invoke-OmadaRestMethod).Parameters.ContainsKey("SkipBodyRedaction") | Should -BeFalse
         { Invoke-OmadaPSWebRequestWrapper } | Should -Not -Throw
         $Script:RunTimeData.RestMethodParam.ContainsKey("SkipBodyRedaction") | Should -BeFalse
     }
@@ -162,7 +173,6 @@ Describe "Invoke-OmadaPSWebRequestWrapper body redaction pass-through" {
         Initialize-WrapperTestState
         $Script:SkipBodyRedaction = $true
 
-        # Shadows the older mock for the duration of this test with a module that has the switch.
         function Invoke-OmadaRestMethod {
             [CmdletBinding()]
             param(
@@ -173,6 +183,7 @@ Describe "Invoke-OmadaPSWebRequestWrapper body redaction pass-through" {
             return [PSCustomObject]@{ value = @() }
         }
 
+        (Get-Command Invoke-OmadaRestMethod).Parameters.ContainsKey("SkipBodyRedaction") | Should -BeTrue
         $script:ReceivedSkipBodyRedaction = $null
         Invoke-OmadaPSWebRequestWrapper | Out-Null
 
@@ -194,6 +205,7 @@ Describe "Invoke-OmadaPSWebRequestWrapper body redaction pass-through" {
             return [PSCustomObject]@{ value = @() }
         }
 
+        (Get-Command Invoke-OmadaRestMethod).Parameters.ContainsKey("SkipBodyRedaction") | Should -BeTrue
         $script:ReceivedSkipBodyRedaction = $null
         Invoke-OmadaPSWebRequestWrapper | Out-Null
 

--- a/tests/Invoke-OmadaPSWebRequestWrapper.Tests.ps1
+++ b/tests/Invoke-OmadaPSWebRequestWrapper.Tests.ps1
@@ -140,3 +140,64 @@ Describe "Invoke-OmadaPSWebRequestWrapper connection state" {
         $script:ConnectionStateCalls[0] | Should -BeFalse
     }
 }
+
+Describe "Invoke-OmadaPSWebRequestWrapper body redaction pass-through" {
+
+    AfterEach {
+        $Script:SkipBodyRedaction = $false
+    }
+
+    It "does not pass SkipBodyRedaction to an OmadaWeb.PS that does not declare it" {
+        # The pinned minimum version predates the switch, and splatting a parameter a cmdlet does
+        # not have is a terminating error - so the capability check has to keep the key out.
+        Initialize-WrapperTestState
+        $Script:SkipBodyRedaction = $true
+
+        # The BeforeAll mock takes only remaining arguments, standing in for an older module.
+        { Invoke-OmadaPSWebRequestWrapper } | Should -Not -Throw
+        $Script:RunTimeData.RestMethodParam.ContainsKey("SkipBodyRedaction") | Should -BeFalse
+    }
+
+    It "passes the current state to an OmadaWeb.PS that declares the switch" {
+        Initialize-WrapperTestState
+        $Script:SkipBodyRedaction = $true
+
+        # Shadows the older mock for the duration of this test with a module that has the switch.
+        function Invoke-OmadaRestMethod {
+            [CmdletBinding()]
+            param(
+                [switch]$SkipBodyRedaction,
+                [Parameter(ValueFromRemainingArguments = $true)]$IgnoredRest
+            )
+            $script:ReceivedSkipBodyRedaction = $SkipBodyRedaction.IsPresent
+            return [PSCustomObject]@{ value = @() }
+        }
+
+        $script:ReceivedSkipBodyRedaction = $null
+        Invoke-OmadaPSWebRequestWrapper | Out-Null
+
+        $Script:RunTimeData.RestMethodParam.SkipBodyRedaction | Should -BeTrue
+        $script:ReceivedSkipBodyRedaction | Should -BeTrue
+    }
+
+    It "passes the switch as off when the option is off" {
+        Initialize-WrapperTestState
+        $Script:SkipBodyRedaction = $false
+
+        function Invoke-OmadaRestMethod {
+            [CmdletBinding()]
+            param(
+                [switch]$SkipBodyRedaction,
+                [Parameter(ValueFromRemainingArguments = $true)]$IgnoredRest
+            )
+            $script:ReceivedSkipBodyRedaction = $SkipBodyRedaction.IsPresent
+            return [PSCustomObject]@{ value = @() }
+        }
+
+        $script:ReceivedSkipBodyRedaction = $null
+        Invoke-OmadaPSWebRequestWrapper | Out-Null
+
+        $Script:RunTimeData.RestMethodParam.SkipBodyRedaction | Should -BeFalse
+        $script:ReceivedSkipBodyRedaction | Should -BeFalse
+    }
+}

--- a/tests/Open-LogForm.Tests.ps1
+++ b/tests/Open-LogForm.Tests.ps1
@@ -56,3 +56,89 @@ Describe 'Open-LogForm log level fallback' {
         $Script:OpenLogFormSource | Should -Match 'Get-ConfigSchemaDefault -Property "LogLevel"'
     }
 }
+
+Describe 'Show request body option (issue #62)' {
+
+    BeforeAll {
+        $ParentPath = Split-Path -Path $PSScriptRoot -Parent
+        $Script:ShowRequestBodyCheckBox = $Script:LogFormXaml.SelectSingleNode("//w:CheckBox[@x:Name='CheckboxShowRequestBody']", $Script:XamlNamespace)
+        $Script:ShowRequestBodyEventSource = Get-Content (Join-Path $ParentPath -ChildPath "src\lib\Events\LogForm.Elements.CheckboxShowRequestBody.ps1") -Raw
+        $Script:BodyRedactionStateSource = Get-Content (Join-Path $ParentPath -ChildPath "src\lib\functions\Private\Set-BodyRedactionState.ps1") -Raw
+        $Script:EntryPointSource = Get-Content (Join-Path $ParentPath -ChildPath "src\lib\functions\Public\Invoke-OmadaSqlTroubleshooter.ps1") -Raw
+        $Script:GlobalConfigSchema = Get-Content (Join-Path $ParentPath -ChildPath "src\lib\schema\appGlobalConfigSchema.json") -Raw | ConvertFrom-Json
+    }
+
+    Context 'Checkbox' {
+
+        It 'sits in the log form bottom bar' {
+            $Script:ShowRequestBodyCheckBox | Should -Not -BeNullOrEmpty
+            $Script:ShowRequestBodyCheckBox.GetAttribute("Content") | Should -Be "Show request body"
+        }
+
+        It 'starts unchecked, so the safe default survives a fresh install' {
+            $Script:ShowRequestBodyCheckBox.Attributes["IsChecked"] | Should -BeNullOrEmpty
+        }
+
+        It 'warns in its tooltip that the query text reaches an exported log file' {
+            $ToolTip = $Script:ShowRequestBodyCheckBox.GetAttribute("ToolTip")
+
+            $ToolTip | Should -Match "exported log file"
+            # The tooltip is where the checkbox label and the cmdlet switch are tied together.
+            $ToolTip | Should -Match "SkipBodyRedaction"
+        }
+    }
+
+    Context 'Event handler' {
+
+        It 'routes both directions through the single state writer' {
+            $Script:ShowRequestBodyEventSource | Should -Match 'Add_Checked'
+            $Script:ShowRequestBodyEventSource | Should -Match 'Add_UnChecked'
+            $Script:ShowRequestBodyEventSource | Should -Match 'Set-BodyRedactionState -Enabled \$true'
+            $Script:ShowRequestBodyEventSource | Should -Match 'Set-BodyRedactionState -Enabled \$false'
+        }
+
+        It 'persists the choice like the other log viewer checkboxes do' {
+            $Script:ShowRequestBodyEventSource | Should -Match 'Set-ConfigProperty -Property "SkipBodyRedaction"'
+        }
+    }
+
+    Context 'State writer' {
+
+        It 'sets the module scope flag the redactor reads' {
+            $Script:BodyRedactionStateSource | Should -Match '\$Script:SkipBodyRedaction = \$Enabled'
+        }
+
+        It 'warns once per session that query text now reaches the log' {
+            $Script:BodyRedactionStateSource | Should -Match 'SkipBodyRedactionWarned'
+            $Script:BodyRedactionStateSource | Should -Match '-LogType WARNING'
+        }
+    }
+
+    Context 'Command line' {
+
+        It 'offers a -SkipBodyRedaction switch named after the OmadaWeb.PS one it drives' {
+            $Script:EntryPointSource | Should -Match '\[switch\]\$SkipBodyRedaction'
+        }
+
+        It 'seeds the runtime state before the first request' {
+            $Script:EntryPointSource | Should -Match 'SkipBodyRedaction\s+= \$SkipBodyRedaction.IsPresent'
+            $Script:EntryPointSource | Should -Match '\$Script:SkipBodyRedaction = \$SkipBodyRedaction.IsPresent'
+        }
+
+        It 'documents the switch' {
+            $Script:EntryPointSource | Should -Match '\.PARAMETER SkipBodyRedaction'
+        }
+    }
+
+    Context 'Persistence' {
+
+        It 'is a known global config property, so Set-ConfigProperty stores it instead of warning' {
+            ($Script:GlobalConfigSchema | Where-Object { $_.Name -eq "SkipBodyRedaction" }).Type | Should -Be "Bool"
+        }
+
+        It 'reflects the resolved state in the checkbox when the log viewer opens' {
+            $Script:OpenLogFormSource | Should -Match 'CheckboxShowRequestBody.IsChecked'
+            $Script:OpenLogFormSource | Should -Match '\$Script:RunTimeConfig.Logging.SkipBodyRedaction'
+        }
+    }
+}

--- a/tests/Open-LogForm.Tests.ps1
+++ b/tests/Open-LogForm.Tests.ps1
@@ -63,7 +63,6 @@ Describe 'Show request body option (issue #62)' {
         $ParentPath = Split-Path -Path $PSScriptRoot -Parent
         $Script:ShowRequestBodyCheckBox = $Script:LogFormXaml.SelectSingleNode("//w:CheckBox[@x:Name='CheckboxShowRequestBody']", $Script:XamlNamespace)
         $Script:ShowRequestBodyEventSource = Get-Content (Join-Path $ParentPath -ChildPath "src\lib\Events\LogForm.Elements.CheckboxShowRequestBody.ps1") -Raw
-        $Script:BodyRedactionStateSource = Get-Content (Join-Path $ParentPath -ChildPath "src\lib\functions\Private\Set-BodyRedactionState.ps1") -Raw
         $Script:EntryPointSource = Get-Content (Join-Path $ParentPath -ChildPath "src\lib\functions\Public\Invoke-OmadaSqlTroubleshooter.ps1") -Raw
         $Script:GlobalConfigSchema = Get-Content (Join-Path $ParentPath -ChildPath "src\lib\schema\appGlobalConfigSchema.json") -Raw | ConvertFrom-Json
     }
@@ -99,18 +98,6 @@ Describe 'Show request body option (issue #62)' {
 
         It 'persists the choice like the other log viewer checkboxes do' {
             $Script:ShowRequestBodyEventSource | Should -Match 'Set-ConfigProperty -Property "SkipBodyRedaction"'
-        }
-    }
-
-    Context 'State writer' {
-
-        It 'sets the module scope flag the redactor reads' {
-            $Script:BodyRedactionStateSource | Should -Match '\$Script:SkipBodyRedaction = \$Enabled'
-        }
-
-        It 'warns once per session that query text now reaches the log' {
-            $Script:BodyRedactionStateSource | Should -Match 'SkipBodyRedactionWarned'
-            $Script:BodyRedactionStateSource | Should -Match '-LogType WARNING'
         }
     }
 

--- a/tests/Open-LogForm.Tests.ps1
+++ b/tests/Open-LogForm.Tests.ps1
@@ -115,6 +115,12 @@ Describe 'Show request body option (issue #62)' {
         It 'documents the switch' {
             $Script:EntryPointSource | Should -Match '\.PARAMETER SkipBodyRedaction'
         }
+
+        It 'rearms the once-per-session warning, since the module outlives an application session' {
+            # Without this, a second Invoke-OmadaSqlTroubleshooter in the same console would enable
+            # body logging without warning about it.
+            $Script:EntryPointSource | Should -Match '\$Script:SkipBodyRedactionWarned = \$false'
+        }
     }
 
     Context 'Persistence' {

--- a/tests/Set-BodyRedactionState.Tests.ps1
+++ b/tests/Set-BodyRedactionState.Tests.ps1
@@ -1,0 +1,116 @@
+BeforeAll {
+    $ParentPath = Split-Path -Path $PSScriptRoot -Parent
+    $FunctionPath = Join-Path $ParentPath -ChildPath "src\lib\functions\Private"
+    . (Join-Path $FunctionPath -ChildPath "Set-BodyRedactionState.ps1")
+    # The tracer preamble of the function under test redacts its bound parameters.
+    . (Join-Path $FunctionPath -ChildPath "ConvertTo-RedactedLogString.ps1")
+
+    $Script:Tracer = [System.Diagnostics.Trace]
+
+    # Records what reached the log instead of touching the real log object, so the assertions can be
+    # about which lines are written rather than about how they are rendered.
+    function Write-LogOutput {
+        param(
+            [parameter(Mandatory = $false, Position = 0, ValueFromPipeline = $true)]
+            [string]$Message,
+            $ErrorObject,
+            [string]$LogType = "INFO",
+            [switch]$SkipDialog
+        )
+        process {
+            $Script:LogLines.Add([PSCustomObject]@{ LogType = $LogType; Message = $Message; SkipDialog = $SkipDialog.IsPresent })
+        }
+    }
+}
+
+Describe 'Set-BodyRedactionState' {
+
+    BeforeEach {
+        $Script:LogLines = [System.Collections.Generic.List[object]]::new()
+        $Script:SkipBodyRedaction = $false
+        $Script:SkipBodyRedactionWarned = $false
+        $Script:RunTimeConfig = [PSCustomObject]@{
+            ApplicationName = "Test"
+            Logging         = [PSCustomObject]@{ SkipBodyRedaction = $false }
+        }
+    }
+
+    Context 'State' {
+
+        It 'sets the module scope flag the redactor reads' {
+            Set-BodyRedactionState -Enabled $true
+
+            $Script:SkipBodyRedaction | Should -BeTrue
+        }
+
+        It 'clears the flag again' {
+            Set-BodyRedactionState -Enabled $true
+            Set-BodyRedactionState -Enabled $false
+
+            $Script:SkipBodyRedaction | Should -BeFalse
+        }
+
+        It 'mirrors the state into the runtime configuration the rest of the application reads' {
+            Set-BodyRedactionState -Enabled $true
+
+            $Script:RunTimeConfig.Logging.SkipBodyRedaction | Should -BeTrue
+        }
+    }
+
+    Context 'Warning' {
+
+        It 'warns that query text now reaches the log and any file exported from it' {
+            Set-BodyRedactionState -Enabled $true
+
+            $Warnings = $Script:LogLines | Where-Object { $_.LogType -eq "WARNING" }
+            ($Warnings | Measure-Object).Count | Should -Be 1
+            $Warnings[0].Message | Should -Match "exported from it"
+        }
+
+        It 'warns without a modal dialog, which would land in front of the query being run' {
+            Set-BodyRedactionState -Enabled $true
+
+            ($Script:LogLines | Where-Object { $_.LogType -eq "WARNING" })[0].SkipDialog | Should -BeTrue
+        }
+
+        It 'warns only once per session, however often the option is toggled' {
+            Set-BodyRedactionState -Enabled $true
+            Set-BodyRedactionState -Enabled $false
+            Set-BodyRedactionState -Enabled $true
+
+            ($Script:LogLines | Where-Object { $_.LogType -eq "WARNING" } | Measure-Object).Count | Should -Be 1
+        }
+
+        It 'does not warn when the option is switched off' {
+            Set-BodyRedactionState -Enabled $false
+
+            $Script:LogLines | Where-Object { $_.LogType -eq "WARNING" } | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'Log noise' {
+
+        It 'writes nothing at all when the option was already off' {
+            # Initialize-GlobalConfigSettings resolves this state on every start, so a line here
+            # would appear in the log of every session that never touches the option.
+            Set-BodyRedactionState -Enabled $false
+
+            $Script:LogLines | Should -BeNullOrEmpty
+        }
+
+        It 'reports the option being switched off only when it was actually on' {
+            Set-BodyRedactionState -Enabled $true
+            $Script:LogLines.Clear()
+
+            Set-BodyRedactionState -Enabled $false
+
+            ($Script:LogLines | Where-Object { $_.LogType -eq "LOG" }).Message | Should -Match "disabled"
+        }
+
+        It 'reports the option being on, so the state is visible in the log' {
+            Set-BodyRedactionState -Enabled $true
+
+            ($Script:LogLines | Where-Object { $_.LogType -eq "LOG" }).Message | Should -Match "enabled"
+        }
+    }
+}


### PR DESCRIPTION
Closes #62

## What was masked, and why it mattered

The central redaction layer (#39) replaces every request **body** value with its type and length, wherever a body is logged. That is the right default for a log window with an "Export Log File" button - but in a SQL troubleshooter the request body *is* the query, so the single most useful line in the log read:

```
Parameters: { "Uri": "...", "Method": "POST", "Body": { "C_QUERY": "String(24)" } }
```

When a query fails, comes back empty, or does not match what the editor shows, `String(24)` is exactly what you need to read and cannot - and the workaround was to re-run the query outside the app, which is what the app exists to avoid.

This adds an opt-in option, in the UI and on the command line, that lifts **that one rule and nothing else**.

## The new pieces

| Piece | File | What it does |
| --- | --- | --- |
| Checkbox | `src/Lib/ui/LogForm.xaml` | `CheckboxShowRequestBody` ("Show request body") in the bottom bar next to Word wrap / Console Log, with a tooltip that names `-SkipBodyRedaction` and warns about exported log files |
| Event handler | `src/Lib/Events/LogForm.Elements.CheckboxShowRequestBody.ps1` | `Add_Checked`/`Add_UnChecked` route through the state writer and persist via `Set-ConfigProperty -Property "SkipBodyRedaction"`, exactly like `CheckboxConsoleLog` |
| State writer | `src/Lib/Functions/Private/Set-BodyRedactionState.ps1` (new) | Single writer of `$Script:SkipBodyRedaction` and `$Script:RunTimeConfig.Logging.SkipBodyRedaction`; emits one `WARNING` per session when the option is switched on |
| Redactor | `src/Lib/Functions/Private/ConvertTo-RedactedLogString.ps1` | `Get-RedactedMemberValue` gates the `Body` rule on module-scope state; `-ShapeOnly` is gated the same way so the `Body:` lines agree with the `Parameters:` line |
| Cmdlet switch | `src/Lib/Functions/Public/Invoke-OmadaSqlTroubleshooter.ps1` | `[switch]$SkipBodyRedaction`, documented, seeds the flag before anything can log |
| Start-up resolution | `src/Lib/Functions/Private/Initialize-GlobalConfigSettings.ps1` | Parameter wins, otherwise the persisted setting is restored - the same shape as console logging directly above it |
| Checkbox reflection | `src/Lib/Functions/Private/Open-LogForm.ps1` | Opens the log viewer with the box reflecting the resolved state |
| Persistence | `src/Lib/schema/appGlobalConfigSchema.json` | `SkipBodyRedaction` (Bool) as a global config property |
| Module pass-through | `src/Lib/Functions/Private/Invoke-OmadaPSWebRequestWrapper.ps1` | Adds `SkipBodyRedaction` to `$Script:RunTimeData.RestMethodParam` **only when the installed `Invoke-OmadaRestMethod` declares it** |

## Acceptance criteria

- [x] **With the option off, behaviour is byte-for-byte what it is today.**
  `ConvertTo-RedactedLogString.Tests.ps1` → *"produces byte-for-byte the output it produced before the option existed"* asserts `-BeExactly` against the exact JSON the pre-change code emits for a `Uri`/`Method`/`Body` parameter set, plus *"still reduces a body passed on its own via -ShapeOnly to its shape"*. All 31 pre-existing tests in that suite still pass unchanged.
- [x] **With the checkbox checked, the `Parameters:` line at log level VERBOSE shows the executed query text.**
  The `Parameters:` line in `Invoke-OmadaPSWebRequestWrapper` is `ConvertTo-RedactedLogString -InputObject $Private:Parameters` at `-LogType VERBOSE`; *"shows the executed query text instead of its shape"* proves that call now renders `SELECT * FROM dbo.Identity` in full, and the checkbox handler is what sets the state (`Open-LogForm.Tests.ps1` → *"routes both directions through the single state writer"*).
- [x] **`Invoke-OmadaSqlTroubleshooter -SkipBodyRedaction` starts with the checkbox checked and the first request already unredacted.**
  `Initialize-GlobalConfigSettings.Tests.ps1` → *"turns the option on for -SkipBodyRedaction, before the first request"* (state resolved during initialization, before any request, and stored so the viewer opens checked); `Open-LogForm.Tests.ps1` → *"seeds the runtime state before the first request"* and *"reflects the resolved state in the checkbox when the log viewer opens"*.
- [x] **A secret inside the body is still masked with the option on - covered by a test in `tests/ConvertTo-RedactedLogString.Tests.ps1`.**
  Four tests: a body member named `Password` (still `***REDACTED***`), a `PSCredential` in the body (user name kept, password never serialized), a `SecureString` in the body, and a bearer token inside a body value (caught by `Protect-LogMessage`, the last gate before the exportable log). Plus *"leaves everything outside the body alone"* for headers.
- [x] **The exported log file contains what the window shows, and the tooltip says so before the user clicks.**
  Export writes `AppLogObject` verbatim, which is what the window shows, so this is unchanged by construction. The tooltip reads: *"Log the request body (your query) instead of its shape - the same as starting with -SkipBodyRedaction. Secrets are still masked and a very long value is still truncated, but the query text ends up in this window and in any exported log file."* - asserted by *"warns in its tooltip that the query text reaches an exported log file"*. A `WARNING` line is also written to the log the first time the option is switched on in a session.

## Decisions worth reviewing

1. **Capability check instead of a version bump.** The issue asks for `$MinimumOmadaWebPSVersion` to be raised to the first OmadaWeb.PS release carrying `-SkipBodyRedaction`. Fortigi/OmadaWeb.PS#74 is merged, but no *published* release carries the switch yet, so a bump would pin the app to a version nobody can install. Instead the wrapper asks the installed cmdlet whether it has the parameter (`(Get-Command Invoke-OmadaRestMethod).Parameters.ContainsKey("SkipBodyRedaction")`) and only splats it when it does - splatting an undeclared parameter is a terminating error. `$MinimumOmadaWebPSVersion` stays at `2026.07.09.9`. This works the day the switch ships, with no follow-up release of this app; the cost is that the app's log can be ahead of the module's verbose stream on an older install, which is strictly better than today.
2. **The checkbox persists across sessions** (open question 1), through `Set-ConfigProperty`, following `CheckboxConsoleLog` exactly - the issue's own proposal and the predictable option. The counter-argument stands: this is the setting that puts query text into an exportable log, and resetting to off on every launch would be the safer default. The compensations are the tooltip and the once-per-session `WARNING`.
3. **A one-time WARNING when the option is switched on** (open question 3): *"Request body logging is enabled: query text is now written to this log in full, and to any log file exported from it."* It is written with `-SkipDialog` on purpose - `WARNING` otherwise pops a modal box, and this is a heads-up that belongs in the log the user is already looking at, not in front of the query they are trying to run. It fires once per session, including when the option is restored from the config or supplied as `-SkipBodyRedaction`.
4. **Naming** (open question 2): the checkbox reads "Show request body" (describes the effect), the switch is `-SkipBodyRedaction` (matches OmadaWeb.PS), and the tooltip names both so the connection is discoverable.
5. **`-ShapeOnly` is gated too** - a deliberate extension of the letter of the issue. Upstream OmadaWeb.PS gates only the `Body` name rule, but this app has four `"Body: {0}" -f (ConvertTo-RedactedLogString ... -ShapeOnly)` call sites (`Invoke-ExecuteQuery`, `Save-Query`, `Get-SqlHistory`, `New-TemporarySqlQueryObject`) that log the body *itself*. Leaving them shaped would produce one log showing the query on the `Parameters:` line and `String(24)` on the `Body:` line of the same request. It is the same rule at a call site with no key name to match on. Happy to narrow it if you would rather stay literally in step with upstream.
6. **A new private function rather than inline code.** Three places turn the option on (parameter, restored setting, checkbox) and all three must agree, so `Set-BodyRedactionState` is the single writer. The alternative was triplicating the assignment and the warning guard.
7. **Truncation is left alone, and the wording now admits it.** `ConvertTo-RedactedLogString` truncates any string over `MaxStringLength` (512) to `...(truncated, N chars)`. That is a *volume* rule, not a redaction rule, so lifting it would be lifting a second rule - out of scope here, and adjacent to #42. The consequence is real though: a query longer than 512 characters is still cut off, which blunts the feature for exactly the large queries you most want to read. The tooltip, parameter help, example and WARNING all say so rather than promising the body "as it was sent". **If you would rather this feature be useful for long queries, the change is one argument** - pass a larger `-MaxStringLength` from the `Parameters:`/`Body:` call sites when `$Script:SkipBodyRedaction` is set - and I am happy to add it here or file it as a follow-up.
8. **Neither source turns the option off.** `-SkipBodyRedaction` or a persisted "on" enables it; `-SkipBodyRedaction:$false` does *not* override a persisted "on". This mirrors `-LogToConsole`/`CheckboxConsoleLog` exactly, and unchecking the box (or `-Reset`) is how it goes off. Worth a look if you would rather the parameter were authoritative in both directions - that would mean diverging from the console-logging pattern.

## Verification

```
./build/build.ps1 -Task TestBuildOnly
```

| | Passed | Failed |
| --- | --- | --- |
| Baseline on `origin/main` (4b14e42) | 405 | 0 |
| This branch | 442 | 0 |

37 new tests. `Analyze` (PSScriptAnalyzer) and `Build` (formatting) both clean, psake `Success : True`. PR Validation green on both matrix legs (pwsh and Windows PowerShell 5.1).

### Review follow-ups in this branch

| Commit | Finding |
| --- | --- |
| b02f0a7 | `Set-BodyRedactionState` logged "disabled" on the default path, adding a line to every session that never uses the option. Now written only on a real on→off transition; `tests/Set-BodyRedactionState.Tests.ps1` (new) exercises the writer directly. |
| 8e9e193 | `$Script:SkipBodyRedactionWarned` survived between runs because the module outlives the app, so a second launch in the same console could enable body logging silently. Rearmed at start-up. |
| 77a6fd4 | The comment above the start-up resolution overstated what the `-or` does (see decision 8). |
| 35fce87 | Four user-facing strings promised the body "as it was sent" / "in full" while the length limit still truncates (see decision 7). |

One reported finding was **not** a defect: `Invoke-OmadaRestMethod @Parameters` vs `$Private:Parameters`. `Private:` is a scope modifier, not part of the name - both refer to the same hashtable in the same scope, and the two new wrapper tests assert the switch actually arrives at the cmdlet. Reasoning is in the resolved thread.
