### PR TITLE
Bundle and hash-verify the WebView2 SDK assemblies at build time (issue #54 Part B)

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,15 +295,24 @@ are no others. You can verify this for yourself in two ways: search the module s
 |---|---|---|---|
 | **Your Omada tenant** (`https://<tenant>.omada.cloud` or the URL you enter) | While connected | Your SQL query text, saved query metadata and OData requests; the session credential or token for the tenant | This is the application's actual work: the SQL Troubleshooter OData endpoint (`C_P_SQLTROUBLESHOOTING`) and the Omada Enterprise Server API |
 | **Your identity provider** (Entra ID or the tenant's own sign-in page) | On sign-in only | Your credentials, handled by the browser/WebView2 sign-in flow of [OmadaWeb.PS](https://github.com/Fortigi/OmadaWeb.PS) | Authentication |
-| `api.nuget.org` | On module import, and only when the pinned WebView2 assemblies are not already present | Nothing but the package request itself | Download the Microsoft WebView2 .NET SDK at the exact version pinned in [`src/DependencyLock.psd1`](src/DependencyLock.psd1), then verify it against the SHA-256 pinned there — see [SECURITY.md](SECURITY.md#runtime-dependency-verification) and [THIRD-PARTY-NOTICES.md](THIRD-PARTY-NOTICES.md) |
+| `api.nuget.org` | **Not on a normal import.** Only when the WebView2 assemblies shipped inside the module are missing or fail their hash check, or on a 32-bit process | Nothing but the package request itself | Fall back to downloading the Microsoft WebView2 .NET SDK at the exact version pinned in [`src/DependencyLock.psd1`](src/DependencyLock.psd1), then verify it against the SHA-256 pinned there — see [SECURITY.md](SECURITY.md#runtime-dependency-verification) and [THIRD-PARTY-NOTICES.md](THIRD-PARTY-NOTICES.md) |
 | `www.powershellgallery.com` | On module import, and only when the module was installed from the PowerShell Gallery | The module name, in a public package-lookup request | Warn you when a newer version is available |
 
 The last two are ordinary package requests to Microsoft-operated services. They carry no
 tenant name, no user name and no query data. No other host is contacted by this module.
 
-Once the WebView2 assemblies have been downloaded and verified, later imports contact
-`api.nuget.org` only when the pinned version changes. Nothing about the version is resolved over
-the network: it comes from the lock file that ships inside the module.
+**A normal import contacts `nuget.org` not at all.** The four WebView2 assemblies are fetched
+and hash-verified when the module is *built*, and ship inside the package in
+`Bin\WebView2Dlls\win-x64` (0.94 MB). They are loaded from there, and each one is re-checked
+against its pinned SHA-256 immediately before it is loaded. The application therefore starts on
+a machine with no route to nuget.org at all.
+
+`api.nuget.org` is contacted only if that bundle is unusable — deleted, corrupted, or a version
+that no longer matches the pin — or on a 32-bit process, for which no bundle is built. The
+module then downloads the same pinned package to
+`%LOCALAPPDATA%\OmadaSqlTroubleshooter\Bin\win-x64\` and verifies it there. Nothing about the
+version is resolved over the network in either case: it comes from the lock file that ships
+inside the module.
 
 ### Data stored on your machine
 
@@ -314,7 +323,7 @@ location beyond `%APPDATA%`, and nothing is written outside your profile.
 |---|---|---|---|---|
 | `%APPDATA%\OmadaSqlTroubleshooter\config\OmadaSqlTroubleshooter.json` | Application settings only: log level, window positions and sizes, last-used export folder and file type, tab capacity, and `InstanceGuid` (see below). No credentials, no query text, no results. | NTFS permissions on your profile | Until deleted | `Invoke-OmadaSqlTroubleshooter -Reset` restores defaults, or delete the file |
 | `%APPDATA%\OmadaSqlTroubleshooter\config\tabs.clixml` | Per-tab session state written when the application closes: tenant URL, user name, Entra application ID URI and tenant ID, the selected data connection, the *name* of the selected saved query, and — only if you ticked **Save password** — your password. The SQL text itself is not stored here; it lives in your Omada tenant. | The password field is encrypted with Windows DPAPI, bound to your Windows user account on that machine. The remaining fields are stored as plain CliXml. | Overwritten at each close; kept until deleted | `Invoke-OmadaSqlTroubleshooter -Reset` deletes the file, or delete it yourself |
-| `%LOCALAPPDATA%\OmadaSqlTroubleshooter\Bin\...` | The Microsoft WebView2 .NET SDK assemblies, downloaded from NuGet at the pinned version and hash-verified before use, plus a `WebView2.pin` stamp recording which pin they came from. No user data. | NTFS permissions on your profile | Until deleted; refreshed when the pinned version changes | `Clear-OmadaSqlTroubleshooterCache -Scope Binaries`, or delete the folder. It is re-downloaded and re-verified on the next import |
+| `%LOCALAPPDATA%\OmadaSqlTroubleshooter\Bin\...` | **Only used as a fallback.** The Microsoft WebView2 .NET SDK assemblies normally ship inside the module and this folder stays empty. It is populated only when that bundle is unusable, or on a 32-bit process: the assemblies are then downloaded from NuGet at the pinned version and hash-verified before use, plus a `WebView2.pin` stamp recording which pin they came from. No user data. | NTFS permissions on your profile | Until deleted; refreshed when the pinned version changes | `Clear-OmadaSqlTroubleshooterCache -Scope Binaries`, or delete the folder. It is re-downloaded and re-verified on the next import that needs it |
 | `%LOCALAPPDATA%\OmadaSqlTroubleshooter\Edge User Data\OmadaWebView2Profile` | A WebView2 browser-profile folder created when the first tab's editor starts. It is created but not currently used as a profile location — the editor's WebView2 uses the `%TEMP%` folder below — so it stays empty. | NTFS permissions on your profile | Until deleted | `Clear-OmadaSqlTroubleshooterCache -Scope BrowserProfiles`, or delete the folder |
 | `%TEMP%\OmadaSqlTroubleshooter` | The WebView2 user-data folder (browser cache and local storage) for the editor. This WebView2 instance only ever loads the local Monaco editor page — it never loads Omada or a sign-in page, so it holds no session cookies and no tenant data. | NTFS permissions on your profile | Until deleted; `%TEMP%` is not cleared automatically by the application | Delete the folder while the application is closed |
 | `%LOCALAPPDATA%\OmadaSqlTroubleShooter\Run.ps1`, plus Start Menu and Desktop shortcuts | A small launcher script and shortcuts. No user data. | NTFS permissions on your profile | Until deleted | Delete the file and the shortcuts |
@@ -416,8 +425,9 @@ This project is licensed under the MIT License. See the [LICENSE](LICENSE) file 
 
 ### Third-party components
 
-OmadaSqlTroubleshooter bundles the Monaco editor, downloads the Microsoft WebView2 .NET SDK at
-run time, and requires the Microsoft Edge WebView2 Runtime and the OmadaWeb.PS module. Every
+OmadaSqlTroubleshooter bundles the Monaco editor and the Microsoft WebView2 .NET SDK — the
+latter fetched and hash-verified at build time rather than committed to the repository — and
+requires the Microsoft Edge WebView2 Runtime and the OmadaWeb.PS module. Every
 such component, its version, its licence and where it comes from is listed in
 [THIRD-PARTY-NOTICES.md](THIRD-PARTY-NOTICES.md), which also records the review confirming that
 this project does not redistribute the WebView2 Runtime.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -89,14 +89,28 @@ Out of scope:
 
 ## Runtime dependency verification
 
-The module ships no binaries. The four `Microsoft.Web.WebView2` assemblies that host the Monaco SQL
-editor — `Microsoft.Web.WebView2.Core.dll`, `Microsoft.Web.WebView2.WinForms.dll`,
-`Microsoft.Web.WebView2.Wpf.dll` and `WebView2Loader.dll` — are downloaded to
-`%LOCALAPPDATA%\OmadaSqlTroubleshooter\Bin` on first import and then loaded into the PowerShell
-session with `[Reflection.Assembly]::LoadFrom`.
+The four `Microsoft.Web.WebView2` assemblies that host the Monaco SQL editor —
+`Microsoft.Web.WebView2.Core.dll`, `Microsoft.Web.WebView2.WinForms.dll`,
+`Microsoft.Web.WebView2.Wpf.dll` and `WebView2Loader.dll` — are the module's entire binary supply
+chain. They are loaded into the PowerShell session with `[Reflection.Assembly]::LoadFrom`, so
+whatever bytes are on disk at that moment run with the privileges of the session.
 
-That download is the module's entire binary supply chain, so it is verified before the package is
-expanded or copied into `Bin`:
+They reach the machine one of two ways, and both are verified:
+
+- **Bundled (normal).** `build/Get-BundledDependency.ps1` fetches the pinned package during the
+  build, checks its SHA-256 **before** opening it, extracts each pinned file, re-hashes every
+  extracted file against its own pin, and writes the result into the package at
+  `Bin\WebView2Dlls\win-x64` (0.94 MB). Importing the module then makes **no network call at all**,
+  which is what lets the application start on a machine with no route to nuget.org.
+- **Downloaded (fallback).** Where the bundle is missing, incomplete or fails its hash check — and on
+  32-bit processes, which are not bundled — `Install-WebView2` downloads the same pinned package to
+  `%LOCALAPPDATA%\OmadaSqlTroubleshooter\Bin` and verifies it there, exactly as before.
+
+Because the module now redistributes those assemblies rather than only downloading them, per-file
+SHA-256 pins were added alongside the package pin: a package hash cannot verify a file that has been
+extracted out of the package.
+
+Whichever route the assemblies took, these properties hold:
 
 - **Pinned and hash-verified.** The artefact has a pinned version, an exact download URL and an
   expected SHA-256 in [`src/DependencyLock.psd1`](src/DependencyLock.psd1), which ships with the
@@ -116,6 +130,16 @@ expanded or copied into `Bin`:
 - **No version lookup over the network.** The version comes from the lock file inside the module, so
   module import performs no NuGet metadata request at all, and nothing about the loaded bytes depends
   on what a feed happens to serve on a given day.
+- **Re-verified immediately before loading.** Verification used to happen only at download time, and
+  nothing re-checked a file that was swapped afterwards — both folders the assemblies can come from
+  are writable by something at some point. Each assembly is now hashed against its pinned value
+  immediately before `Add-ReflectionAssembly`, once per session. A mismatch **deletes the file** and
+  aborts rather than loading it; the next import re-downloads and re-verifies.
+- **A broken bundle degrades, it does not break.** `Test-WebView2Bundle` never throws. A missing,
+  incomplete, tampered or wrongly-versioned bundle returns "unusable" and the module falls back to
+  the verified download, so a damaged install cannot stop the module from importing. It compares
+  against the hashes in the lock file rather than the ones in the bundle's own stamp, since anything
+  able to swap an assembly could also rewrite a stamp sitting beside it.
 
 To force a fresh, verified download — after a rollback, after an aborted integrity check, or simply
 to be sure of what is on disk:
@@ -150,19 +174,36 @@ To do it by hand:
 ./build/Update-DependencyLock.ps1 -Check     # verify without changing anything
 ```
 
-### Why the assemblies are still downloaded rather than shipped
+### Why the assemblies are shipped, and why the download stays
 
-Packaging the assemblies into the module at build time is the better end state, and it is planned:
-issue [#54](https://github.com/Fortigi/OmadaSqlTroubleshooter/issues/54) Part B covers bundling them
-into the published package with per-file hashes, keeping this download as the fallback. It is not in
-this release because redistributing the WebView2 SDK changes Fortigi's obligations under Microsoft's
-Distributable Code terms, and that review has to be completed and recorded in
-[THIRD-PARTY-NOTICES.md](THIRD-PARTY-NOTICES.md) before the first bundled release.
+Shipping them removes the last reason the application needed egress to nuget.org to start. That was
+never a theoretical problem: restricted corporate networks are the norm for Omada customers, and
+`Install-WebView2` returning `$false` is a terminating error, so a machine without a route to
+nuget.org could not run the application at all.
 
-Pinning and verifying stands on its own in the meantime: it closes the integrity hole for a few
-kilobytes of text, needs no licensing decision, and is a prerequisite for bundling anyway — a
-build-time fetch that is not itself verified would only move the unverified download from the user's
-machine to the build agent.
+The build-time fetch is verified for the same reason the run-time one is. Bundling *without* pinning
+would only move the unverified download from the user's machine to the build agent, which is why the
+pin and the hash gate landed first, in
+[#54](https://github.com/Fortigi/OmadaSqlTroubleshooter/issues/54) Part A.
+
+The `%LOCALAPPDATA%` download path stays, for three reasons:
+
+1. The module folder is typically read-only, and the bundle is used in place. Nothing is copied out
+   of it, so a writable location is still needed when the bundle cannot be used.
+2. A damaged or corrupted bundle has to degrade to something that works rather than bricking the
+   install.
+3. 32-bit processes are not bundled — the manifest declares `ProcessorArchitecture = 'Amd64'` — and
+   still need the assemblies.
+
+> **Licensing status.** Bundling moves `Microsoft.Web.WebView2` from "downloaded by the user" to
+> "redistributed by Fortigi", which is a real change in Fortigi's obligations. The redistribution
+> review in [THIRD-PARTY-NOTICES.md §1.3](THIRD-PARTY-NOTICES.md) is currently a **draft awaiting
+> sign-off** and must be accepted by a named person at Fortigi before the first release that ships
+> the bundle.
+
+Only the SDK assemblies are bundled. The 260 MB WebView2 **Runtime** is not, and bundling it was
+rejected — see the note below and
+[THIRD-PARTY-NOTICES.md §3.1](THIRD-PARTY-NOTICES.md#31-microsoft-edge-webview2-runtime).
 
 Note that the **WebView2 Runtime** is a separate question and is not affected by any of this. It is a
 prerequisite the user installs from Microsoft; this project neither ships nor downloads it. See

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -11,21 +11,33 @@ obligations apply:
 
 | Section | How the component reaches the user | Redistributed by Fortigi? |
 |---|---|---|
-| [1. Redistributed components](#1-redistributed-components) | Committed to this repository and shipped inside the published module | **Yes** |
+| [1. Redistributed components](#1-redistributed-components) | Committed to this repository, **or fetched and hash-verified at build time**, and shipped inside the published module | **Yes** |
 | [2. Downloaded at run time](#2-components-downloaded-at-run-time) | Fetched from the vendor's servers onto the user's machine by this module | No |
 | [3. Prerequisites](#3-prerequisites-installed-by-the-user) | Installed separately by the user | No |
 
-Last reviewed: **2026-08-21**, against commit contents of `src/`.
-The inventory below is checked automatically on every pull request by
-`tests/ThirdPartyNotices.Tests.ps1`, so it cannot silently drift out of date.
+Inventory last reviewed: **2026-09-01**, against commit contents of `src/` and the pinned
+package in `src/DependencyLock.psd1`. The inventory below is checked automatically on every pull
+request by `tests/ThirdPartyNotices.Tests.ps1`, so it cannot silently drift out of date.
+
+> **Outstanding:** the redistribution review for the WebView2 .NET SDK in
+> [§1.3](#13-microsoftwebwebview2-webview2-net-sdk) is a **draft awaiting sign-off**. It must be
+> accepted by a named person at Fortigi before the first release that ships the bundled
+> assemblies.
 
 ---
 
 ## 1. Redistributed components
 
-The files below are committed to this repository and are copied into the published
-`OmadaSqlTroubleshooter` package by `build/psakeBuild.ps1`. Their licence notices travel with
-the package: `LICENSE` and this file are included in the module output.
+The files below are committed to this repository **or fetched and hash-verified at build time**,
+and are copied into the published `OmadaSqlTroubleshooter` package by `build/psakeBuild.ps1`.
+Their licence notices travel with the package: `LICENSE` and this file are included in the
+module output.
+
+Nothing binary is committed to this repository. The one component that is not in the repository
+— the WebView2 .NET SDK in §1.3 — is downloaded from NuGet during the build, verified against
+the SHA-256 pinned in `src/DependencyLock.psd1`, and only then written into the package. That
+keeps the repository free of binaries (asserted by `tests/ThirdPartyNotices.Tests.ps1`) while
+still shipping a module that works without network access.
 
 ### 1.1 Monaco Editor
 
@@ -93,6 +105,107 @@ icon artwork carries a different licence (CC BY 4.0) from the surrounding MIT-li
 Attribution, as CC BY 4.0 requires: *Codicons* © Microsoft Corporation, licensed under
 [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/), unmodified.
 
+### 1.3 Microsoft.Web.WebView2 (WebView2 .NET SDK)
+
+| Field | Value |
+|---|---|
+| Component | `Microsoft.Web.WebView2` |
+| Version | **1.0.4129.50** — pinned in `src/DependencyLock.psd1` |
+| Publisher | Microsoft Corporation |
+| Licence | See the licence text and the **redistribution review** below |
+| Licence text | Reproduced below, from `LICENSE.txt` in the pinned package · <https://www.nuget.org/packages/Microsoft.Web.WebView2/1.0.4129.50/license> |
+| Project | <https://aka.ms/webview> |
+| Fetched by | `build/Get-BundledDependency.ps1`, during the build |
+| Fetched from | `https://api.nuget.org/v3-flatcontainer/microsoft.web.webview2/1.0.4129.50/microsoft.web.webview2.1.0.4129.50.nupkg` |
+| Verified against | SHA-256 `d3934f482d484b89fb4825df720c710664e1143a1e90f7b3a60794ef33f473d2` for the package, plus a per-file SHA-256 for each assembly, all pinned in `src/DependencyLock.psd1` |
+| Location in repository | *Not committed.* Fetched at build time |
+| Location in package | `Bin/WebView2Dlls/win-x64/` |
+| Size in package | 0.94 MB (986,496 bytes of assemblies, plus a `WebView2.pin` stamp) |
+
+Four assemblies are taken from the package and shipped in the module:
+`Microsoft.Web.WebView2.Core.dll`, `Microsoft.Web.WebView2.WinForms.dll`,
+`Microsoft.Web.WebView2.Wpf.dll` and `WebView2Loader.dll`. They host the Monaco editor inside
+the WPF application. The WPF assembly is taken from the package's `lib_manual/netcoreapp3.0`
+folder; the package ships three builds of it with different bytes, and the pinned `Source` in
+the lock file settles which one is meant.
+
+The version is **not** resolved at run time. It is pinned, together with the exact download URL
+and the expected SHA-256 of the package *and of every individual file*, in
+[`src/DependencyLock.psd1`](src/DependencyLock.psd1), which ships with the module. Each
+assembly is re-verified against its pinned hash immediately before it is loaded. See
+[SECURITY.md](SECURITY.md#runtime-dependency-verification).
+
+**Run-time fallback.** Where the bundle is missing or fails verification — a damaged install, or
+a 32-bit process, which is not bundled — the module falls back to downloading the same pinned
+package to `%LOCALAPPDATA%\OmadaSqlTroubleshooter\Bin\win-x64\` (or `win-x86`) and verifying it
+there, exactly as before. That fallback is described in §2.
+
+#### Redistribution review — DRAFT, NOT YET SIGNED OFF
+
+> **This section is a draft prepared for review. It is not a conclusion, and no one has yet
+> accepted it on Fortigi's behalf. Bundling the SDK moves this component from "downloaded by the
+> user" to "redistributed by Fortigi", which is a real change in Fortigi's obligations. A named
+> person at Fortigi must read the terms below and record their conclusion here before the first
+> release that ships the bundle.**
+>
+> **TODO: reviewed by \<name\>, \<date\>.**
+
+The pinned package carries its terms in `LICENSE.txt` at the package root. Those terms are not
+the Microsoft Software License Terms "Distributable Code" boilerplate that governs the WebView2
+*Runtime* (§3.1); they are a BSD-3-Clause-style grant. Reproduced verbatim:
+
+```
+Copyright (C) Microsoft Corporation. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * The name of Microsoft Corporation, or the names of its contributors
+may not be used to endorse or promote products derived from this
+software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```
+
+Points the reviewer needs to decide on, each of which the draft above only *proposes* an answer to:
+
+1. **Is binary redistribution permitted at all?** The second bullet permits "redistributions in
+   binary form" provided the copyright notice, the conditions and the disclaimer are reproduced
+   "in the documentation and/or other materials provided with the distribution". Reproducing the
+   text in this file, which `build/psakeBuild.ps1` copies into every published package, is the
+   intended way of satisfying that. The reviewer should confirm that this file counts as the
+   accompanying documentation for a PowerShell Gallery package.
+2. **The no-endorsement clause.** The third bullet forbids using Microsoft's name to endorse or
+   promote the product. Nothing in the README, the manifest or the gallery description currently
+   does so, but that is a constraint on future marketing copy, not a one-off check.
+3. **Does the `NOTICE.txt` in the package carry through?** The package also contains a
+   `NOTICE.txt` listing third-party material inside the SDK (Antlr3.Runtime and others). It is
+   not currently reproduced here, and the reviewer should decide whether shipping the four
+   assemblies obliges Fortigi to carry it as well.
+4. **Which mode does this actually put Fortigi in?** §3.1 records a dated conclusion that this
+   project does not redistribute the WebView2 *Runtime*. That conclusion is unaffected — the
+   Runtime is not bundled, and the `No redistributable binaries` test keeps it that way. This
+   review is only about the SDK assemblies.
+
+Until this is signed off, the bundle should be treated as unreleased.
+
 ---
 
 ## 2. Components downloaded at run time
@@ -100,33 +213,20 @@ Attribution, as CC BY 4.0 requires: *Codicons* © Microsoft Corporation, license
 These are **not** redistributed by Fortigi. Each user's machine fetches them directly from the
 vendor, under the vendor's own terms, and they are stored only in that user's profile.
 
-### 2.1 Microsoft.Web.WebView2 (WebView2 .NET SDK)
+### 2.1 Microsoft.Web.WebView2 (WebView2 .NET SDK) — fallback only
 
-| Field | Value |
-|---|---|
-| Component | `Microsoft.Web.WebView2` |
-| Version | **1.0.4129.50** — pinned in `src/DependencyLock.psd1` |
-| Publisher | Microsoft Corporation |
-| Licence | Microsoft Software License Terms, embedded in the NuGet package |
-| Licence text | <https://www.nuget.org/packages/Microsoft.Web.WebView2/#license-body> |
-| Project | <https://aka.ms/webview> |
-| Downloaded by | `src/Lib/Functions/Private/Install-WebView2.ps1`, on module import |
-| Downloaded from | `https://api.nuget.org/v3-flatcontainer/microsoft.web.webview2/1.0.4129.50/microsoft.web.webview2.1.0.4129.50.nupkg` |
-| Verified against | SHA-256 `d3934f482d484b89fb4825df720c710664e1143a1e90f7b3a60794ef33f473d2`, pinned in `src/DependencyLock.psd1` |
-| Installed to | `%LOCALAPPDATA%\OmadaSqlTroubleshooter\Bin\win-x64\` (or `win-x86`) |
+The SDK is normally shipped inside the package; see [§1.3](#13-microsoftwebwebview2-webview2-net-sdk)
+for the component, its version, its licence and the redistribution review.
 
-Four files are extracted from the package: `Microsoft.Web.WebView2.Core.dll`,
-`Microsoft.Web.WebView2.WinForms.dll`, `Microsoft.Web.WebView2.Wpf.dll` and
-`WebView2Loader.dll`. They host the Monaco editor inside the WPF application.
+This section covers the case where it is **not** used from the package: a damaged or incomplete
+bundle, or a 32-bit process, for which no bundle is built. `Install-WebView2` then downloads the
+same pinned package from the same pinned URL, verifies the bytes against the same SHA-256, and
+installs the four assemblies to `%LOCALAPPDATA%\OmadaSqlTroubleshooter\Bin\win-x64\` (or
+`win-x86`). On a hash mismatch it deletes the file and aborts. An artefact with no entry in
+`src/DependencyLock.psd1` is not downloaded at all.
 
-The version is **not** resolved at run time. It is pinned, together with the exact download URL
-and the expected SHA-256, in [`src/DependencyLock.psd1`](src/DependencyLock.psd1), which ships
-with the module. `Invoke-DownloadFile` verifies the downloaded bytes against that hash before
-the package is expanded or copied into `Bin`; on a mismatch it deletes the file and aborts. An
-artefact with no entry in the lock file is not downloaded at all. See
-[SECURITY.md](SECURITY.md#runtime-dependency-verification).
-
-No copy of this package is committed to this repository or included in the published module.
+In this mode the SDK is fetched by the user's own machine from Microsoft's feed, so it is not
+redistributed by Fortigi — which is why it is described here as well as in §1.3.
 
 ---
 
@@ -192,9 +292,9 @@ nightly build. It fails the build when:
 - a path listed above no longer exists in the repository;
 - a redistributable binary (`.exe`, `.dll`, `.msi`, `.cab`) is committed to the repository;
 - a component listed above loses its entry in this file;
-- the WebView2 SDK version or download URL recorded in §2.1 no longer matches the pin in
+- the WebView2 SDK version or download URL recorded in §1.3 no longer matches the pin in
   `src/DependencyLock.psd1`, so the notices cannot drift away from what the module actually
-  downloads and verifies.
+  ships, downloads and verifies.
 
 When a component is added, upgraded, or removed, update this file in the same change. Once a
 machine-readable SBOM is produced for the module, generate the inventory table from it and

--- a/build/Get-BundledDependency.ps1
+++ b/build/Get-BundledDependency.ps1
@@ -81,10 +81,29 @@ function Get-Sha256 {
     }
 }
 
+function Get-ExpectedBundleFileName {
+    # Everything the bundle folder is allowed to contain: the pinned targets and the stamp. Anything
+    # else is an unpinned file that would be redistributed inside the package.
+    param([hashtable]$Artifact)
+
+    return @(@($Artifact.Files | ForEach-Object { $_.Target }) + "WebView2.pin")
+}
+
+function Get-UnexpectedBundleFileName {
+    param([string]$Path, [hashtable]$Artifact)
+
+    $Expected = Get-ExpectedBundleFileName -Artifact $Artifact
+
+    return @(Get-ChildItem -Path $Path -Force -Recurse -ErrorAction SilentlyContinue |
+            Where-Object { $_.PSIsContainer -or $Expected -notcontains $_.Name } |
+            ForEach-Object { $_.Name })
+}
+
 function Test-ExistingBundle {
-    # True when the folder already holds every target at its pinned hash and a stamp for this
-    # version. Purely a build-time shortcut so a local rebuild does not re-download 9 MB; it never
-    # relaxes a check, because a bundle that fails here is simply rebuilt from a verified download.
+    # True when the folder already holds every target at its pinned hash, a stamp for this version,
+    # and nothing else. Purely a build-time shortcut so a local rebuild does not re-download 9 MB; it
+    # never relaxes a check, because a bundle that fails here is simply rebuilt from a verified
+    # download.
     param([string]$Path, [hashtable]$Artifact)
 
     $StampPath = Join-Path $Path "WebView2.pin"
@@ -104,6 +123,12 @@ function Test-ExistingBundle {
         if ((Get-Sha256 -Path $FilePath) -ne $File.Sha256) {
             return $false
         }
+    }
+
+    # A folder that holds the right files plus something else is not a bundle this script produced,
+    # and reusing it would ship the extra file. Rebuild instead.
+    if ((Get-UnexpectedBundleFileName -Path $Path -Artifact $Artifact).Count -gt 0) {
+        return $false
     }
 
     return $true
@@ -140,6 +165,11 @@ if (-not $Force -and (Test-ExistingBundle -Path $OutputPath -Artifact $Artifact)
     "  Bundle size: {0:N0} bytes ({1:N2} MB)" -f $ExistingSize, ($ExistingSize / 1MB) | Write-Host -ForegroundColor Green
     return
 }
+
+# Emptied before anything is written. Overwriting the pinned targets is not enough: if the Files
+# list changes between pins - an assembly renamed or dropped upstream - the previous run's copy
+# would survive here and be redistributed inside the package with no pin covering it.
+Get-ChildItem -Path $OutputPath -Force -ErrorAction SilentlyContinue | Remove-Item -Recurse -Force
 
 $PackagePath = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid().ToString() + ".nupkg")
 
@@ -214,6 +244,13 @@ $StampContent = @(
 
 $StampPath = Join-Path $OutputPath "WebView2.pin"
 [System.IO.File]::WriteAllText($StampPath, ($StampContent + "`r`n"), (New-Object System.Text.UTF8Encoding($false)))
+
+# Belt and braces after the clear above: whatever is in this folder is about to be published, so
+# assert it is exactly the pinned set and nothing more.
+$Unexpected = Get-UnexpectedBundleFileName -Path $OutputPath -Artifact $Artifact
+if ($Unexpected.Count -gt 0) {
+    "The bundle folder '{0}' contains {1} file(s) that are not pinned in '{2}': {3}. Refusing to publish an unpinned binary." -f $OutputPath, $Unexpected.Count, $LockPath, ($Unexpected -join ", ") | Write-Error -ErrorAction Stop
+}
 
 $BundleSize = (Get-ChildItem -Path $OutputPath -File | Measure-Object -Property Length -Sum).Sum
 "  Wrote stamp '{0}'" -f $StampPath | Write-Host

--- a/build/Get-BundledDependency.ps1
+++ b/build/Get-BundledDependency.ps1
@@ -196,12 +196,19 @@ try {
     $Archive = [System.IO.Compression.ZipFile]::OpenRead($PackagePath)
     try {
         foreach ($File in $PinnedFile) {
-            $Entry = $Archive.Entries | Where-Object { $_.FullName -eq $File.Source }
-            if ($null -eq $Entry) {
+            # 0, 1 and many are all handled explicitly. A zip may legally carry two entries with the
+            # same name; letting $Entry become an array would fail inside ExtractToFile with an
+            # opaque method-resolution error instead of saying what is actually wrong.
+            $Entry = @($Archive.Entries | Where-Object { $_.FullName -eq $File.Source })
+            if ($Entry.Count -eq 0) {
                 # Deliberately terminating. An upstream repackaging that moves a file must fail the
                 # build; a bundle missing an assembly would import, then fail at the first tab.
                 "Artefact '{0}' version {1} has no entry '{2}'. The package layout has changed upstream. Correct the Files list in '{3}' and re-pin the hashes with build/Update-DependencyLock.ps1 -Refresh." -f $Artifact.Id, $Artifact.Version, $File.Source, $LockPath | Write-Error -ErrorAction Stop
             }
+            if ($Entry.Count -gt 1) {
+                "Artefact '{0}' version {1} has {2} entries named '{3}'. Which one is meant is ambiguous, so nothing is extracted." -f $Artifact.Id, $Artifact.Version, $Entry.Count, $File.Source | Write-Error -ErrorAction Stop
+            }
+            $Entry = $Entry[0]
 
             $TargetPath = Join-Path $OutputPath $File.Target
             [System.IO.Compression.ZipFileExtensions]::ExtractToFile($Entry, $TargetPath, $true)

--- a/build/Get-BundledDependency.ps1
+++ b/build/Get-BundledDependency.ps1
@@ -1,0 +1,221 @@
+#Requires -Version 5.1
+
+<#
+.SYNOPSIS
+    Fetches the pinned dependency package and lays its files out as a bundle in the build output.
+.DESCRIPTION
+    OmadaSqlTroubleshooter used to download the WebView2 .NET SDK on every machine, on first module
+    import. That fails outright on a machine with no route to nuget.org, which is the normal state of
+    affairs on the restricted corporate networks Omada customers run. This script fetches the package
+    once, at build time, and lays the assemblies out inside the published module so a normal import
+    makes no network call at all.
+
+    Every step is verified:
+
+      1. The package is downloaded from the exact URL pinned in src/DependencyLock.psd1 and its
+         SHA-256 is checked BEFORE a single entry is read out of it. Unverified bytes are never
+         expanded.
+      2. Each file listed in the artefact's Files array is copied out by its in-archive path. A
+         Source that is not in the package is a terminating error, not a skip - an upstream
+         repackaging has to break the build rather than produce a silently incomplete bundle.
+      3. Each copied file is re-hashed on disk against its own pin. The package hash cannot cover an
+         extracted file, so this is what makes the bundle verifiable at all.
+      4. A WebView2.pin stamp is written next to the files, in the same format Install-WebView2
+         writes at run time, so Test-WebView2Bundle and Test-WebView2RuntimeVersion read one format.
+
+    This script replaces build/RetrieveDependencies.ps1, build/AddSrcDependencies.ps1 and the two
+    copies of RetrieveFromNuGet, all of which downloaded without any integrity check.
+
+    It writes only into -OutputPath, which is under buildoutput. It must never write into src/:
+    .gitignore only excludes src/bin/Debug/**, so a stray src\bin\*.dll would be committable and
+    would immediately fail the "No redistributable binaries" test in tests/ThirdPartyNotices.Tests.ps1.
+
+    Kept clean of PowerShell 7 syntax on purpose: the PR validation matrix runs one leg under Windows
+    PowerShell 5.1.
+.PARAMETER ArtifactId
+    Id of the artefact in the lock file to bundle.
+.PARAMETER OutputPath
+    Folder the files are written into. Created if it does not exist.
+.PARAMETER LockPath
+    Path to the lock file. Defaults to src/DependencyLock.psd1.
+.PARAMETER Force
+    Re-download even when the folder already holds a complete, matching bundle.
+.EXAMPLE
+    ./build/Get-BundledDependency.ps1 -OutputPath ./buildoutput/OmadaSqlTroubleShooter/Bin/WebView2Dlls/win-x64
+
+    Fetches the pinned WebView2 SDK and bundles the four assemblies with a pin stamp.
+#>
+[CmdletBinding()]
+param(
+    [parameter(Mandatory = $false)]
+    [string]$ArtifactId = "Microsoft.Web.WebView2",
+    [parameter(Mandatory = $true)]
+    [string]$OutputPath,
+    [parameter(Mandatory = $false)]
+    [string]$LockPath = (Join-Path (Join-Path $PSScriptRoot "..") "src\DependencyLock.psd1"),
+    [parameter(Mandatory = $false)]
+    [switch]$Force
+)
+
+$ErrorActionPreference = "Stop"
+
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+Add-Type -AssemblyName "System.IO.Compression.FileSystem" -ErrorAction SilentlyContinue
+
+function Get-Sha256 {
+    param([string]$Path)
+
+    $Sha256 = [System.Security.Cryptography.SHA256]::Create()
+    try {
+        $Stream = [System.IO.File]::OpenRead($Path)
+        try {
+            return ([System.BitConverter]::ToString($Sha256.ComputeHash($Stream)) -replace "-", "").ToLowerInvariant()
+        }
+        finally {
+            $Stream.Dispose()
+        }
+    }
+    finally {
+        $Sha256.Dispose()
+    }
+}
+
+function Test-ExistingBundle {
+    # True when the folder already holds every target at its pinned hash and a stamp for this
+    # version. Purely a build-time shortcut so a local rebuild does not re-download 9 MB; it never
+    # relaxes a check, because a bundle that fails here is simply rebuilt from a verified download.
+    param([string]$Path, [hashtable]$Artifact)
+
+    $StampPath = Join-Path $Path "WebView2.pin"
+    if (-not (Test-Path $StampPath -PathType Leaf)) {
+        return $false
+    }
+
+    if ((Get-Content -Path $StampPath -Raw) -notmatch ('Version\s*=\s*"{0}"' -f [regex]::Escape($Artifact.Version))) {
+        return $false
+    }
+
+    foreach ($File in @($Artifact.Files)) {
+        $FilePath = Join-Path $Path $File.Target
+        if (-not (Test-Path $FilePath -PathType Leaf)) {
+            return $false
+        }
+        if ((Get-Sha256 -Path $FilePath) -ne $File.Sha256) {
+            return $false
+        }
+    }
+
+    return $true
+}
+
+if (-not (Test-Path $LockPath -PathType Leaf)) {
+    "Lock file '{0}' does not exist, so nothing can be verified or bundled." -f $LockPath | Write-Error -ErrorAction Stop
+}
+
+$Lock = Import-PowerShellDataFile -Path $LockPath
+if ($Lock.SchemaVersion -ne 1) {
+    "Lock file '{0}' has schema version '{1}', expected 1." -f $LockPath, $Lock.SchemaVersion | Write-Error -ErrorAction Stop
+}
+
+$Artifact = @($Lock.Artifacts | Where-Object { $_.Id -eq $ArtifactId })
+if ($Artifact.Count -ne 1) {
+    "Lock file '{0}' holds {1} entries for artefact '{2}'; exactly one is required." -f $LockPath, $Artifact.Count, $ArtifactId | Write-Error -ErrorAction Stop
+}
+$Artifact = $Artifact[0]
+
+$PinnedFile = @($Artifact.Files)
+if ($PinnedFile.Count -eq 0) {
+    "Artefact '{0}' lists no Files, so there is nothing to bundle." -f $ArtifactId | Write-Error -ErrorAction Stop
+}
+
+"Bundling {0} {1}" -f $Artifact.Id, $Artifact.Version | Write-Host -ForegroundColor Cyan
+
+New-Item -Path $OutputPath -ItemType Directory -Force | Out-Null
+$OutputPath = (Resolve-Path -Path $OutputPath).Path
+
+if (-not $Force -and (Test-ExistingBundle -Path $OutputPath -Artifact $Artifact)) {
+    "  Bundle already present and matching the pin; skipping download. Use -Force to refetch." | Write-Host
+    $ExistingSize = (Get-ChildItem -Path $OutputPath -File | Measure-Object -Property Length -Sum).Sum
+    "  Bundle size: {0:N0} bytes ({1:N2} MB)" -f $ExistingSize, ($ExistingSize / 1MB) | Write-Host -ForegroundColor Green
+    return
+}
+
+$PackagePath = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid().ToString() + ".nupkg")
+
+try {
+    "  Downloading {0}" -f $Artifact.Url | Write-Host
+    $WebClient = New-Object System.Net.WebClient
+    try {
+        $WebClient.DownloadFile($Artifact.Url, $PackagePath)
+    }
+    finally {
+        $WebClient.Dispose()
+    }
+
+    # Gate one: the package, before anything is read out of it.
+    $ActualPackageSha256 = Get-Sha256 -Path $PackagePath
+    if ($ActualPackageSha256 -ne $Artifact.Sha256) {
+        "Integrity check FAILED for '{0}' from '{1}'.`r`n  Expected SHA-256: {2}`r`n  Actual SHA-256:   {3}`r`nNothing was extracted. Either the download was corrupted, or the published package no longer matches the version pinned in '{4}'. Do not work around this by editing the lock file." -f $Artifact.Id, $Artifact.Url, $Artifact.Sha256, $ActualPackageSha256, $LockPath | Write-Error -ErrorAction Stop
+    }
+    "  Package SHA-256 matches the pin" | Write-Host
+
+    # Read entries straight out of the archive rather than expanding it. Nothing unpinned ever
+    # reaches disk, and it sidesteps Expand-Archive's refusal to open a file that is not named .zip -
+    # the bug that made the old deploy-time copy of this fail.
+    $Archive = [System.IO.Compression.ZipFile]::OpenRead($PackagePath)
+    try {
+        foreach ($File in $PinnedFile) {
+            $Entry = $Archive.Entries | Where-Object { $_.FullName -eq $File.Source }
+            if ($null -eq $Entry) {
+                # Deliberately terminating. An upstream repackaging that moves a file must fail the
+                # build; a bundle missing an assembly would import, then fail at the first tab.
+                "Artefact '{0}' version {1} has no entry '{2}'. The package layout has changed upstream. Correct the Files list in '{3}' and re-pin the hashes with build/Update-DependencyLock.ps1 -Refresh." -f $Artifact.Id, $Artifact.Version, $File.Source, $LockPath | Write-Error -ErrorAction Stop
+            }
+
+            $TargetPath = Join-Path $OutputPath $File.Target
+            [System.IO.Compression.ZipFileExtensions]::ExtractToFile($Entry, $TargetPath, $true)
+
+            # Gate two: the extracted bytes on disk, against this file's own pin. The package hash
+            # above says nothing about a single extracted file.
+            $ActualFileSha256 = Get-Sha256 -Path $TargetPath
+            if ($ActualFileSha256 -ne $File.Sha256) {
+                Remove-Item -Path $TargetPath -Force -ErrorAction SilentlyContinue
+                "Integrity check FAILED for '{0}' extracted from '{1}'.`r`n  Expected SHA-256: {2}`r`n  Actual SHA-256:   {3}`r`nThe file was deleted and has not been bundled." -f $File.Target, $File.Source, $File.Sha256, $ActualFileSha256 | Write-Error -ErrorAction Stop
+            }
+
+            "    {0,-40} {1,9:N0} bytes  OK" -f $File.Target, (Get-Item $TargetPath).Length | Write-Host
+        }
+    }
+    finally {
+        $Archive.Dispose()
+    }
+}
+finally {
+    Remove-Item -Path $PackagePath -Force -ErrorAction SilentlyContinue
+}
+
+# Same stamp format Install-WebView2 writes at run time, so one reader serves both layouts.
+$FileEntry = foreach ($File in $PinnedFile) {
+    '        @{{ Name = "{0}"; Sha256 = "{1}" }}' -f $File.Target, $File.Sha256
+}
+
+$StampContent = @(
+    "# Written by build/Get-BundledDependency.ps1. Records the pin the assemblies in this folder were"
+    "# fetched and verified against. Test-WebView2Bundle refuses the bundle when this version no longer"
+    "# matches src\DependencyLock.psd1, and the module falls back to the runtime download."
+    "@{"
+    ('    Version = "{0}"' -f $Artifact.Version)
+    "    Files   = @("
+    $FileEntry
+    "    )"
+    "}"
+) -join "`r`n"
+
+$StampPath = Join-Path $OutputPath "WebView2.pin"
+[System.IO.File]::WriteAllText($StampPath, ($StampContent + "`r`n"), (New-Object System.Text.UTF8Encoding($false)))
+
+$BundleSize = (Get-ChildItem -Path $OutputPath -File | Measure-Object -Property Length -Sum).Sum
+"  Wrote stamp '{0}'" -f $StampPath | Write-Host
+"  Bundle: {0} file(s) in '{1}'" -f (@($PinnedFile).Count + 1), $OutputPath | Write-Host
+"  Bundle size: {0:N0} bytes ({1:N2} MB)" -f $BundleSize, ($BundleSize / 1MB) | Write-Host -ForegroundColor Green

--- a/build/Update-DependencyLock.ps1
+++ b/build/Update-DependencyLock.ps1
@@ -197,15 +197,31 @@ function Set-ArtifactValue {
 }
 
 function Set-ArtifactFileHash {
-    # Rewrites the Sha256 of each Files entry, keyed on the Target line immediately above it. Only
-    # the hash line is touched, so Source, Target and the layout survive untouched.
+    # Rewrites the Sha256 of each Files entry belonging to ONE artefact, keyed on the Target line
+    # immediately above it. Only the hash line is touched, so Source, Target and the layout survive
+    # untouched.
+    #
+    # Scoped to $Id the same way Set-ArtifactValue is. Target names are not unique across artefacts -
+    # nothing stops a second package from also shipping a file called WebView2Loader.dll - and an
+    # unscoped rewrite would silently repin another artefact's file to this one's bytes.
     param(
         [string[]]$Line,
+        [string]$Id,
         [hashtable]$HashByTarget
     )
 
+    $CurrentId = $null
     $CurrentTarget = $null
     for ($Index = 0; $Index -lt $Line.Count; $Index++) {
+        # Id appears only at artefact level; the Files entries below it carry Source/Target/Sha256.
+        if ($Line[$Index] -match '^\s*Id\s*=\s*"([^"]+)"\s*$') {
+            $CurrentId = $Matches[1]
+            $CurrentTarget = $null
+            continue
+        }
+        if ($CurrentId -ne $Id) {
+            continue
+        }
         if ($Line[$Index] -match '^\s*Target\s*=\s*"([^"]+)"\s*$') {
             $CurrentTarget = $Matches[1]
             continue
@@ -393,7 +409,7 @@ if ($PSCmdlet.ParameterSetName -eq "Refresh") {
                 Url     = $Url
                 Sha256  = $Sha256
             }
-            $Line = Set-ArtifactFileHash -Line $Line -HashByTarget $FileHash
+            $Line = Set-ArtifactFileHash -Line $Line -Id $Artifact.Id -HashByTarget $FileHash
             $Changed++
         }
         finally {

--- a/build/Update-DependencyLock.ps1
+++ b/build/Update-DependencyLock.ps1
@@ -103,12 +103,21 @@ function Save-RemotePackage {
     param([string]$Url)
 
     $TempFile = [System.IO.Path]::GetTempFileName()
-    $WebClient = New-Object System.Net.WebClient
     try {
-        $WebClient.DownloadFile($Url, $TempFile)
+        $WebClient = New-Object System.Net.WebClient
+        try {
+            $WebClient.DownloadFile($Url, $TempFile)
+        }
+        finally {
+            $WebClient.Dispose()
+        }
     }
-    finally {
-        $WebClient.Dispose()
+    catch {
+        # GetTempFileName has already created the file, so a failed download leaves an empty or
+        # partial one behind. The caller only deletes what it was handed, and it is handed nothing
+        # when this throws - so clean up here before rethrowing.
+        Remove-Item -Path $TempFile -Force -ErrorAction SilentlyContinue
+        throw
     }
     return $TempFile
 }

--- a/build/Update-DependencyLock.ps1
+++ b/build/Update-DependencyLock.ps1
@@ -129,10 +129,19 @@ function Get-PackageEntrySha256 {
 
     $Archive = [System.IO.Compression.ZipFile]::OpenRead($PackagePath)
     try {
-        $Entry = $Archive.Entries | Where-Object { $_.FullName -eq $EntryPath }
-        if ($null -eq $Entry) {
+        # 0, 1 and many are all handled explicitly. A zip may legally carry two entries with the same
+        # name; letting $Entry become an array would fail on $Entry.Open() with an opaque method
+        # invocation error rather than saying what is actually wrong.
+        $Entry = @($Archive.Entries | Where-Object { $_.FullName -eq $EntryPath })
+        if ($Entry.Count -eq 0) {
             return $null
         }
+        if ($Entry.Count -gt 1) {
+            # Not $null: "absent" and "ambiguous" are different problems and the caller reports them
+            # differently.
+            "Package '{0}' contains {1} entries named '{2}'. Which one the pin refers to is ambiguous." -f $PackagePath, $Entry.Count, $EntryPath | Write-Error -ErrorAction Stop
+        }
+        $Entry = $Entry[0]
 
         $Sha256 = [System.Security.Cryptography.SHA256]::Create()
         try {

--- a/build/Update-DependencyLock.ps1
+++ b/build/Update-DependencyLock.ps1
@@ -97,28 +97,68 @@ function Get-FlatContainerUrl {
     return "https://api.nuget.org/v3-flatcontainer/{0}/{1}/{0}.{1}.nupkg" -f $PackageId.ToLowerInvariant(), $Version.ToLowerInvariant()
 }
 
-function Get-RemoteSha256 {
+function Save-RemotePackage {
+    # Downloads an artefact to a temp file and hands back the path. The caller deletes it. Split out
+    # from hashing because the per-file pins need the package kept around long enough to be read.
     param([string]$Url)
 
     $TempFile = [System.IO.Path]::GetTempFileName()
+    $WebClient = New-Object System.Net.WebClient
     try {
-        $WebClient = New-Object System.Net.WebClient
-        try {
-            $WebClient.DownloadFile($Url, $TempFile)
-        }
-        finally {
-            $WebClient.Dispose()
-        }
-        return (Get-FileHash -Path $TempFile -Algorithm SHA256).Hash.ToLowerInvariant()
+        $WebClient.DownloadFile($Url, $TempFile)
     }
     finally {
-        Remove-Item -Path $TempFile -Force -ErrorAction SilentlyContinue
+        $WebClient.Dispose()
+    }
+    return $TempFile
+}
+
+function Get-Sha256 {
+    param([string]$Path)
+
+    return (Get-FileHash -Path $Path -Algorithm SHA256).Hash.ToLowerInvariant()
+}
+
+function Get-PackageEntrySha256 {
+    # SHA-256 of one entry inside a .nupkg, read straight out of the archive - nothing is expanded to
+    # disk. Returns $null when the entry is absent, which the callers report as a problem rather than
+    # skipping: a Source that has moved means the bundle would be silently incomplete.
+    param([string]$PackagePath, [string]$EntryPath)
+
+    Add-Type -AssemblyName "System.IO.Compression.FileSystem" -ErrorAction SilentlyContinue
+
+    $Archive = [System.IO.Compression.ZipFile]::OpenRead($PackagePath)
+    try {
+        $Entry = $Archive.Entries | Where-Object { $_.FullName -eq $EntryPath }
+        if ($null -eq $Entry) {
+            return $null
+        }
+
+        $Sha256 = [System.Security.Cryptography.SHA256]::Create()
+        try {
+            $Stream = $Entry.Open()
+            try {
+                return ([System.BitConverter]::ToString($Sha256.ComputeHash($Stream)) -replace "-", "").ToLowerInvariant()
+            }
+            finally {
+                $Stream.Dispose()
+            }
+        }
+        finally {
+            $Sha256.Dispose()
+        }
+    }
+    finally {
+        $Archive.Dispose()
     }
 }
 
 function Set-ArtifactValue {
     # Rewrites Version/Url/Sha256 in place for one artefact, leaving every other line - comments and
     # alignment included - exactly as it was.
+    #
+    # Scanning stops at the artefact's "Files = @(" line. The per-file entries below it carry their
+    # own Sha256 keys, and without this the package hash would be written over all four of them.
     param(
         [string[]]$Line,
         [string]$Id,
@@ -134,10 +174,39 @@ function Set-ArtifactValue {
         if ($CurrentId -ne $Id) {
             continue
         }
+        if ($Line[$Index] -match '^\s*Files\s*=\s*@\(') {
+            $CurrentId = $null
+            continue
+        }
         foreach ($Key in $Value.Keys) {
             if ($Line[$Index] -match ('^(\s*{0}\s*=\s*)"[^"]*"\s*$' -f [regex]::Escape($Key))) {
                 $Line[$Index] = '{0}"{1}"' -f $Matches[1], $Value[$Key]
             }
+        }
+    }
+    return $Line
+}
+
+function Set-ArtifactFileHash {
+    # Rewrites the Sha256 of each Files entry, keyed on the Target line immediately above it. Only
+    # the hash line is touched, so Source, Target and the layout survive untouched.
+    param(
+        [string[]]$Line,
+        [hashtable]$HashByTarget
+    )
+
+    $CurrentTarget = $null
+    for ($Index = 0; $Index -lt $Line.Count; $Index++) {
+        if ($Line[$Index] -match '^\s*Target\s*=\s*"([^"]+)"\s*$') {
+            $CurrentTarget = $Matches[1]
+            continue
+        }
+        if ($null -eq $CurrentTarget -or -not $HashByTarget.ContainsKey($CurrentTarget)) {
+            continue
+        }
+        if ($Line[$Index] -match '^(\s*Sha256\s*=\s*)"[^"]*"\s*$') {
+            $Line[$Index] = '{0}"{1}"' -f $Matches[1], $HashByTarget[$CurrentTarget]
+            $CurrentTarget = $null
         }
     }
     return $Line
@@ -191,6 +260,37 @@ foreach ($Artifact in $Artifacts) {
     $ExpectedUrl = Get-FlatContainerUrl -PackageId $Artifact.PackageId -Version $Artifact.Version
     if ($Artifact.Url -ne $ExpectedUrl) {
         Add-Problem ("Artefact '{0}' has URL '{1}' but its pinned version implies '{2}'." -f $Artifact.Id, $Artifact.Url, $ExpectedUrl)
+    }
+
+    # Files is what build/Get-BundledDependency.ps1 copies into the package and what the module
+    # re-checks before it loads each assembly. An entry that is malformed here is a bundle that
+    # cannot be verified, so it is checked as strictly as the package pin itself.
+    $ArtifactFile = @($Artifact.Files)
+    if ($ArtifactFile.Count -eq 0) {
+        Add-Problem ("Artefact '{0}' lists no Files, so nothing can be bundled or re-verified before load." -f $Artifact.Id)
+    }
+
+    $SeenTarget = @{}
+    foreach ($File in $ArtifactFile) {
+        if ([string]::IsNullOrWhiteSpace($File.Source) -or [string]::IsNullOrWhiteSpace($File.Target)) {
+            Add-Problem ("Artefact '{0}' has a Files entry with an empty Source or Target." -f $Artifact.Id)
+            continue
+        }
+
+        if ($File.Source -match '\\') {
+            Add-Problem ("Artefact '{0}' file '{1}' has Source '{2}'; entry paths inside a .nupkg use forward slashes." -f $Artifact.Id, $File.Target, $File.Source)
+        }
+
+        if ($File.Sha256 -notmatch '^[0-9a-f]{64}$') {
+            Add-Problem ("Artefact '{0}' file '{1}' has SHA-256 '{2}', which is not 64 lower-case hex characters." -f $Artifact.Id, $File.Target, $File.Sha256)
+        }
+
+        if ($SeenTarget.ContainsKey($File.Target)) {
+            # Two sources writing the same file name means whichever copies last wins, which is
+            # precisely the netcoreapp3.0 / net5.0-windows Wpf.dll ambiguity this pin exists to settle.
+            Add-Problem ("Artefact '{0}' maps more than one Source onto target '{1}'." -f $Artifact.Id, $File.Target)
+        }
+        $SeenTarget[$File.Target] = $true
     }
 
     if ([string]::IsNullOrWhiteSpace($Artifact.Manifest)) {
@@ -250,21 +350,46 @@ if ($PSCmdlet.ParameterSetName -eq "Refresh") {
         }
 
         $Url = Get-FlatContainerUrl -PackageId $Artifact.PackageId -Version $Version
-        $Sha256 = Get-RemoteSha256 -Url $Url
 
-        if ($Version -eq $Artifact.Version -and $Url -eq $Artifact.Url -and $Sha256 -eq $Artifact.Sha256) {
-            "  {0} {1} unchanged" -f $Artifact.Id, $Version | Write-Host
-            continue
-        }
+        $PackagePath = Save-RemotePackage -Url $Url
+        try {
+            $Sha256 = Get-Sha256 -Path $PackagePath
 
-        "  {0}: {1} -> {2}" -f $Artifact.Id, $Artifact.Version, $Version | Write-Host -ForegroundColor Yellow
-        "    sha256 {0} -> {1}" -f $Artifact.Sha256, $Sha256 | Write-Host -ForegroundColor Yellow
-        $Line = Set-ArtifactValue -Line $Line -Id $Artifact.Id -Value @{
-            Version = $Version
-            Url     = $Url
-            Sha256  = $Sha256
+            # Per-file hashes are recomputed from the same download the package hash came from, so
+            # the two can never describe different bytes.
+            $FileHash = @{}
+            $FileChanged = $false
+            foreach ($File in @($Artifact.Files)) {
+                $EntrySha256 = Get-PackageEntrySha256 -PackagePath $PackagePath -EntryPath $File.Source
+                if ($null -eq $EntrySha256) {
+                    Add-Problem ("Artefact '{0}' version {1} has no entry '{2}'. The package layout changed; the Files list has to be corrected by hand." -f $Artifact.Id, $Version, $File.Source)
+                    continue
+                }
+                $FileHash[$File.Target] = $EntrySha256
+                if ($EntrySha256 -ne $File.Sha256) {
+                    $FileChanged = $true
+                    "    {0} sha256 {1} -> {2}" -f $File.Target, $File.Sha256, $EntrySha256 | Write-Host -ForegroundColor Yellow
+                }
+            }
+
+            if ($Version -eq $Artifact.Version -and $Url -eq $Artifact.Url -and $Sha256 -eq $Artifact.Sha256 -and -not $FileChanged) {
+                "  {0} {1} unchanged" -f $Artifact.Id, $Version | Write-Host
+                continue
+            }
+
+            "  {0}: {1} -> {2}" -f $Artifact.Id, $Artifact.Version, $Version | Write-Host -ForegroundColor Yellow
+            "    sha256 {0} -> {1}" -f $Artifact.Sha256, $Sha256 | Write-Host -ForegroundColor Yellow
+            $Line = Set-ArtifactValue -Line $Line -Id $Artifact.Id -Value @{
+                Version = $Version
+                Url     = $Url
+                Sha256  = $Sha256
+            }
+            $Line = Set-ArtifactFileHash -Line $Line -HashByTarget $FileHash
+            $Changed++
         }
-        $Changed++
+        finally {
+            Remove-Item -Path $PackagePath -Force -ErrorAction SilentlyContinue
+        }
     }
 
     if ($Changed -gt 0) {
@@ -278,12 +403,35 @@ if ($PSCmdlet.ParameterSetName -eq "Refresh") {
 }
 elseif (-not $SkipDownload) {
     foreach ($Artifact in $Artifacts) {
-        $Actual = Get-RemoteSha256 -Url $Artifact.Url
-        if ($Actual -ne $Artifact.Sha256) {
-            Add-Problem ("Artefact '{0}' no longer matches what '{1}' serves.`r`n    Pinned: {2}`r`n    Actual: {3}" -f $Artifact.Id, $Artifact.Url, $Artifact.Sha256, $Actual)
-        }
-        else {
+        $PackagePath = Save-RemotePackage -Url $Artifact.Url
+        try {
+            $Actual = Get-Sha256 -Path $PackagePath
+            if ($Actual -ne $Artifact.Sha256) {
+                Add-Problem ("Artefact '{0}' no longer matches what '{1}' serves.`r`n    Pinned: {2}`r`n    Actual: {3}" -f $Artifact.Id, $Artifact.Url, $Artifact.Sha256, $Actual)
+                continue
+            }
+
             "  {0} {1} OK" -f $Artifact.Id, $Artifact.Version | Write-Host
+
+            # The package hash matching is not enough on its own. The bundle ships extracted files,
+            # which that hash cannot cover, so each per-file pin is re-derived from the package here.
+            # This is what catches a refresh that bumped the package hash but left the Files stale.
+            foreach ($File in @($Artifact.Files)) {
+                $EntrySha256 = Get-PackageEntrySha256 -PackagePath $PackagePath -EntryPath $File.Source
+                if ($null -eq $EntrySha256) {
+                    Add-Problem ("Artefact '{0}' pins file '{1}', but the package has no entry at that path. The bundle would be incomplete." -f $Artifact.Id, $File.Source)
+                    continue
+                }
+                if ($EntrySha256 -ne $File.Sha256) {
+                    Add-Problem ("Artefact '{0}' file '{1}' no longer matches the package.`r`n    Pinned: {2}`r`n    Actual: {3}" -f $Artifact.Id, $File.Source, $File.Sha256, $EntrySha256)
+                }
+                else {
+                    "    {0} OK" -f $File.Target | Write-Host
+                }
+            }
+        }
+        finally {
+            Remove-Item -Path $PackagePath -Force -ErrorAction SilentlyContinue
         }
     }
 }

--- a/build/psakeBuild.ps1
+++ b/build/psakeBuild.ps1
@@ -9,6 +9,13 @@ Properties {
     $OutputDir = Join-Path -Path $ParentPath -ChildPath 'buildoutput\OmadaSqlTroubleShooter'
     New-Item -Path $OutputDir -ItemType Directory -Force | Out-Null
 
+    # Where Task Dependencies lays the hash-verified WebView2 assemblies out, and where
+    # Resolve-WebView2AssemblyPath looks for them at run time. The layout mirrors
+    # %LOCALAPPDATA%\OmadaSqlTroubleshooter\Bin\win-x64 so load-time resolution is a single "which
+    # directory?" decision. x64 only: the manifest declares ProcessorArchitecture = 'Amd64', and x86
+    # falls back to the runtime download.
+    $BundleDir = Join-Path -Path $OutputDir -ChildPath 'Bin\WebView2Dlls\win-x64'
+
     # When set (PR validation only), scopes Analyze/Test to just these files so unrelated pre-existing issues don't block unrelated PRs.
     $ChangedFiles = @()
     if ($env:PR_CHANGED_FILES) {
@@ -18,9 +25,9 @@ Properties {
     }
 }
 
-Task default -Depends Analyze, Test, Build, ImportModule
-Task TestBuildOnly -Depends Analyze, Test, Build
-Task Pipeline -Depends Analyze, Test, Build
+Task default -Depends Analyze, Test, Build, TestAssemblies, ImportModule
+Task TestBuildOnly -Depends Analyze, Test, Build, TestAssemblies
+Task Pipeline -Depends Analyze, Test, Build, TestAssemblies
 Task DeployOnly -Depends Build, Deploy
 
 # End-to-end suite: launches the REAL app against a fully mocked Omada backend and drives every
@@ -167,7 +174,25 @@ Task Test -Depends Analyze {
     }
 }
 
-Task Build -Depends Test {
+Task Dependencies {
+    try {
+        # Fetches the pinned WebView2 SDK and lays the four assemblies out in the package, so a normal
+        # module import makes no network call at all. Every byte is hash-verified: the package before
+        # it is opened, then each extracted file against its own pin in src\DependencyLock.psd1.
+        #
+        # This deliberately writes into buildoutput and never into src\. .gitignore only excludes
+        # src/bin/Debug/**, so a stray src\bin\*.dll would be committable and would fail the
+        # "No redistributable binaries" test in tests\ThirdPartyNotices.Tests.ps1.
+        "Bundle pinned dependencies" | Write-Host
+        & "$PSScriptRoot\Get-BundledDependency.ps1" -ArtifactId "Microsoft.Web.WebView2" -OutputPath $BundleDir
+    }
+    catch {
+        throw $_
+        exit 1
+    }
+}
+
+Task Build -Depends Test, Dependencies {
     try {
         $FormattingSettings = @{
             IncludeRules = @("PSPlaceOpenBrace", "PSUseConsistentIndentation", "PsAvoidUsingCmdletAliases", "PSUseConsistentWhitespace", "PSAlignAssignmentStatement", "PSPlaceCloseBrace")
@@ -476,11 +501,64 @@ Task ImportModule -Depends Build {
     }
 }
 
-# Deploy used to depend on a TestAssemblies task that asserted a Bin\WebView2Dlls folder and a
-# msedgewebview2.exe were present in the build output. Nothing ever produced them - the only task
-# that would have was in no task chain - so the assertion could only ever fail. The module downloads
-# and hash-verifies those assemblies at runtime instead. Bundling them into the package is issue #54
-# Part B, which will reintroduce this check against what the lock file actually produces.
-Task Deploy -Depends Build {
+# The old TestAssemblies asserted a Bin\WebView2Dlls folder AND a msedgewebview2.exe in the build
+# output. Nothing ever produced either - the only task that would have was in no task chain - so it
+# could only ever fail, and Part A removed it. It is back here, checking what Task Dependencies
+# actually produces.
+#
+# The msedgewebview2.exe requirement is deliberately not back. That is the WebView2 *Runtime*, a
+# 260 MB component this project does not redistribute (see THIRD-PARTY-NOTICES.md section 3.1) and
+# never ships into the package. Only the SDK assemblies are bundled.
+#
+# In the chains directly, not just reachable through Deploy: a package whose bundle is missing or
+# corrupt still imports - it degrades to the runtime download - so nothing else would notice.
+Task TestAssemblies {
+    try {
+        "Verify bundled assemblies" | Write-Host
+
+        if (-not (Test-Path $BundleDir -PathType Container)) {
+            "The bundle folder '{0}' does not exist. Task Dependencies did not run." -f $BundleDir | Write-Error -ErrorAction Stop
+        }
+
+        $Lock = Import-PowerShellDataFile -Path (Join-Path $ModuleSource -ChildPath "DependencyLock.psd1")
+        $Artifact = @($Lock.Artifacts | Where-Object { $_.Id -eq "Microsoft.Web.WebView2" })[0]
+
+        foreach ($File in @($Artifact.Files)) {
+            $FilePath = Join-Path $BundleDir -ChildPath $File.Target
+            if (-not (Test-Path $FilePath -PathType Leaf)) {
+                "The bundled assembly '{0}' is missing from '{1}'." -f $File.Target, $BundleDir | Write-Error -ErrorAction Stop
+            }
+
+            $ActualSha256 = (Get-FileHash -Path $FilePath -Algorithm SHA256).Hash.ToLowerInvariant()
+            if ($ActualSha256 -ne $File.Sha256) {
+                "The bundled assembly '{0}' does not match its pin.`r`n  Expected: {1}`r`n  Actual:   {2}" -f $File.Target, $File.Sha256, $ActualSha256 | Write-Error -ErrorAction Stop
+            }
+
+            "  {0} OK" -f $File.Target | Write-Host
+        }
+
+        # Without a stamp at the pinned version Test-WebView2Bundle refuses the bundle, and every
+        # install would silently fall back to downloading - the bundle would be dead weight.
+        $StampPath = Join-Path $BundleDir -ChildPath "WebView2.pin"
+        if (-not (Test-Path $StampPath -PathType Leaf)) {
+            "The bundle at '{0}' has no WebView2.pin stamp, so the module would ignore it and download instead." -f $BundleDir | Write-Error -ErrorAction Stop
+        }
+
+        $Stamp = Import-PowerShellDataFile -Path $StampPath
+        if ($Stamp.Version -ne $Artifact.Version) {
+            "The bundle stamp records version '{0}' but the lock pins '{1}'." -f $Stamp.Version, $Artifact.Version | Write-Error -ErrorAction Stop
+        }
+
+        $BundleSize = (Get-ChildItem -Path $BundleDir -File | Measure-Object -Property Length -Sum).Sum
+        "  Stamp OK, pinned version {0}" -f $Artifact.Version | Write-Host
+        "  Bundle adds {0:N0} bytes ({1:N2} MB) to the package" -f $BundleSize, ($BundleSize / 1MB) | Write-Host
+    }
+    catch {
+        throw $_
+        exit 1
+    }
+}
+
+Task Deploy -Depends Build, TestAssemblies {
 
 }

--- a/build/psakeBuild.ps1
+++ b/build/psakeBuild.ps1
@@ -552,8 +552,19 @@ Task TestAssemblies -Depends Dependencies {
         "The bundle stamp records version '{0}' but the lock pins '{1}'." -f $Stamp.Version, $Artifact.Version | Write-Error -ErrorAction Stop
     }
 
+    # Nothing unpinned may travel in the package. The nuspec packages the build output wholesale, so
+    # any stray file in this folder would be redistributed with no hash covering it - and neither
+    # Test-WebView2Bundle nor the load-time check would ever look at it.
+    $ExpectedName = @(@($Artifact.Files | ForEach-Object { $_.Target }) + "WebView2.pin")
+    $UnexpectedName = @(Get-ChildItem -Path $BundleDir -Force -Recurse |
+            Where-Object { $_.PSIsContainer -or $ExpectedName -notcontains $_.Name } |
+            ForEach-Object { $_.Name })
+    if ($UnexpectedName.Count -gt 0) {
+        "The bundle folder '{0}' contains {1} unpinned item(s): {2}. They would be redistributed in the package unverified." -f $BundleDir, $UnexpectedName.Count, ($UnexpectedName -join ", ") | Write-Error -ErrorAction Stop
+    }
+
     $BundleSize = (Get-ChildItem -Path $BundleDir -File | Measure-Object -Property Length -Sum).Sum
-    "  Stamp OK, pinned version {0}" -f $Artifact.Version | Write-Host
+    "  Stamp OK, pinned version {0}, no unpinned files" -f $Artifact.Version | Write-Host
     "  Bundle adds {0:N0} bytes ({1:N2} MB) to the package" -f $BundleSize, ($BundleSize / 1MB) | Write-Host
 }
 

--- a/build/psakeBuild.ps1
+++ b/build/psakeBuild.ps1
@@ -175,21 +175,18 @@ Task Test -Depends Analyze {
 }
 
 Task Dependencies {
-    try {
-        # Fetches the pinned WebView2 SDK and lays the four assemblies out in the package, so a normal
-        # module import makes no network call at all. Every byte is hash-verified: the package before
-        # it is opened, then each extracted file against its own pin in src\DependencyLock.psd1.
-        #
-        # This deliberately writes into buildoutput and never into src\. .gitignore only excludes
-        # src/bin/Debug/**, so a stray src\bin\*.dll would be committable and would fail the
-        # "No redistributable binaries" test in tests\ThirdPartyNotices.Tests.ps1.
-        "Bundle pinned dependencies" | Write-Host
-        & "$PSScriptRoot\Get-BundledDependency.ps1" -ArtifactId "Microsoft.Web.WebView2" -OutputPath $BundleDir
-    }
-    catch {
-        throw $_
-        exit 1
-    }
+    # Fetches the pinned WebView2 SDK and lays the four assemblies out in the package, so a normal
+    # module import makes no network call at all. Every byte is hash-verified: the package before it
+    # is opened, then each extracted file against its own pin in src\DependencyLock.psd1.
+    #
+    # This deliberately writes into buildoutput and never into src\. .gitignore only excludes
+    # src/bin/Debug/**, so a stray src\bin\*.dll would be committable and would fail the
+    # "No redistributable binaries" test in tests\ThirdPartyNotices.Tests.ps1.
+    #
+    # No try/catch: the script sets $ErrorActionPreference = "Stop", and psake fails the build on a
+    # terminating error anyway. Catching only to rethrow would lose the original stack.
+    "Bundle pinned dependencies" | Write-Host
+    & "$PSScriptRoot\Get-BundledDependency.ps1" -ArtifactId "Microsoft.Web.WebView2" -OutputPath $BundleDir
 }
 
 Task Build -Depends Test, Dependencies, TestAssemblies {
@@ -516,51 +513,48 @@ Task ImportModule -Depends Build {
 # Build depends on it as well as the chains listing it. That is what covers the nightly, which runs
 # a bare "Build" and publishes the result to the PowerShell Gallery; without it the one lane that
 # ships nightly packages would be the only one not checking what it ships.
+#
+# No try/catch: every failure below is already a terminating error, and psake fails the build on
+# one. Catching only to rethrow would lose the original stack.
 Task TestAssemblies -Depends Dependencies {
-    try {
-        "Verify bundled assemblies" | Write-Host
+    "Verify bundled assemblies" | Write-Host
 
-        if (-not (Test-Path $BundleDir -PathType Container)) {
-            "The bundle folder '{0}' does not exist. Task Dependencies did not run." -f $BundleDir | Write-Error -ErrorAction Stop
-        }
-
-        $Lock = Import-PowerShellDataFile -Path (Join-Path $ModuleSource -ChildPath "DependencyLock.psd1")
-        $Artifact = @($Lock.Artifacts | Where-Object { $_.Id -eq "Microsoft.Web.WebView2" })[0]
-
-        foreach ($File in @($Artifact.Files)) {
-            $FilePath = Join-Path $BundleDir -ChildPath $File.Target
-            if (-not (Test-Path $FilePath -PathType Leaf)) {
-                "The bundled assembly '{0}' is missing from '{1}'." -f $File.Target, $BundleDir | Write-Error -ErrorAction Stop
-            }
-
-            $ActualSha256 = (Get-FileHash -Path $FilePath -Algorithm SHA256).Hash.ToLowerInvariant()
-            if ($ActualSha256 -ne $File.Sha256) {
-                "The bundled assembly '{0}' does not match its pin.`r`n  Expected: {1}`r`n  Actual:   {2}" -f $File.Target, $File.Sha256, $ActualSha256 | Write-Error -ErrorAction Stop
-            }
-
-            "  {0} OK" -f $File.Target | Write-Host
-        }
-
-        # Without a stamp at the pinned version Test-WebView2Bundle refuses the bundle, and every
-        # install would silently fall back to downloading - the bundle would be dead weight.
-        $StampPath = Join-Path $BundleDir -ChildPath "WebView2.pin"
-        if (-not (Test-Path $StampPath -PathType Leaf)) {
-            "The bundle at '{0}' has no WebView2.pin stamp, so the module would ignore it and download instead." -f $BundleDir | Write-Error -ErrorAction Stop
-        }
-
-        $Stamp = Import-PowerShellDataFile -Path $StampPath
-        if ($Stamp.Version -ne $Artifact.Version) {
-            "The bundle stamp records version '{0}' but the lock pins '{1}'." -f $Stamp.Version, $Artifact.Version | Write-Error -ErrorAction Stop
-        }
-
-        $BundleSize = (Get-ChildItem -Path $BundleDir -File | Measure-Object -Property Length -Sum).Sum
-        "  Stamp OK, pinned version {0}" -f $Artifact.Version | Write-Host
-        "  Bundle adds {0:N0} bytes ({1:N2} MB) to the package" -f $BundleSize, ($BundleSize / 1MB) | Write-Host
+    if (-not (Test-Path $BundleDir -PathType Container)) {
+        "The bundle folder '{0}' does not exist. Task Dependencies did not run." -f $BundleDir | Write-Error -ErrorAction Stop
     }
-    catch {
-        throw $_
-        exit 1
+
+    $Lock = Import-PowerShellDataFile -Path (Join-Path $ModuleSource -ChildPath "DependencyLock.psd1")
+    $Artifact = @($Lock.Artifacts | Where-Object { $_.Id -eq "Microsoft.Web.WebView2" })[0]
+
+    foreach ($File in @($Artifact.Files)) {
+        $FilePath = Join-Path $BundleDir -ChildPath $File.Target
+        if (-not (Test-Path $FilePath -PathType Leaf)) {
+            "The bundled assembly '{0}' is missing from '{1}'." -f $File.Target, $BundleDir | Write-Error -ErrorAction Stop
+        }
+
+        $ActualSha256 = (Get-FileHash -Path $FilePath -Algorithm SHA256).Hash.ToLowerInvariant()
+        if ($ActualSha256 -ne $File.Sha256) {
+            "The bundled assembly '{0}' does not match its pin.`r`n  Expected: {1}`r`n  Actual:   {2}" -f $File.Target, $File.Sha256, $ActualSha256 | Write-Error -ErrorAction Stop
+        }
+
+        "  {0} OK" -f $File.Target | Write-Host
     }
+
+    # Without a stamp at the pinned version Test-WebView2Bundle refuses the bundle, and every
+    # install would silently fall back to downloading - the bundle would be dead weight.
+    $StampPath = Join-Path $BundleDir -ChildPath "WebView2.pin"
+    if (-not (Test-Path $StampPath -PathType Leaf)) {
+        "The bundle at '{0}' has no WebView2.pin stamp, so the module would ignore it and download instead." -f $BundleDir | Write-Error -ErrorAction Stop
+    }
+
+    $Stamp = Import-PowerShellDataFile -Path $StampPath
+    if ($Stamp.Version -ne $Artifact.Version) {
+        "The bundle stamp records version '{0}' but the lock pins '{1}'." -f $Stamp.Version, $Artifact.Version | Write-Error -ErrorAction Stop
+    }
+
+    $BundleSize = (Get-ChildItem -Path $BundleDir -File | Measure-Object -Property Length -Sum).Sum
+    "  Stamp OK, pinned version {0}" -f $Artifact.Version | Write-Host
+    "  Bundle adds {0:N0} bytes ({1:N2} MB) to the package" -f $BundleSize, ($BundleSize / 1MB) | Write-Host
 }
 
 Task Deploy -Depends Build, TestAssemblies {

--- a/build/psakeBuild.ps1
+++ b/build/psakeBuild.ps1
@@ -192,7 +192,7 @@ Task Dependencies {
     }
 }
 
-Task Build -Depends Test, Dependencies {
+Task Build -Depends Test, Dependencies, TestAssemblies {
     try {
         $FormattingSettings = @{
             IncludeRules = @("PSPlaceOpenBrace", "PSUseConsistentIndentation", "PsAvoidUsingCmdletAliases", "PSUseConsistentWhitespace", "PSAlignAssignmentStatement", "PSPlaceCloseBrace")
@@ -512,7 +512,11 @@ Task ImportModule -Depends Build {
 #
 # In the chains directly, not just reachable through Deploy: a package whose bundle is missing or
 # corrupt still imports - it degrades to the runtime download - so nothing else would notice.
-Task TestAssemblies {
+#
+# Build depends on it as well as the chains listing it. That is what covers the nightly, which runs
+# a bare "Build" and publishes the result to the PowerShell Gallery; without it the one lane that
+# ships nightly packages would be the only one not checking what it ships.
+Task TestAssemblies -Depends Dependencies {
     try {
         "Verify bundled assemblies" | Write-Host
 

--- a/src/DependencyLock.psd1
+++ b/src/DependencyLock.psd1
@@ -26,6 +26,25 @@
       InstalledBy  - the module function that downloads it
       PinReason    - why this entry is held at a version the manifest does not track
       Description  - why the module needs it
+      Files        - the individual files taken out of the package, each with its own SHA-256
+
+    About Files. The package hash above verifies the .nupkg as downloaded. It cannot verify a file
+    that has been *extracted* out of it, which is exactly what the build-time bundle in
+    Bin\WebView2Dlls\win-x64 contains - so every extracted file carries its own pin here. Those
+    same per-file hashes are what let the module re-check each assembly immediately before
+    [Reflection.Assembly]::LoadFrom, closing the window between "verified at download" and "loaded",
+    during which the user-writable Bin folder could have been written to by something else.
+
+      Source - path inside the .nupkg, forward slashes, exactly as the archive stores it
+      Target - file name written into the bundle folder and into %LOCALAPPDATA%\...\Bin
+      Sha256 - expected SHA-256 of that one file, lower-case hex
+
+    Note on Microsoft.Web.WebView2.Wpf.dll: the package ships three copies with different bytes, in
+    lib/net462, lib_manual/netcoreapp3.0 and lib_manual/net5.0-windows10.0.17763.0. The two fetchers
+    this repository used to have disagreed about which one to take. netcoreapp3.0 is the one
+    Install-WebView2 has always used and is the one pinned here. build/Get-BundledDependency.ps1
+    throws when a Source below is absent from the package, so an upstream repackaging becomes a build
+    failure rather than a silently incomplete bundle.
 #>
 @{
     SchemaVersion = 1
@@ -41,6 +60,28 @@
             InstalledBy  = "Install-WebView2"
             PinReason    = ""
             Description  = "Hosts the Monaco SQL editor inside the WPF application."
+            Files        = @(
+                @{
+                    Source = "lib_manual/netcoreapp3.0/Microsoft.Web.WebView2.Core.dll"
+                    Target = "Microsoft.Web.WebView2.Core.dll"
+                    Sha256 = "958efdb7f13a6d1f3079756c96956cc96cf713ae46fa085c8b1e7f44316a4f7e"
+                }
+                @{
+                    Source = "lib_manual/netcoreapp3.0/Microsoft.Web.WebView2.WinForms.dll"
+                    Target = "Microsoft.Web.WebView2.WinForms.dll"
+                    Sha256 = "ba823b3de79297389a9aad662e389d4d229bf3a6a0056f9ede4ee64cc49dc19c"
+                }
+                @{
+                    Source = "lib_manual/netcoreapp3.0/Microsoft.Web.WebView2.Wpf.dll"
+                    Target = "Microsoft.Web.WebView2.Wpf.dll"
+                    Sha256 = "85f62dc8c6d36759212fae31bdac27ac6f9096f9d84563db765340cf58fa4744"
+                }
+                @{
+                    Source = "runtimes/win-x64/native/WebView2Loader.dll"
+                    Target = "WebView2Loader.dll"
+                    Sha256 = "a9a09232c25805323d4cfb3fc8f545a190a9c8a99c93262ea99d0b88df99ec90"
+                }
+            )
         }
     )
 }

--- a/src/Lib/Functions/Private/Confirm-FileHash.ps1
+++ b/src/Lib/Functions/Private/Confirm-FileHash.ps1
@@ -14,10 +14,15 @@ function Confirm-FileHash {
         [string]$ExpectedHashSource
     )
 
-    # Where the expected hash came from, named in the failure so the remediation advice fits. It is
-    # the lock file for a download and for the build-time bundle, but the WebView2.pin stamp for
-    # assemblies already installed under %LOCALAPPDATA% - telling someone to stop editing the lock
-    # file when the mismatch is against a stamp sends them to the wrong place.
+    # Which file recorded the expected hash, named in the failure so the reader is sent to the right
+    # place. There are three callers and they do not all use the same one:
+    #
+    #   Invoke-DownloadFile        - DependencyLock.psd1, the pin for the package it just fetched.
+    #   Load time, bundle source   - DependencyLock.psd1, the per-file pins for the shipped bundle.
+    #   Load time, download source - WebView2.pin, the stamp Install-WebView2 wrote beside the
+    #                                assemblies in %LOCALAPPDATA% when it installed them.
+    #
+    # Defaults to the lock, so callers that predate this parameter are unchanged.
     if ([string]::IsNullOrWhiteSpace($ExpectedHashSource)) {
         $ExpectedHashSource = $Script:DependencyLockPath
     }
@@ -52,7 +57,7 @@ function Confirm-FileHash {
             $Disposition = "The file was deleted and has not been loaded."
         }
 
-        "Integrity check FAILED for '{0}' from '{1}'.`r`n  Expected SHA-256: {2}`r`n  Actual SHA-256:   {3}`r`n{4} Either the bytes were corrupted or replaced, or the artefact no longer matches what is recorded in '{5}'. Do not work around this by editing that file - run 'Clear-OmadaSqlTroubleshooterCache -Scope Binaries' to force a fresh, verified copy, and report it at https://github.com/Fortigi/OmadaSqlTroubleshooter/security/advisories/new if you believe the upstream artefact was tampered with." -f $ArtifactName, $SourceUrl, $ExpectedSha256.ToLowerInvariant(), $ActualSha256, $Disposition, $ExpectedHashSource | Write-Error -ErrorAction "Stop"
+        "Integrity check FAILED for '{0}' from '{1}'.`r`n  Expected SHA-256: {2}`r`n  Actual SHA-256:   {3}`r`n{4} Either the bytes were corrupted or replaced, or the artefact no longer matches what is recorded in '{5}'. Do not work around this by editing that file. If the file was downloaded, 'Clear-OmadaSqlTroubleshooterCache -Scope Binaries' forces a fresh, verified copy; if it shipped inside the module, reinstall the module with 'Update-Module -Name OmadaSqlTroubleshooter'. Report it at https://github.com/Fortigi/OmadaSqlTroubleshooter/security/advisories/new if you believe the upstream artefact was tampered with." -f $ArtifactName, $SourceUrl, $ExpectedSha256.ToLowerInvariant(), $ActualSha256, $Disposition, $ExpectedHashSource | Write-Error -ErrorAction "Stop"
     }
 
     "{0} - '{1}' matches the pinned SHA-256" -f $MyInvocation.MyCommand, $ArtifactName | Write-Verbose

--- a/src/Lib/Functions/Private/Confirm-FileHash.ps1
+++ b/src/Lib/Functions/Private/Confirm-FileHash.ps1
@@ -9,8 +9,18 @@ function Confirm-FileHash {
         [parameter(Mandatory = $true)]
         [string]$ArtifactName,
         [parameter(Mandatory = $false)]
-        [string]$SourceUrl
+        [string]$SourceUrl,
+        [parameter(Mandatory = $false)]
+        [string]$ExpectedHashSource
     )
+
+    # Where the expected hash came from, named in the failure so the remediation advice fits. It is
+    # the lock file for a download and for the build-time bundle, but the WebView2.pin stamp for
+    # assemblies already installed under %LOCALAPPDATA% - telling someone to stop editing the lock
+    # file when the mismatch is against a stamp sends them to the wrong place.
+    if ([string]::IsNullOrWhiteSpace($ExpectedHashSource)) {
+        $ExpectedHashSource = $Script:DependencyLockPath
+    }
 
     # No tracer preamble: see Get-DependencyLock. This runs during module import.
 
@@ -23,7 +33,7 @@ function Confirm-FileHash {
     # An empty pin would otherwise compare equal to nothing and silently accept any bytes, so it is
     # refused outright rather than treated as "no check requested".
     if ([string]::IsNullOrWhiteSpace($ExpectedSha256)) {
-        "Artefact '{0}' has no expected SHA-256 in '{1}', so it cannot be verified. Refusing to use it." -f $ArtifactName, $Script:DependencyLockPath | Write-Error -ErrorAction "Stop"
+        "Artefact '{0}' has no expected SHA-256 in '{1}', so it cannot be verified. Refusing to use it." -f $ArtifactName, $ExpectedHashSource | Write-Error -ErrorAction "Stop"
     }
 
     $ActualSha256 = Get-FileSha256 -Path $Path
@@ -42,7 +52,7 @@ function Confirm-FileHash {
             $Disposition = "The file was deleted and has not been loaded."
         }
 
-        "Integrity check FAILED for '{0}' from '{1}'.`r`n  Expected SHA-256: {2}`r`n  Actual SHA-256:   {3}`r`n{4} Either the download was corrupted, or the published artefact no longer matches the version pinned in '{5}'. Do not work around this by editing the lock file - report it at https://github.com/Fortigi/OmadaSqlTroubleshooter/security/advisories/new if you believe the upstream artefact was tampered with." -f $ArtifactName, $SourceUrl, $ExpectedSha256.ToLowerInvariant(), $ActualSha256, $Disposition, $Script:DependencyLockPath | Write-Error -ErrorAction "Stop"
+        "Integrity check FAILED for '{0}' from '{1}'.`r`n  Expected SHA-256: {2}`r`n  Actual SHA-256:   {3}`r`n{4} Either the bytes were corrupted or replaced, or the artefact no longer matches what is recorded in '{5}'. Do not work around this by editing that file - run 'Clear-OmadaSqlTroubleshooterCache -Scope Binaries' to force a fresh, verified copy, and report it at https://github.com/Fortigi/OmadaSqlTroubleshooter/security/advisories/new if you believe the upstream artefact was tampered with." -f $ArtifactName, $SourceUrl, $ExpectedSha256.ToLowerInvariant(), $ActualSha256, $Disposition, $ExpectedHashSource | Write-Error -ErrorAction "Stop"
     }
 
     "{0} - '{1}' matches the pinned SHA-256" -f $MyInvocation.MyCommand, $ArtifactName | Write-Verbose

--- a/src/Lib/Functions/Private/Get-WebView2ExpectedHash.ps1
+++ b/src/Lib/Functions/Private/Get-WebView2ExpectedHash.ps1
@@ -1,0 +1,49 @@
+function Get-WebView2ExpectedHash {
+    [CmdletBinding()]
+    param()
+
+    # Returns a hashtable of file name -> expected SHA-256 for the assemblies that are about to be
+    # loaded, taken from whichever source they were resolved from.
+    #
+    #   Bundle   - the Files array in src\DependencyLock.psd1. The lock ships with the module, so it
+    #              is the authority on what the pin means.
+    #   Download - the stamp Install-WebView2 wrote next to the assemblies it verified. The lock
+    #              cannot be used here: it pins the files as they come out of the package, and the
+    #              download path is free to be at any pinned version the stamp records.
+    #
+    # Returns an empty hashtable when there is nothing to compare against, which the caller treats as
+    # "cannot verify" rather than "verified".
+    #
+    # No tracer preamble and no Write-LogOutput here: see Get-DependencyLock. This is reached from
+    # Initialize-OmadaSqlTroubleShooter but shares the import-time constraints of its collaborators.
+
+    $ExpectedHash = @{}
+
+    try {
+        if ($Script:WebView2Source -eq "Bundle") {
+            $Artifact = Get-LockedArtifact -Id "Microsoft.Web.WebView2"
+            foreach ($File in @($Artifact.Files)) {
+                $ExpectedHash[$File.Target] = $File.Sha256
+            }
+            return $ExpectedHash
+        }
+
+        $Stamp = Get-WebView2Stamp
+        if ($null -eq $Stamp) {
+            return $ExpectedHash
+        }
+
+        foreach ($StampedFile in @($Stamp.Files)) {
+            if ($null -eq $StampedFile -or [string]::IsNullOrWhiteSpace($StampedFile.Name)) {
+                continue
+            }
+            $ExpectedHash[$StampedFile.Name] = $StampedFile.Sha256
+        }
+    }
+    catch {
+        "The expected WebView2 assembly hashes could not be resolved ({0})." -f $_.Exception.Message | Write-Verbose
+        return @{}
+    }
+
+    return $ExpectedHash
+}

--- a/src/Lib/Functions/Private/Initialize-OmadaSqltroubleShooter.ps1
+++ b/src/Lib/Functions/Private/Initialize-OmadaSqltroubleShooter.ps1
@@ -73,7 +73,18 @@ function Initialize-OmadaSqlTroubleShooter {
                 # (the lock for a bundle, the install stamp for a download), so getting here means
                 # the install is damaged rather than merely unusual.
                 if (-not $ExpectedWebView2Hash.ContainsKey($WebView2AssemblyName)) {
-                    "Refusing to load '{0}' from '{1}': no expected SHA-256 is recorded for it in '{2}', so its integrity cannot be established. Run 'Clear-OmadaSqlTroubleshooterCache -Scope Binaries' and start the application again to force a fresh, verified download." -f $WebView2AssemblyName, $Script:WebView2BasePath, $ExpectedWebView2HashSource | Write-Error -ErrorAction "Stop"
+                    # The fix depends on which file is incomplete. A missing entry in the stamp is a
+                    # damaged cache, which clearing repairs. A missing entry in the lock is a damaged
+                    # module installation, and clearing the cache would neither fix it nor even be
+                    # possible to recover from on a machine with no route to nuget.org.
+                    if ($Script:WebView2Source -eq "Bundle") {
+                        $Remediation = "Reinstall the module with 'Update-Module -Name OmadaSqlTroubleshooter' or 'Install-Module -Name OmadaSqlTroubleshooter -Force' to restore the dependency lock and the bundled assemblies."
+                    }
+                    else {
+                        $Remediation = "Run 'Clear-OmadaSqlTroubleshooterCache -Scope Binaries' and start the application again to force a fresh, verified download."
+                    }
+
+                    "Refusing to load '{0}' from '{1}': no expected SHA-256 is recorded for it in '{2}', so its integrity cannot be established. {3}" -f $WebView2AssemblyName, $Script:WebView2BasePath, $ExpectedWebView2HashSource, $Remediation | Write-Error -ErrorAction "Stop"
                 }
 
                 "Verify assembly before load: '{0}'" -f $WebView2AssemblyName | Write-LogOutput -LogType DEBUG

--- a/src/Lib/Functions/Private/Initialize-OmadaSqltroubleShooter.ps1
+++ b/src/Lib/Functions/Private/Initialize-OmadaSqltroubleShooter.ps1
@@ -48,6 +48,11 @@ function Initialize-OmadaSqlTroubleShooter {
         if (-not $Script:WebView2AssemblyVerified) {
             $ExpectedWebView2Hash = Get-WebView2ExpectedHash
 
+            # Which file the expected hashes actually came from, so a failure points at the right
+            # one. The bundle is pinned by the lock; assemblies downloaded to %LOCALAPPDATA% are
+            # pinned by the stamp Install-WebView2 wrote beside them.
+            $ExpectedWebView2HashSource = if ($Script:WebView2Source -eq "Bundle") { $Script:DependencyLockPath } else { $Script:WebView2StampPath }
+
             # WebView2Loader.dll is verified alongside the three managed assemblies. It is not loaded
             # through Add-ReflectionAssembly - the Core assembly pulls it in natively - but it is
             # still native code entering this process, so a gate that skipped it would be a gate with
@@ -68,11 +73,11 @@ function Initialize-OmadaSqlTroubleShooter {
                 # (the lock for a bundle, the install stamp for a download), so getting here means
                 # the install is damaged rather than merely unusual.
                 if (-not $ExpectedWebView2Hash.ContainsKey($WebView2AssemblyName)) {
-                    "Refusing to load '{0}' from '{1}': no expected SHA-256 is recorded for it, so its integrity cannot be established. Run 'Clear-OmadaSqlTroubleshooterCache -Scope Binaries' and start the application again to force a fresh, verified download." -f $WebView2AssemblyName, $Script:WebView2BasePath | Write-Error -ErrorAction "Stop"
+                    "Refusing to load '{0}' from '{1}': no expected SHA-256 is recorded for it in '{2}', so its integrity cannot be established. Run 'Clear-OmadaSqlTroubleshooterCache -Scope Binaries' and start the application again to force a fresh, verified download." -f $WebView2AssemblyName, $Script:WebView2BasePath, $ExpectedWebView2HashSource | Write-Error -ErrorAction "Stop"
                 }
 
                 "Verify assembly before load: '{0}'" -f $WebView2AssemblyName | Write-LogOutput -LogType DEBUG
-                Confirm-FileHash -Path $WebView2AssemblyPath -ExpectedSha256 $ExpectedWebView2Hash[$WebView2AssemblyName] -ArtifactName $WebView2AssemblyName -SourceUrl $Script:WebView2BasePath
+                Confirm-FileHash -Path $WebView2AssemblyPath -ExpectedSha256 $ExpectedWebView2Hash[$WebView2AssemblyName] -ArtifactName $WebView2AssemblyName -SourceUrl $Script:WebView2BasePath -ExpectedHashSource $ExpectedWebView2HashSource
             }
 
             # Only after every file has actually been verified.

--- a/src/Lib/Functions/Private/Initialize-OmadaSqltroubleShooter.ps1
+++ b/src/Lib/Functions/Private/Initialize-OmadaSqltroubleShooter.ps1
@@ -37,6 +37,34 @@ function Initialize-OmadaSqlTroubleShooter {
                 else { throw $_.Exception.Message }
             }
         }
+        # Re-verify immediately before loading. Until now verification happened only at download
+        # time, and nothing re-checked a file swapped afterwards - both folders these assemblies can
+        # come from are writable by something at some point, and Assembly.LoadFrom runs whatever
+        # bytes are there in this session. A mismatch deletes the file and aborts rather than
+        # loading it; the next import re-downloads and re-verifies.
+        #
+        # Guarded to run once per session: the hashes cannot change under a loaded assembly, and
+        # re-hashing 0.94 MB on every call would be for nothing.
+        if (-not $Script:WebView2AssemblyVerified) {
+            $ExpectedWebView2Hash = Get-WebView2ExpectedHash
+
+            if ($ExpectedWebView2Hash.Count -eq 0) {
+                "The WebView2 assemblies could not be checked against a recorded hash before loading." | Write-LogOutput -LogType WARNING
+            }
+
+            foreach ($WebView2AssemblyPath in @($Script:WebView2CorePath, $Script:WebView2WinFormsPath, $Script:WebView2WpfPath)) {
+                $WebView2AssemblyName = Split-Path $WebView2AssemblyPath -Leaf
+                if (-not $ExpectedWebView2Hash.ContainsKey($WebView2AssemblyName)) {
+                    continue
+                }
+
+                "Verify assembly before load: '{0}'" -f $WebView2AssemblyName | Write-LogOutput -LogType DEBUG
+                Confirm-FileHash -Path $WebView2AssemblyPath -ExpectedSha256 $ExpectedWebView2Hash[$WebView2AssemblyName] -ArtifactName $WebView2AssemblyName -SourceUrl $Script:WebView2BasePath
+            }
+
+            $Script:WebView2AssemblyVerified = $true
+        }
+
         Add-ReflectionAssembly -Object $Script:WebView2CorePath
         Add-ReflectionAssembly -Object $Script:WebView2WinFormsPath
         Add-ReflectionAssembly -Object $Script:WebView2WpfPath

--- a/src/Lib/Functions/Private/Initialize-OmadaSqltroubleShooter.ps1
+++ b/src/Lib/Functions/Private/Initialize-OmadaSqltroubleShooter.ps1
@@ -48,20 +48,34 @@ function Initialize-OmadaSqlTroubleShooter {
         if (-not $Script:WebView2AssemblyVerified) {
             $ExpectedWebView2Hash = Get-WebView2ExpectedHash
 
-            if ($ExpectedWebView2Hash.Count -eq 0) {
-                "The WebView2 assemblies could not be checked against a recorded hash before loading." | Write-LogOutput -LogType WARNING
-            }
+            # WebView2Loader.dll is verified alongside the three managed assemblies. It is not loaded
+            # through Add-ReflectionAssembly - the Core assembly pulls it in natively - but it is
+            # still native code entering this process, so a gate that skipped it would be a gate with
+            # a hole in it.
+            $WebView2AssemblyToVerify = @(
+                $Script:WebView2CorePath
+                $Script:WebView2WinFormsPath
+                $Script:WebView2WpfPath
+                $Script:WebView2LoaderPath
+            )
 
-            foreach ($WebView2AssemblyPath in @($Script:WebView2CorePath, $Script:WebView2WinFormsPath, $Script:WebView2WpfPath)) {
+            foreach ($WebView2AssemblyPath in $WebView2AssemblyToVerify) {
                 $WebView2AssemblyName = Split-Path $WebView2AssemblyPath -Leaf
+
+                # Fail closed. "No hash is recorded for this file" is not the same as "this file is
+                # fine" - it means nothing can vouch for the bytes, and loading them anyway would
+                # defeat the point of checking at all. Both sources always record all four files
+                # (the lock for a bundle, the install stamp for a download), so getting here means
+                # the install is damaged rather than merely unusual.
                 if (-not $ExpectedWebView2Hash.ContainsKey($WebView2AssemblyName)) {
-                    continue
+                    "Refusing to load '{0}' from '{1}': no expected SHA-256 is recorded for it, so its integrity cannot be established. Run 'Clear-OmadaSqlTroubleshooterCache -Scope Binaries' and start the application again to force a fresh, verified download." -f $WebView2AssemblyName, $Script:WebView2BasePath | Write-Error -ErrorAction "Stop"
                 }
 
                 "Verify assembly before load: '{0}'" -f $WebView2AssemblyName | Write-LogOutput -LogType DEBUG
                 Confirm-FileHash -Path $WebView2AssemblyPath -ExpectedSha256 $ExpectedWebView2Hash[$WebView2AssemblyName] -ArtifactName $WebView2AssemblyName -SourceUrl $Script:WebView2BasePath
             }
 
+            # Only after every file has actually been verified.
             $Script:WebView2AssemblyVerified = $true
         }
 

--- a/src/Lib/Functions/Private/Resolve-WebView2AssemblyPath.ps1
+++ b/src/Lib/Functions/Private/Resolve-WebView2AssemblyPath.ps1
@@ -1,0 +1,72 @@
+function Resolve-WebView2AssemblyPath {
+    [CmdletBinding()]
+    param(
+        [parameter(Mandatory = $true)]
+        [string]$ModuleRoot,
+        [parameter(Mandatory = $true)]
+        [string]$BinPath,
+        [parameter(Mandatory = $false)]
+        [string]$ProcessorArchitecture = $Env:PROCESSOR_ARCHITECTURE
+    )
+
+    # Decides which folder the WebView2 assemblies are loaded from, and returns the four paths plus
+    # whether Install-WebView2 still has to run.
+    #
+    # Bundle first: <ModuleRoot>\Bin\WebView2Dlls\win-x64, laid down and hash-verified at build time
+    # by build\Get-BundledDependency.ps1. With a valid bundle module import makes no network call at
+    # all, which is the point - restricted corporate networks are the norm for Omada customers and
+    # the module previously could not start without egress to nuget.org.
+    #
+    # The bundle is used IN PLACE. Nothing is copied out of it. The module folder is typically
+    # read-only, which is fine for LoadFrom and is exactly why the writable %LOCALAPPDATA% path has
+    # to stay for the fallback.
+    #
+    # Otherwise the existing %LOCALAPPDATA%\OmadaSqlTroubleshooter\Bin\<win-x64|win-x86> paths are
+    # returned unchanged, with RequiresInstall set, and the download path behaves exactly as before.
+    #
+    # No tracer preamble and no Write-LogOutput here: see Get-DependencyLock. This runs during module
+    # import, before Invoke-OmadaSqlTroubleshooter populates $Script:RunTimeConfig.
+
+    # Only x64 is bundled. The manifest declares ProcessorArchitecture = 'Amd64', and neither of the
+    # two fetchers this repository used to have ever targeted x86, so x86 always downloads.
+    $RuntimeFolder = "win-x64"
+    if ($ProcessorArchitecture -ne "AMD64") {
+        $RuntimeFolder = "win-x86"
+    }
+
+    $DownloadPath = [System.IO.Path]::Combine($BinPath, $RuntimeFolder)
+
+    $Resolved = @{
+        Core            = [System.IO.Path]::Combine($DownloadPath, "Microsoft.Web.WebView2.Core.dll")
+        WinForms        = [System.IO.Path]::Combine($DownloadPath, "Microsoft.Web.WebView2.WinForms.dll")
+        Wpf             = [System.IO.Path]::Combine($DownloadPath, "Microsoft.Web.WebView2.Wpf.dll")
+        Loader          = [System.IO.Path]::Combine($DownloadPath, "WebView2Loader.dll")
+        BasePath        = $DownloadPath
+        Source          = "Download"
+        RequiresInstall = $true
+    }
+
+    if ($RuntimeFolder -ne "win-x64") {
+        "{0} - Architecture '{1}' is not bundled; the assemblies will be downloaded and verified" -f $MyInvocation.MyCommand, $ProcessorArchitecture | Write-Verbose
+        return $Resolved
+    }
+
+    $BundlePath = [System.IO.Path]::Combine($ModuleRoot, "Bin", "WebView2Dlls", "win-x64")
+
+    if (-not (Test-WebView2Bundle -BundlePath $BundlePath)) {
+        "{0} - No usable bundle at '{1}'; the assemblies will be downloaded and verified" -f $MyInvocation.MyCommand, $BundlePath | Write-Verbose
+        return $Resolved
+    }
+
+    "{0} - Using the bundled WebView2 assemblies in '{1}'" -f $MyInvocation.MyCommand, $BundlePath | Write-Verbose
+
+    return @{
+        Core            = [System.IO.Path]::Combine($BundlePath, "Microsoft.Web.WebView2.Core.dll")
+        WinForms        = [System.IO.Path]::Combine($BundlePath, "Microsoft.Web.WebView2.WinForms.dll")
+        Wpf             = [System.IO.Path]::Combine($BundlePath, "Microsoft.Web.WebView2.Wpf.dll")
+        Loader          = [System.IO.Path]::Combine($BundlePath, "WebView2Loader.dll")
+        BasePath        = $BundlePath
+        Source          = "Bundle"
+        RequiresInstall = $false
+    }
+}

--- a/src/Lib/Functions/Private/Test-WebView2Bundle.ps1
+++ b/src/Lib/Functions/Private/Test-WebView2Bundle.ps1
@@ -1,0 +1,104 @@
+function Test-WebView2Bundle {
+    [CmdletBinding()]
+    param(
+        [parameter(Mandatory = $true)]
+        [AllowEmptyString()]
+        [string]$BundlePath
+    )
+
+    # Returns $true only when the folder holds a complete bundle that matches the pin: a stamp that
+    # parses, whose version equals the lock's, and every file the lock lists present and hashing to
+    # its pinned value.
+    #
+    # THIS MUST NEVER THROW. It is called during module import to choose between the bundled
+    # assemblies and the runtime download. Any problem at all - no folder, no stamp, a hand-edited
+    # stamp, a missing file, a tampered file, an unreadable lock - has to come back as $false so the
+    # module degrades to downloading rather than failing to import. That is the whole reason the
+    # fallback still exists.
+    #
+    # No tracer preamble and no Write-LogOutput here: see Get-DependencyLock. This runs during module
+    # import, before Invoke-OmadaSqlTroubleshooter populates $Script:RunTimeConfig.
+
+    try {
+        if ([string]::IsNullOrWhiteSpace($BundlePath) -or -not (Test-Path $BundlePath -PathType Container)) {
+            "{0} - No bundle folder at '{1}'" -f $MyInvocation.MyCommand, $BundlePath | Write-Verbose
+            return $false
+        }
+
+        $Artifact = Get-LockedArtifact -Id "Microsoft.Web.WebView2"
+
+        $PinnedFile = @($Artifact.Files)
+        if ($PinnedFile.Count -eq 0) {
+            "{0} - The lock lists no files for the bundle, so it cannot be verified" -f $MyInvocation.MyCommand | Write-Verbose
+            return $false
+        }
+
+        $StampPath = Join-Path $BundlePath -ChildPath "WebView2.pin"
+        if (-not (Test-Path $StampPath -PathType Leaf)) {
+            "{0} - No stamp at '{1}'" -f $MyInvocation.MyCommand, $StampPath | Write-Verbose
+            return $false
+        }
+
+        # Same parser as Get-DependencyLock: SafeGetValue evaluates constant expressions only, so a
+        # stamp file can never execute code. A stamp full of garbage lands in the catch below and
+        # comes back as $false, which is what keeps a corrupt bundle from killing module import.
+        $ParseErrors = $null
+        $Tokens = $null
+        $StampAst = [System.Management.Automation.Language.Parser]::ParseFile($StampPath, [ref]$Tokens, [ref]$ParseErrors)
+        if (($ParseErrors | Measure-Object).Count -gt 0) {
+            "{0} - Stamp '{1}' does not parse" -f $MyInvocation.MyCommand, $StampPath | Write-Verbose
+            return $false
+        }
+
+        $HashtableAst = $StampAst.Find({ param($Node) $Node -is [System.Management.Automation.Language.HashtableAst] }, $false)
+        if ($null -eq $HashtableAst) {
+            "{0} - Stamp '{1}' contains no hashtable" -f $MyInvocation.MyCommand, $StampPath | Write-Verbose
+            return $false
+        }
+
+        $Stamp = $HashtableAst.SafeGetValue()
+
+        if (-not $Stamp.ContainsKey("Version") -or [string]::IsNullOrWhiteSpace($Stamp.Version)) {
+            "{0} - Stamp '{1}' records no version" -f $MyInvocation.MyCommand, $StampPath | Write-Verbose
+            return $false
+        }
+
+        if ($Stamp.Version -ne $Artifact.Version) {
+            # Deliberately -ne and not -lt. A pin moving backwards is a rollback after a bad bump,
+            # precisely when it most needs to take effect.
+            "The bundled WebView2 assemblies are stamped {0} but the pinned version is {1}. They will be ignored in favour of a verified download." -f $Stamp.Version, $Artifact.Version | Write-Verbose
+            return $false
+        }
+
+        foreach ($File in $PinnedFile) {
+            $FilePath = Join-Path $BundlePath -ChildPath $File.Target
+            if (-not (Test-Path $FilePath -PathType Leaf)) {
+                "{0} - Bundled assembly '{1}' is missing" -f $MyInvocation.MyCommand, $File.Target | Write-Verbose
+                return $false
+            }
+
+            # Compared against the hash in the LOCK, not the one in the stamp. The stamp sits in the
+            # same folder as the assemblies, so anything able to swap a DLL could rewrite the stamp
+            # to match it; the lock ships with the module and is what the pin actually means.
+            #
+            # Hashed rather than run through Confirm-FileHash on purpose. Confirm-FileHash deletes the
+            # file it rejects, which is right for a download landing in a temp file and wrong for a
+            # probe against an installed module folder - a probe must not damage the installation it
+            # is inspecting. The real gate is unchanged: Confirm-FileHash still runs against these
+            # same hashes immediately before each assembly is loaded, whichever folder it came from.
+            if ((Get-FileSha256 -Path $FilePath) -ne $File.Sha256) {
+                "The bundled WebView2 assembly '{0}' does not match the hash pinned in the dependency lock. The bundle will be ignored in favour of a verified download." -f $File.Target | Write-Warning
+                return $false
+            }
+        }
+
+        "{0} - Bundle at '{1}' is complete and matches pinned version {2}" -f $MyInvocation.MyCommand, $BundlePath, $Artifact.Version | Write-Verbose
+        return $true
+    }
+    catch {
+        # Intentionally swallowed. See the contract at the top: no failure mode here may prevent the
+        # module from importing, because there is always the download path to fall back to.
+        "The bundled WebView2 assemblies could not be verified ({0}). Falling back to the runtime download." -f $_.Exception.Message | Write-Verbose
+        return $false
+    }
+}

--- a/src/OmadaSqlTroubleShooter.psm1
+++ b/src/OmadaSqlTroubleShooter.psm1
@@ -59,34 +59,45 @@ try {
 
     "{0} - Set paths" -f $MyInvocation.MyCommand | Write-Verbose
 
-    #WebView2 Base Path
+    # WebView2 assembly locations. Prefers the bundle laid down and hash-verified at build time in
+    # <ModuleRoot>\Bin\WebView2Dlls\win-x64; falls back to the writable
+    # %LOCALAPPDATA%\OmadaSqlTroubleshooter\Bin\<win-x64|win-x86> download path, unchanged. With a
+    # valid bundle nothing is downloaded and module import makes no network call at all.
+    $ResolvedWebView2Path = Resolve-WebView2AssemblyPath -ModuleRoot $PSScriptRoot -BinPath $WebBinBasePath
+
+    $Script:WebView2CorePath = $ResolvedWebView2Path.Core
+    $Script:WebView2WinFormsPath = $ResolvedWebView2Path.WinForms
+    $Script:WebView2WpfPath = $ResolvedWebView2Path.Wpf
+    $Script:WebView2LoaderPath = $ResolvedWebView2Path.Loader
+
+    # Which of the two folders the paths above point at. Get-WebView2ExpectedHash reads it to decide
+    # whether the load-time check compares against the lock or against the download stamp.
+    $Script:WebView2Source = $ResolvedWebView2Path.Source
+
+    # Named in the load-time integrity error, so the message says which folder the rejected bytes
+    # were in rather than just which file.
+    $Script:WebView2BasePath = $ResolvedWebView2Path.BasePath
+
+    "{0} - WebView2 assemblies resolved from the {1} at '{2}'" -f $MyInvocation.MyCommand, $ResolvedWebView2Path.Source.ToLowerInvariant(), $ResolvedWebView2Path.BasePath | Write-Verbose
+
+    # The pin stamp Install-WebView2 writes always lives with the DOWNLOADED assemblies, never in the
+    # bundle. Write-WebView2Stamp, Test-WebView2RuntimeVersion and
+    # Clear-OmadaSqlTroubleshooterCache -Scope Binaries all address that one, and the module folder
+    # is typically read-only anyway. The bundle carries its own stamp, which Test-WebView2Bundle
+    # reads directly.
     if ($Env:PROCESSOR_ARCHITECTURE -eq "AMD64") {
-        $WebView2BasePath = [System.IO.Path]::Combine($WebBinBasePath, "win-x64")
+        $WebView2DownloadPath = [System.IO.Path]::Combine($WebBinBasePath, "win-x64")
     }
     else {
-        $WebView2BasePath = [System.IO.Path]::Combine($WebBinBasePath, "win-x86")
+        $WebView2DownloadPath = [System.IO.Path]::Combine($WebBinBasePath, "win-x86")
     }
-    New-Item -ItemType Directory -Path $WebView2BasePath -Force | Out-Null
+    $Script:WebView2StampPath = [System.IO.Path]::Combine($WebView2DownloadPath, "WebView2.pin")
 
-    #WebView2 Core Location
-    $Script:WebView2CorePath = [System.IO.Path]::Combine($WebView2BasePath, "Microsoft.Web.WebView2.Core.dll")
-    "{0} - {1}" -f $MyInvocation.MyCommand, $Script:WebView2CorePath | Write-Verbose
-
-    #WebView2 WinForms Location
-    $Script:WebView2WinFormsPath = [System.IO.Path]::Combine($WebView2BasePath, "Microsoft.Web.WebView2.WinForms.dll")
-    "{0} - {1}" -f $MyInvocation.MyCommand, $Script:WebView2WinFormsPath | Write-Verbose
-
-    #WebView2 WPF Location
-    $Script:WebView2WpfPath = [System.IO.Path]::Combine($WebView2BasePath, "Microsoft.Web.WebView2.Wpf.dll")
-    "{0} - {1}" -f $MyInvocation.MyCommand, $Script:WebView2WpfPath | Write-Verbose
-
-    #WebView2 Loader Location
-    $Script:WebView2LoaderPath = [System.IO.Path]::Combine($WebView2BasePath, "WebView2Loader.dll")
-    "{0} - {1}" -f $MyInvocation.MyCommand, $Script:WebView2LoaderPath | Write-Verbose
-
-    #WebView2 Pin Stamp Location - records which pinned version the installed assemblies came from
-    $Script:WebView2StampPath = [System.IO.Path]::Combine($WebView2BasePath, "WebView2.pin")
-    "{0} - {1}" -f $MyInvocation.MyCommand, $Script:WebView2StampPath | Write-Verbose
+    if ($ResolvedWebView2Path.RequiresInstall) {
+        # Only created when it is actually going to be used, so a bundled install does not leave an
+        # empty folder behind in the user's profile.
+        New-Item -ItemType Directory -Path $WebView2DownloadPath -Force | Out-Null
+    }
 
     #WebView2 User Profile Base Location
     $Script:WebView2UserProfileBasePath = [System.IO.Path]::Combine($Script:ModuleAppDataPath, "Edge User Data")
@@ -95,7 +106,15 @@ try {
     $Script:WebView2UserProfilePath = [System.IO.Path]::Combine($Script:ModuleAppDataPath, "Edge User Data\OmadaWebView2Profile")
     "{0} - {1}" -f $MyInvocation.MyCommand, $Script:WebView2UserProfilePath | Write-Verbose
 
-    $WebViewInstalled = Install-WebView2 -IncludeWpf
+    # Only downloads when there is no usable bundle. Install-WebView2 is unchanged: it fetches the
+    # pinned URL, verifies the bytes, and writes the assemblies and their stamp into
+    # %LOCALAPPDATA%\OmadaSqlTroubleshooter\Bin, exactly as before.
+    if ($ResolvedWebView2Path.RequiresInstall) {
+        $WebViewInstalled = Install-WebView2 -IncludeWpf
+    }
+    else {
+        $WebViewInstalled = $true
+    }
     # (Join-Path $env:ProgramFiles -ChildPath "Microsoft\EdgeWebView"), (Join-Path ${env:ProgramFiles(x86)} -ChildPath "Microsoft\EdgeWebView"), (Join-Path $LocalAppDataPath -ChildPath "$ModuleName\bin\Webview2Runtime"), (Join-Path $PsscriptRoot -ChildPath "bin\Webview2Runtime") | ForEach-Object {
     #     if (Test-Path $_) {
     #         (Get-ChildItem $_ -Filter *.exe -Recurse | Where-Object { $_.Name -eq "msedgewebview2.exe" }) | ForEach-Object {

--- a/tests/Confirm-FileHash.Tests.ps1
+++ b/tests/Confirm-FileHash.Tests.ps1
@@ -64,6 +64,40 @@ Describe 'Confirm-FileHash' -Tag 'Unit' {
         $Message | Should -BeLike '*d121be3103007b41edf96f8262925f8c7d61894afe9a041843b631f69445bc57*'
     }
 
+    It 'Should point at the dependency lock by default' {
+        Set-Content -Path $Script:PayloadPath -Value 'tampered' -NoNewline
+
+        $Message = $null
+        try {
+            Confirm-FileHash -Path $Script:PayloadPath -ExpectedSha256 $Script:HelloSha256 -ArtifactName 'Test 1.0.0' -ErrorAction Stop
+        }
+        catch {
+            $Message = $_.Exception.Message
+        }
+
+        $Message | Should -BeLike '*DependencyLock.psd1*'
+    }
+
+    It 'Should name the file the expected hash actually came from' {
+        # The same verifier runs against a download pinned by the lock and against assemblies
+        # already installed under %LOCALAPPDATA%, whose expected hashes come from the WebView2.pin
+        # stamp beside them. Telling someone to stop editing the lock file when the mismatch is
+        # against a stamp sends them to the wrong file.
+        Set-Content -Path $Script:PayloadPath -Value 'tampered' -NoNewline
+        $StampPath = Join-Path $TestDrive 'WebView2.pin'
+
+        $Message = $null
+        try {
+            Confirm-FileHash -Path $Script:PayloadPath -ExpectedSha256 $Script:HelloSha256 -ArtifactName 'Test 1.0.0' -ExpectedHashSource $StampPath -ErrorAction Stop
+        }
+        catch {
+            $Message = $_.Exception.Message
+        }
+
+        $Message | Should -BeLike ('*{0}*' -f $StampPath)
+        $Message | Should -Not -BeLike '*DependencyLock.psd1*'
+    }
+
     It 'Should say the file is still on disk when it could not be deleted' {
         # Removal is best-effort: the file can be locked, or the directory read-only. Claiming "the
         # file was deleted" when it was not is the sentence that stops someone removing it by hand.

--- a/tests/DependencyLock.Tests.ps1
+++ b/tests/DependencyLock.Tests.ps1
@@ -64,6 +64,54 @@ Describe 'DependencyLock.psd1' -Tag 'Unit' {
         }
     }
 
+    It 'Should list the files taken out of every package' {
+        # The package hash cannot verify a file that has been extracted out of the package, and the
+        # build-time bundle ships exactly those extracted files. Without a Files list there is
+        # nothing for Get-BundledDependency to copy and nothing for Test-WebView2Bundle to check.
+        foreach ($Artifact in $Script:Artifacts) {
+            @($Artifact.Files).Count | Should -BeGreaterThan 0 -Because "artefact '$($Artifact.Id)' is bundled at build time"
+        }
+    }
+
+    It 'Should pin a 64-character lower-case SHA-256 for every bundled file' {
+        foreach ($Artifact in $Script:Artifacts) {
+            foreach ($File in @($Artifact.Files)) {
+                $File.Sha256 | Should -Match '^[0-9a-f]{64}$' -Because "'$($File.Target)' is re-verified immediately before it is loaded"
+                $File.Source | Should -Not -BeNullOrEmpty
+                $File.Target | Should -Not -BeNullOrEmpty
+            }
+        }
+    }
+
+    It 'Should map each bundled file onto a unique target name' {
+        # Microsoft.Web.WebView2.Wpf.dll exists three times in the package with different bytes. Two
+        # sources writing one target would mean whichever copied last wins - the exact ambiguity the
+        # two old fetchers disagreed about.
+        foreach ($Artifact in $Script:Artifacts) {
+            $Duplicate = @($Artifact.Files) | Group-Object { $_.Target } | Where-Object { $_.Count -gt 1 }
+            $Duplicate | Should -BeNullOrEmpty -Because "artefact '$($Artifact.Id)' must resolve one source per target"
+        }
+    }
+
+    It 'Should reference package entries by their in-archive path' {
+        foreach ($Artifact in $Script:Artifacts) {
+            foreach ($File in @($Artifact.Files)) {
+                $File.Source | Should -Not -Match '\\' -Because 'zip entry names use forward slashes'
+                $File.Source | Should -BeLike ('*{0}' -f $File.Target) -Because "'$($File.Source)' should end in the file it produces"
+            }
+        }
+    }
+
+    It 'Should take the WPF assembly from the framework Install-WebView2 has always used' {
+        # netcoreapp3.0, not net5.0-windows10.0.17763.0 and not net462. All three ship a
+        # Microsoft.Web.WebView2.Wpf.dll with different bytes; the deleted build/RetrieveDependencies.ps1
+        # took the net5.0 one while the module loaded the netcoreapp3.0 one.
+        $WebView2 = @($Script:Artifacts | Where-Object { $_.Id -eq 'Microsoft.Web.WebView2' })[0]
+        $Wpf = @($WebView2.Files | Where-Object { $_.Target -eq 'Microsoft.Web.WebView2.Wpf.dll' })[0]
+        $Wpf | Should -Not -BeNullOrEmpty
+        $Wpf.Source | Should -Be 'lib_manual/netcoreapp3.0/Microsoft.Web.WebView2.Wpf.dll'
+    }
+
     It 'Should name an installer that exists for every artefact' {
         foreach ($Artifact in $Script:Artifacts) {
             $InstallerPath = Join-Path $Script:PrivatePath -ChildPath ('{0}.ps1' -f $Artifact.InstalledBy)

--- a/tests/DependencyLock.Tests.ps1
+++ b/tests/DependencyLock.Tests.ps1
@@ -160,6 +160,37 @@ Describe 'Dependency lock packaging' -Tag 'Unit' {
         $Deploy | Should -Match 'DependencyLock\.psd1'
     }
 
+    It 'Should have its bundled files fetched into the package by psake' {
+        # Task Dependencies is what puts the assemblies in the package. Part A removed a Task
+        # Dependencies that was in no task chain at all, so the package contained no bin folder;
+        # asserting the call and the chain together is what keeps that from recurring.
+        $Psake = Get-Content -Path (Join-Path $Script:RepositoryRoot -ChildPath 'build\psakeBuild.ps1') -Raw
+
+        $Psake | Should -Match 'Get-BundledDependency\.ps1' -Because 'something has to fetch the bundle'
+        $Psake | Should -Match 'Task Build -Depends Test, Dependencies' -Because 'bundling must be in every chain that publishes'
+    }
+
+    It 'Should have the bundled files verified by psake before the package is published' {
+        $Psake = Get-Content -Path (Join-Path $Script:RepositoryRoot -ChildPath 'build\psakeBuild.ps1') -Raw
+
+        $Psake | Should -Match 'Task TestAssemblies'
+        foreach ($Chain in @('Task TestBuildOnly', 'Task Pipeline')) {
+            $ChainLine = [regex]::Match($Psake, ('(?m)^{0}.*$' -f [regex]::Escape($Chain))).Value
+            $ChainLine | Should -Match 'TestAssemblies' -Because "a package with a broken bundle still imports, so '$Chain' would not otherwise notice"
+        }
+    }
+
+    It 'Should not require the WebView2 Runtime executable in the build output' {
+        # msedgewebview2.exe is the 260 MB WebView2 Runtime, which this project does not
+        # redistribute (THIRD-PARTY-NOTICES.md section 3.1). The old TestAssemblies demanded it and
+        # could therefore only ever fail.
+        $Psake = Get-Content -Path (Join-Path $Script:RepositoryRoot -ChildPath 'build\psakeBuild.ps1') -Raw
+        $TaskBody = [regex]::Match($Psake, '(?s)Task TestAssemblies \{.*?\r?\n\}').Value
+
+        $TaskBody | Should -Not -BeNullOrEmpty
+        $TaskBody | Should -Not -Match 'msedgewebview2'
+    }
+
     It 'Should be verified by every CI lane that builds or publishes' {
         foreach ($Workflow in @('pr-validation.yml', 'release.yml', 'nightly.yml')) {
             $Content = Get-Content -Path (Join-Path $Script:RepositoryRoot -ChildPath ('.github\workflows\{0}' -f $Workflow)) -Raw

--- a/tests/DependencyLock.Tests.ps1
+++ b/tests/DependencyLock.Tests.ps1
@@ -167,7 +167,7 @@ Describe 'Dependency lock packaging' -Tag 'Unit' {
         $Psake = Get-Content -Path (Join-Path $Script:RepositoryRoot -ChildPath 'build\psakeBuild.ps1') -Raw
 
         $Psake | Should -Match 'Get-BundledDependency\.ps1' -Because 'something has to fetch the bundle'
-        $Psake | Should -Match 'Task Build -Depends Test, Dependencies' -Because 'bundling must be in every chain that publishes'
+        $Psake | Should -Match 'Task Build -Depends Test, Dependencies' -Because 'bundling must be in every chain that publishes, including the nightly which runs a bare Build'
     }
 
     It 'Should have the bundled files verified by psake before the package is published' {
@@ -185,7 +185,7 @@ Describe 'Dependency lock packaging' -Tag 'Unit' {
         # redistribute (THIRD-PARTY-NOTICES.md section 3.1). The old TestAssemblies demanded it and
         # could therefore only ever fail.
         $Psake = Get-Content -Path (Join-Path $Script:RepositoryRoot -ChildPath 'build\psakeBuild.ps1') -Raw
-        $TaskBody = [regex]::Match($Psake, '(?s)Task TestAssemblies \{.*?\r?\n\}').Value
+        $TaskBody = [regex]::Match($Psake, '(?s)Task TestAssemblies\b[^\{]*\{.*?\r?\n\}').Value
 
         $TaskBody | Should -Not -BeNullOrEmpty
         $TaskBody | Should -Not -Match 'msedgewebview2'

--- a/tests/Resolve-WebView2AssemblyPath.Tests.ps1
+++ b/tests/Resolve-WebView2AssemblyPath.Tests.ps1
@@ -1,0 +1,135 @@
+BeforeAll {
+    $ParentPath = Split-Path -Path $PSScriptRoot -Parent
+    # Test-WebView2Bundle is dot-sourced so it can be mocked - Mock refuses a command that does not
+    # exist. Its own behaviour is covered by Test-WebView2Bundle.Tests.ps1; here it is only the
+    # bundle-valid / bundle-invalid switch.
+    . (Join-Path $ParentPath -ChildPath "src\lib\functions\Private\Get-FileSha256.ps1")
+    . (Join-Path $ParentPath -ChildPath "src\lib\functions\Private\Test-WebView2Bundle.ps1")
+    . (Join-Path $ParentPath -ChildPath "src\lib\functions\Private\Resolve-WebView2AssemblyPath.ps1")
+
+    $Script:AssemblyName = @(
+        'Microsoft.Web.WebView2.Core.dll'
+        'Microsoft.Web.WebView2.WinForms.dll'
+        'Microsoft.Web.WebView2.Wpf.dll'
+        'WebView2Loader.dll'
+    )
+}
+
+Describe 'Resolve-WebView2AssemblyPath' -Tag 'Unit' {
+
+    BeforeEach {
+        $Script:ModuleRoot = Join-Path $TestDrive ([guid]::NewGuid().ToString())
+        $Script:BinPath = Join-Path $TestDrive ([guid]::NewGuid().ToString())
+        New-Item -Path $Script:ModuleRoot -ItemType Directory -Force | Out-Null
+        New-Item -Path $Script:BinPath -ItemType Directory -Force | Out-Null
+
+        $Script:ExpectedBundlePath = Join-Path $Script:ModuleRoot -ChildPath 'Bin\WebView2Dlls\win-x64'
+    }
+
+    Context 'A valid bundle is present' {
+
+        BeforeEach {
+            Mock Test-WebView2Bundle { return $true }
+        }
+
+        It 'Should return the bundled paths' {
+            $Resolved = Resolve-WebView2AssemblyPath -ModuleRoot $Script:ModuleRoot -BinPath $Script:BinPath -ProcessorArchitecture 'AMD64'
+
+            $Resolved.Core | Should -Be (Join-Path $Script:ExpectedBundlePath -ChildPath 'Microsoft.Web.WebView2.Core.dll')
+            $Resolved.WinForms | Should -Be (Join-Path $Script:ExpectedBundlePath -ChildPath 'Microsoft.Web.WebView2.WinForms.dll')
+            $Resolved.Wpf | Should -Be (Join-Path $Script:ExpectedBundlePath -ChildPath 'Microsoft.Web.WebView2.Wpf.dll')
+            $Resolved.Loader | Should -Be (Join-Path $Script:ExpectedBundlePath -ChildPath 'WebView2Loader.dll')
+        }
+
+        It 'Should not require an install, so module import makes no network call' {
+            $Resolved = Resolve-WebView2AssemblyPath -ModuleRoot $Script:ModuleRoot -BinPath $Script:BinPath -ProcessorArchitecture 'AMD64'
+
+            $Resolved.RequiresInstall | Should -BeFalse
+            $Resolved.Source | Should -Be 'Bundle'
+        }
+
+        It 'Should look for the bundle inside the module folder' {
+            Resolve-WebView2AssemblyPath -ModuleRoot $Script:ModuleRoot -BinPath $Script:BinPath -ProcessorArchitecture 'AMD64' | Out-Null
+
+            Should -Invoke Test-WebView2Bundle -Times 1 -ParameterFilter { $BundlePath -eq $Script:ExpectedBundlePath }
+        }
+
+        It 'Should use the bundle in place and copy nothing out of it' {
+            # The module folder is typically read-only, which is fine for LoadFrom. Copying would need
+            # a writable module folder and would defeat the point of shipping the files.
+            Resolve-WebView2AssemblyPath -ModuleRoot $Script:ModuleRoot -BinPath $Script:BinPath -ProcessorArchitecture 'AMD64' | Out-Null
+
+            Get-ChildItem -Path $Script:BinPath -Recurse -File | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'No usable bundle' {
+
+        BeforeEach {
+            Mock Test-WebView2Bundle { return $false }
+        }
+
+        It 'Should fall back to the %LOCALAPPDATA% download paths, unchanged from before' {
+            $Resolved = Resolve-WebView2AssemblyPath -ModuleRoot $Script:ModuleRoot -BinPath $Script:BinPath -ProcessorArchitecture 'AMD64'
+
+            $ExpectedDownloadPath = Join-Path $Script:BinPath -ChildPath 'win-x64'
+            foreach ($Name in $Script:AssemblyName) {
+                @($Resolved.Core, $Resolved.WinForms, $Resolved.Wpf, $Resolved.Loader) |
+                    Should -Contain (Join-Path $ExpectedDownloadPath -ChildPath $Name)
+            }
+        }
+
+        It 'Should require an install so the fallback download runs' {
+            $Resolved = Resolve-WebView2AssemblyPath -ModuleRoot $Script:ModuleRoot -BinPath $Script:BinPath -ProcessorArchitecture 'AMD64'
+
+            $Resolved.RequiresInstall | Should -BeTrue
+            $Resolved.Source | Should -Be 'Download'
+        }
+    }
+
+    Context 'x86' {
+        # Only x64 is bundled: the manifest declares ProcessorArchitecture = 'Amd64', and neither of
+        # the two fetchers this repository used to have ever targeted x86.
+
+        It 'Should always require an install, whatever a bundle folder might contain' {
+            Mock Test-WebView2Bundle { return $true }
+
+            $Resolved = Resolve-WebView2AssemblyPath -ModuleRoot $Script:ModuleRoot -BinPath $Script:BinPath -ProcessorArchitecture 'x86'
+
+            $Resolved.RequiresInstall | Should -BeTrue
+            $Resolved.Source | Should -Be 'Download'
+        }
+
+        It 'Should return the win-x86 download paths' {
+            Mock Test-WebView2Bundle { return $true }
+
+            $Resolved = Resolve-WebView2AssemblyPath -ModuleRoot $Script:ModuleRoot -BinPath $Script:BinPath -ProcessorArchitecture 'x86'
+
+            $Resolved.Core | Should -Be (Join-Path (Join-Path $Script:BinPath -ChildPath 'win-x86') -ChildPath 'Microsoft.Web.WebView2.Core.dll')
+        }
+
+        It 'Should not even look at a bundle' {
+            Mock Test-WebView2Bundle { return $true }
+
+            Resolve-WebView2AssemblyPath -ModuleRoot $Script:ModuleRoot -BinPath $Script:BinPath -ProcessorArchitecture 'x86' | Out-Null
+
+            Should -Invoke Test-WebView2Bundle -Times 0
+        }
+    }
+
+    Context 'Every caller gets a complete answer' {
+
+        It 'Should always return all four assembly paths and a resolution decision' {
+            foreach ($BundleIsValid in @($true, $false)) {
+                Mock Test-WebView2Bundle { return $BundleIsValid }.GetNewClosure()
+
+                $Resolved = Resolve-WebView2AssemblyPath -ModuleRoot $Script:ModuleRoot -BinPath $Script:BinPath -ProcessorArchitecture 'AMD64'
+
+                foreach ($Key in @('Core', 'WinForms', 'Wpf', 'Loader', 'BasePath', 'Source', 'RequiresInstall')) {
+                    $Resolved.ContainsKey($Key) | Should -BeTrue -Because "the psm1 reads '$Key'"
+                }
+                $Resolved.Core | Should -Not -BeNullOrEmpty
+            }
+        }
+    }
+}

--- a/tests/Test-WebView2Bundle.Tests.ps1
+++ b/tests/Test-WebView2Bundle.Tests.ps1
@@ -1,0 +1,185 @@
+BeforeAll {
+    $ParentPath = Split-Path -Path $PSScriptRoot -Parent
+    . (Join-Path $ParentPath -ChildPath "src\lib\functions\Private\Get-FileSha256.ps1")
+    . (Join-Path $ParentPath -ChildPath "src\lib\functions\Private\Test-WebView2Bundle.ps1")
+
+    $Script:PinnedVersion = '1.0.4129.50'
+
+    # SHA-256 of each file's own name, written with no trailing newline. Using distinct content per
+    # file means a test that tampers with one cannot accidentally still match another's pin.
+    $Script:BundleFile = @(
+        @{ Target = 'Microsoft.Web.WebView2.Core.dll'; Content = 'core' }
+        @{ Target = 'Microsoft.Web.WebView2.WinForms.dll'; Content = 'winforms' }
+        @{ Target = 'Microsoft.Web.WebView2.Wpf.dll'; Content = 'wpf' }
+        @{ Target = 'WebView2Loader.dll'; Content = 'loader' }
+    )
+
+    function New-TestBundle {
+        # Lays out a bundle that Test-WebView2Bundle should accept, and returns its path. Individual
+        # tests then break exactly one thing about it.
+        param([string]$Path, [string]$StampVersion = $Script:PinnedVersion, [switch]$NoStamp)
+
+        New-Item -Path $Path -ItemType Directory -Force | Out-Null
+
+        $StampEntry = foreach ($File in $Script:BundleFile) {
+            $FilePath = Join-Path $Path -ChildPath $File.Target
+            Set-Content -Path $FilePath -Value $File.Content -NoNewline
+            '        @{{ Name = "{0}"; Sha256 = "{1}" }}' -f $File.Target, (Get-FileSha256 -Path $FilePath)
+        }
+
+        if (-not $NoStamp) {
+            $StampContent = @(
+                "@{"
+                ('    Version = "{0}"' -f $StampVersion)
+                "    Files   = @("
+                $StampEntry
+                "    )"
+                "}"
+            ) -join "`r`n"
+            Set-Content -Path (Join-Path $Path -ChildPath 'WebView2.pin') -Value $StampContent
+        }
+
+        return $Path
+    }
+
+    function Set-TestArtifact {
+        # Stands in for Get-LockedArtifact. The lock is the authority on the expected hashes, so the
+        # fixture derives them from the freshly written bundle.
+        param([string]$Path, [string]$Version = $Script:PinnedVersion)
+
+        $File = foreach ($Entry in $Script:BundleFile) {
+            @{
+                Source = 'lib_manual/netcoreapp3.0/{0}' -f $Entry.Target
+                Target = $Entry.Target
+                Sha256 = (Get-FileSha256 -Path (Join-Path $Path -ChildPath $Entry.Target))
+            }
+        }
+
+        $Script:TestArtifact = @{
+            Id      = 'Microsoft.Web.WebView2'
+            Version = $Version
+            Files   = @($File)
+        }
+    }
+
+    function Get-LockedArtifact {
+        param([string]$Id)
+
+        if ($null -eq $Script:TestArtifact) {
+            throw "no artefact configured"
+        }
+        return $Script:TestArtifact
+    }
+}
+
+Describe 'Test-WebView2Bundle' -Tag 'Unit' {
+
+    BeforeEach {
+        $Script:BundlePath = New-TestBundle -Path (Join-Path $TestDrive ([guid]::NewGuid().ToString()))
+        Set-TestArtifact -Path $Script:BundlePath
+    }
+
+    Context 'A bundle that should be used' {
+
+        It 'Should accept a complete bundle whose files and stamp match the pin' {
+            Test-WebView2Bundle -BundlePath $Script:BundlePath | Should -BeTrue
+        }
+    }
+
+    Context 'A bundle that must be refused' {
+
+        It 'Should refuse a bundle with a missing file' {
+            Remove-Item -Path (Join-Path $Script:BundlePath -ChildPath 'Microsoft.Web.WebView2.Wpf.dll') -Force
+
+            Test-WebView2Bundle -BundlePath $Script:BundlePath | Should -BeFalse
+        }
+
+        It 'Should refuse a bundle with a tampered file' {
+            Set-Content -Path (Join-Path $Script:BundlePath -ChildPath 'Microsoft.Web.WebView2.Core.dll') -Value 'tampered' -NoNewline
+
+            Test-WebView2Bundle -BundlePath $Script:BundlePath | Should -BeFalse
+        }
+
+        It 'Should refuse a bundle whose stamp records a different version from the pin' {
+            # -ne and not -lt on purpose: a pin moving backwards is a rollback after a bad bump, and
+            # the newer bundled assemblies must stop being loaded.
+            $Rolled = New-TestBundle -Path (Join-Path $TestDrive ([guid]::NewGuid().ToString())) -StampVersion '1.0.9999.0'
+            Set-TestArtifact -Path $Rolled
+
+            Test-WebView2Bundle -BundlePath $Rolled | Should -BeFalse
+        }
+
+        It 'Should refuse a bundle with no stamp at all' {
+            $Unstamped = New-TestBundle -Path (Join-Path $TestDrive ([guid]::NewGuid().ToString())) -NoStamp
+            Set-TestArtifact -Path $Unstamped
+
+            Test-WebView2Bundle -BundlePath $Unstamped | Should -BeFalse
+        }
+
+        It 'Should refuse a folder that does not exist' {
+            Test-WebView2Bundle -BundlePath (Join-Path $TestDrive 'no-such-folder') | Should -BeFalse
+        }
+
+        It 'Should refuse an empty bundle path' {
+            Test-WebView2Bundle -BundlePath '' | Should -BeFalse
+        }
+    }
+
+    Context 'It must never throw, whatever it finds' {
+        # This is the assertion that protects module import. Test-WebView2Bundle is called before the
+        # module has any of its error handling set up, and every failure here has a safe answer: use
+        # the download path instead.
+
+        It 'Should return false rather than throw on a garbage stamp' {
+            Set-Content -Path (Join-Path $Script:BundlePath -ChildPath 'WebView2.pin') -Value "@{ this is not = valid powershell ((("
+
+            { Test-WebView2Bundle -BundlePath $Script:BundlePath -ErrorAction Stop } | Should -Not -Throw
+            Test-WebView2Bundle -BundlePath $Script:BundlePath | Should -BeFalse
+        }
+
+        It 'Should return false rather than throw on a stamp that parses but records no version' {
+            Set-Content -Path (Join-Path $Script:BundlePath -ChildPath 'WebView2.pin') -Value "@{ Files = @() }"
+
+            { Test-WebView2Bundle -BundlePath $Script:BundlePath -ErrorAction Stop } | Should -Not -Throw
+            Test-WebView2Bundle -BundlePath $Script:BundlePath | Should -BeFalse
+        }
+
+        It 'Should return false rather than throw when the stamp holds a command instead of data' {
+            # SafeGetValue evaluates constant expressions only, so this is refused rather than run.
+            $Marker = Join-Path $TestDrive 'stamp-executed.txt'
+            Set-Content -Path (Join-Path $Script:BundlePath -ChildPath 'WebView2.pin') -Value ('@{{ Version = (Set-Content -Path "{0}" -Value "executed") }}' -f $Marker)
+
+            { Test-WebView2Bundle -BundlePath $Script:BundlePath -ErrorAction Stop } | Should -Not -Throw
+            Test-WebView2Bundle -BundlePath $Script:BundlePath | Should -BeFalse
+            Test-Path $Marker | Should -BeFalse -Because 'a stamp file must never be executed'
+        }
+
+        It 'Should return false rather than throw when the lock cannot be read' {
+            $Script:TestArtifact = $null
+
+            { Test-WebView2Bundle -BundlePath $Script:BundlePath -ErrorAction Stop } | Should -Not -Throw
+            Test-WebView2Bundle -BundlePath $Script:BundlePath | Should -BeFalse
+        }
+
+        It 'Should return false rather than throw when the lock lists no files' {
+            $Script:TestArtifact = @{ Id = 'Microsoft.Web.WebView2'; Version = $Script:PinnedVersion; Files = @() }
+
+            { Test-WebView2Bundle -BundlePath $Script:BundlePath -ErrorAction Stop } | Should -Not -Throw
+            Test-WebView2Bundle -BundlePath $Script:BundlePath | Should -BeFalse
+        }
+    }
+
+    Context 'It must not damage the installation it inspects' {
+
+        It 'Should leave a tampered bundle file on disk rather than deleting it' {
+            # Deliberately not Confirm-FileHash here: that deletes what it rejects, which is right for
+            # a download landing in a temp file and wrong for a probe against an installed module
+            # folder. Deleting would permanently degrade the install to the download path.
+            $Tampered = Join-Path $Script:BundlePath -ChildPath 'Microsoft.Web.WebView2.Core.dll'
+            Set-Content -Path $Tampered -Value 'tampered' -NoNewline
+
+            Test-WebView2Bundle -BundlePath $Script:BundlePath | Should -BeFalse
+            Test-Path $Tampered -PathType Leaf | Should -BeTrue
+        }
+    }
+}

--- a/tests/ThirdPartyNotices.Tests.ps1
+++ b/tests/ThirdPartyNotices.Tests.ps1
@@ -98,24 +98,55 @@ Describe 'THIRD-PARTY-NOTICES' -Tag 'Unit' {
         }
     }
 
-    Context 'Runtime download sources' {
+    Context 'Bundled and downloaded dependency sources' {
         # This used to assert that a literal www.nuget.org/api/v2 URL appeared in Install-WebView2.ps1.
         # That function no longer contains a URL at all: the download address comes from
         # src\DependencyLock.psd1. Reading the lock here is both more accurate and stricter - the
-        # notices now cannot drift from the pin the module actually downloads and verifies.
+        # notices now cannot drift from the pin the module actually ships and verifies.
+        #
+        # The entry moved from §2 (downloaded, not redistributed) to §1 (redistributed) when the
+        # assemblies started being bundled into the package at build time.
         BeforeAll {
             $Script:Lock = Import-PowerShellDataFile -Path (Join-Path $Script:ParentPath -ChildPath "src\DependencyLock.psd1")
             $Script:WebView2Artifact = @($Script:Lock.Artifacts | Where-Object { $_.Id -eq 'Microsoft.Web.WebView2' })[0]
 
             # Only the Microsoft.Web.WebView2 entry, so these assertions cannot be satisfied - or
             # broken - by text belonging to another component.
-            $SectionMatch = [regex]::Match($Script:Notices, '(?s)###\s*2\.1\s*Microsoft\.Web\.WebView2.*?(?=\r?\n---)')
+            $SectionMatch = [regex]::Match($Script:Notices, '(?s)###\s*1\.3\s*Microsoft\.Web\.WebView2.*?(?=\r?\n---)')
             $Script:WebView2Section = $SectionMatch.Value
         }
 
         It 'Should have a Microsoft.Web.WebView2 entry to check' {
             $Script:WebView2Artifact | Should -Not -BeNullOrEmpty -Because 'the lock file must pin the SDK'
-            $Script:WebView2Section | Should -Not -BeNullOrEmpty -Because 'the notices must carry a §2.1 entry for it'
+            $Script:WebView2Section | Should -Not -BeNullOrEmpty -Because 'the notices must carry a §1.3 entry for it'
+        }
+
+        It 'Should list the component as redistributed now that it ships in the package' {
+            $Script:WebView2Section | Should -Match 'Location in package' -Because 'a bundled component must say where it lands in the package'
+            $Script:Notices | Should -Match 'fetched and hash-verified at build time' -Because "section 1's opening must cover a component that is not committed"
+        }
+
+        It 'Should still document the run-time download fallback' {
+            # The fallback is what keeps a damaged bundle, and every x86 process, working.
+            $Script:Notices | Should -Match '(?s)###\s*2\.1\s*Microsoft\.Web\.WebView2'
+            $Script:Notices | Should -Match 'LOCALAPPDATA'
+        }
+
+        It 'Should carry a redistribution review that is explicitly not yet signed off' {
+            # Bundling moves this component into Fortigi's redistribution obligations. The review is
+            # a blocking prerequisite for the first bundled release and must not read as concluded
+            # while the placeholder is still there. If someone completes the review, they remove the
+            # TODO and this assertion is updated in the same change.
+            $Script:WebView2Section | Should -Match 'DRAFT, NOT YET SIGNED OFF'
+            $Script:WebView2Section | Should -Match 'TODO: reviewed by'
+        }
+
+        It 'Should reproduce the licence text the redistribution grant depends on' {
+            # The grant permits binary redistribution only if the copyright notice, the conditions
+            # and the disclaimer travel with the distribution. This file is what carries them.
+            $Script:WebView2Section | Should -Match 'Copyright \(C\) Microsoft Corporation\. All rights reserved\.'
+            $Script:WebView2Section | Should -Match 'Redistributions in binary form must reproduce'
+            $Script:WebView2Section | Should -Match 'THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS'
         }
 
         It 'Should record the URL the module actually downloads the SDK from' {


### PR DESCRIPTION
Part B of issue #54: bundle the WebView2 SDK assemblies into the published module at build time, verify them, load them from the module folder, and keep the existing `%LOCALAPPDATA%` download as the fallback.

Part A shipped in #55 (`7416f7b`). This builds directly on its lock file, its hash gate and its pin stamp.

**Deliberately no auto-closing keyword.** Issue #54 must stay open: the WebView2 SDK redistribution licence review is an acceptance criterion, it is a decision for a named person at Fortigi, and it is **not met** by this PR. See "The blocker" below. Relates to #54.

---

## What Part A had already done

Worth stating, because the issue was written before Part A landed and several Part B items were already delivered there. Verified against `origin/main`:

| Issue item | State on main |
|---|---|
| Delete `build/RetrieveDependencies.ps1`, `build/AddSrcDependencies.ps1`, `RetrieveFromNuGet` | Already deleted. `deploy/deploy.ps1` already keeps the Runtime warning and already copies `DependencyLock.psd1` |
| Delete the undefined `$PowerShellType` in the psm1 | Already deleted |
| Land the `WebView2.pin` stamp in Part A | Already landed — `Get-WebView2Stamp.ps1` / `Write-WebView2Stamp.ps1` |
| Always-run test allowlist for `DependencyLock.Tests.ps1` | Already added (`$AlwaysRunTestFile` in `Task Test`) |

So this PR is the remaining Part B work only.

## What this PR does

**Per-file pins.** The package SHA-256 from Part A verifies the `.nupkg` as downloaded; it cannot verify a file extracted out of it, which is what a bundle contains. `DependencyLock.psd1` gains a `Files` array — `Source` (in-archive path), `Target`, `Sha256` — per assembly.

**I computed all four hashes myself** from `microsoft.web.webview2.1.0.4129.50.nupkg`, after first confirming the package's own hash against the existing pin. They match the candidates in the issue, but they were derived, not copied. `Update-DependencyLock.ps1 -Check` now re-derives them from the package independently on every online run.

`Microsoft.Web.WebView2.Wpf.dll` ships **three** times in the package with different bytes:

| Path | SHA-256 |
|---|---|
| `lib/net462/` | `217874fc…` |
| `lib_manual/net5.0-windows10.0.17763.0/` | `ce832969…` |
| **`lib_manual/netcoreapp3.0/`** (pinned) | `85f62dc8…` |

Standardised on `netcoreapp3.0`, what `Install-WebView2` has always loaded. The build **throws** when a listed `Source` is absent, so an upstream repackaging is a build failure rather than a silently incomplete bundle.

**`build/Get-BundledDependency.ps1`** downloads the pinned URL, verifies the package hash *before* opening it, copies each `Files` entry, re-hashes every copy on disk against its own pin, writes the stamp, and reports the size. It reads entries straight out of the archive rather than expanding it — nothing unpinned reaches disk, and it sidesteps `Expand-Archive`'s refusal to open a non-`.zip`, the bug that broke the old deploy-time copy. It writes only into `buildoutput`, never under `src/`.

**Runtime.** `Test-WebView2Bundle` (never throws — any problem returns `$false` and degrades to the download) and `Resolve-WebView2AssemblyPath` (prefers `<ModuleRoot>\Bin\WebView2Dlls\win-x64`, else the existing `%LOCALAPPDATA%` paths with `RequiresInstall`; always `$true` on x86). The psm1 reduces to resolving paths and only calling `Install-WebView2` when `RequiresInstall`.

**Load-time re-verification.** `Initialize-OmadaSqlTroubleShooter` runs `Confirm-FileHash` against the recorded hash immediately before each `Add-ReflectionAssembly`, guarded once per session. This closes the gap where verification happened at download and nothing re-checked a file swapped afterwards.

**psake.** `Task Dependencies` calls the new script; `Build -Depends Test, Dependencies, TestAssemblies`; `TestAssemblies` repointed at what the lock produces, without the `msedgewebview2.exe` requirement; added to `TestBuildOnly` and `Pipeline`.

## The blocker — licence review NOT done

Bundling moves `Microsoft.Web.WebView2` from notices §2 (downloaded) to §1 (redistributed). **A named person at Fortigi must read the terms and record the conclusion before the first bundled release.** I cannot do this and have not pretended to.

`THIRD-PARTY-NOTICES.md` §1.3 carries a section headed **"Redistribution review — DRAFT, NOT YET SIGNED OFF"**, with the package's `LICENSE.txt` reproduced verbatim, the four questions a reviewer has to answer, and an explicit `TODO: reviewed by <name>, <date>` placeholder. A test asserts the placeholder is still present, so this cannot be quietly forgotten.

**One finding the reviewer should know up front:** the SDK package's `LICENSE.txt` is **not** the Microsoft Software License Terms "Distributable Code" boilerplate the issue anticipated. It is a **BSD-3-Clause-style grant** that permits binary redistribution provided the copyright notice, conditions and disclaimer are reproduced in the accompanying documentation. That looks more permissive than expected — but confirming it is the reviewer's call, not mine.

## Interaction with Dependabot PR #59

#59 bumps `Microsoft.Web.WebView2` `1.0.4129.50 → 1.0.4191.47` in `build/Dependencies/Dependencies.csproj`. **This PR deliberately does not do that bump** and stays pinned at `1.0.4129.50`.

The two touch the same file (`src/DependencyLock.psd1`), so order matters:

- **Recommended: merge this PR first, then #59.** After this lands, #59's bump needs `./build/Update-DependencyLock.ps1 -Refresh`, which now re-hashes **the package hash and all four per-file hashes** from the same download in one step. Re-run it on #59's branch (or run `dependency-lock-sync.yml` against it) and validation goes green.
- **If #59 merges first:** this branch must be rebased, `Version`/`Url`/`Sha256` updated for the new version, and — the easy thing to miss — **all four `Files[].Sha256` re-derived from the 4191.47 package**, since the assemblies change with the SDK. The measured bundle size would need re-checking too. `-Refresh` does all of it; `-Check` fails until it has been run.

Either way #59 cannot merge with a stale lock: `Update-DependencyLock.ps1 -Check` runs in PR validation, release and nightly, and now fails on a stale *per-file* hash as well as a stale package hash.

One latent bug fixed while adding this: `Set-ArtifactValue` matched every `Sha256 = "..."` line inside an artefact, so a `-Refresh` after this change would have written the package hash over all four per-file hashes. It now stops at the `Files = @(` line. Confirmed by corrupting the package hash and two file hashes in a copy of the lock, running `-Refresh`, and diffing back to identical.

## Verification

Baselined on unmodified `origin/main` first, so nothing below is a pre-existing failure.

| | Tests | Failed |
|---|---|---|
| Baseline (`origin/main` at branch point, `TestBuildOnly`) | 405 | 0 |
| This branch, before merging main | 442 | 0 |
| **This branch, after merging main (`b1fc1c1`, PR #72)** | **479** | **0** |

37 new tests from this PR; the rest came in with #72, which was merged into this branch after it landed on main. `Task Build` (what nightly runs) also green, and PSScriptAnalyzer clean.

**Measured bundle size: 987,360 bytes = 0.94 MB** — 986,496 bytes of assemblies plus an 864-byte stamp. Matches the issue's estimate. Reported by the build on every run.

End-to-end against the real built package, not mocks:

- Bundle intact → `Source=Bundle`, `RequiresInstall=False` → **no network call on import**.
- One byte of `Microsoft.Web.WebView2.Core.dll` corrupted → `Source=Download`, `RequiresInstall=True`, pointing back at `%LOCALAPPDATA%`, **without throwing**.
- `Update-DependencyLock.ps1 -Check` (online) independently re-derived all four per-file hashes: all OK.
- Both new build scripts run clean under **Windows PowerShell 5.1** as well as pwsh — the validation matrix runs a 5.1 leg, and everything routes through `build/build.ps1`, which always spawns pwsh, so no new workflow step was needed.

## Review round

Copilot raised nine findings across five re-reviews. Seven were valid and are fixed; two I declined with reasoning. All threads resolved. The substantive ones, because several were real bugs rather than style:

| Finding | Outcome |
|---|---|
| Load-time gate marked assemblies "verified" when no expected hash was available, and skipped files with no entry | **Fixed.** Now fails closed and refuses to load a file it cannot vouch for; `WebView2Loader.dll` added to the checked set |
| Bundle folder was never cleared, so a file dropped from `Files[]` would survive and ship unpinned | **Fixed.** Folder emptied before writing, cache shortcut refuses a polluted folder, and both the bundler and `TestAssemblies` assert the folder is exactly the pinned set |
| `Set-ArtifactFileHash` rewrote matching `Target`/`Sha256` pairs across *all* artefacts | **Fixed.** Scoped to one artefact id, same as `Set-ArtifactValue`. Verified with a two-artefact fixture sharing a target name |
| `Save-RemotePackage` leaked a temp file when the download failed | **Fixed.** A regression introduced in this branch — the function it was split out of had the cleanup in a `finally` |
| `Confirm-FileHash` error text assumed the pin always came from the lock | **Fixed.** Optional `-ExpectedHashSource`; remediation advice now differs for a damaged cache vs a damaged install |
| Duplicate zip entry names would fail with an opaque error | **Fixed.** 0/1/many handled explicitly in both scripts |
| `throw $_` plus unreachable `exit 1` in the new psake tasks | **Fixed**, by dropping the pointless `try`/`catch` entirely |
| Suggestion to inline the hash comparison instead of calling `Confirm-FileHash` | **Declined.** One verifier for bundle and download is deliberate; duplicating "delete first, then abort" is exactly where the two would drift |
| Dot-source path casing (`src\lib\functions\`) | **Declined.** 52 of 58 existing dot-sources use that form; these paths use `\` separators so they would not resolve on a case-sensitive filesystem regardless, and the module is Windows-only |

## Acceptance criteria

Part A criteria are marked as they stand on main; Part B criteria are this PR's.

- [x] Every binary the module loads has a pinned version and SHA-256 in a manifest that ships with the module — now per-file as well as per-package
- [x] Verification happens before `Assembly.LoadFrom`; a mismatch deletes the file and aborts naming the artefact and both hashes — **new in this PR**
- [x] The application starts with no route to nuget.org — the point of Part B
- [x] The runtime download fallback still lands in `%LOCALAPPDATA%\OmadaSqlTroubleshooter\Bin\<win-x64|win-x86>\`, unchanged
- [x] A missing or incomplete bundle degrades to that fallback without throwing during module import
- [x] `Update-DependencyLock.ps1 -Check` runs in PR validation, release and nightly, and fails on drift — extended to per-file hashes
- [x] Pester covers the fail-closed paths: tampered download, tampered bundle, unlisted artefact refused without network, pin rollback forces a reinstall
- [x] `build/PushToPsGallery.ps1` no longer selects `DependencyLock.psd1` as the module manifest — done in Part A, unchanged here
- [x] Package size impact measured and reported by the build — 0.94 MB
- [ ] **WebView2 SDK redistribution licence reviewed and recorded in `THIRD-PARTY-NOTICES.md` before the first bundled release — NOT MET.** Draft written, sign-off outstanding. Issue #54 stays open for this.

## Decisions worth reviewing

1. **The licence sign-off is outstanding and blocks release, not merge.** Top of the list deliberately. The code is safe to merge; the *release* is what the review gates. If you would rather it gated the merge too, say so and I will mark the PR draft.
2. **`Test-WebView2Bundle` hashes with `Get-FileSha256`, not `Confirm-FileHash`.** The issue asked for `Confirm-FileHash` so bundle and download "share one verifier". I deviated: `Confirm-FileHash` *deletes* what it rejects, which is right for a download landing in a temp file and wrong for a probe against an installed module folder — one bad byte would permanently degrade the install to the download path, and on a machine with no network that is fatal. The security-critical gate is unchanged: `Confirm-FileHash` still runs against the same hashes immediately before every load, whichever folder the assembly came from. Happy to switch if you disagree.
3. **The bundle is verified against the hashes in the lock, not the ones in its own stamp.** The stamp sits beside the assemblies, so anything able to swap a DLL could rewrite the stamp to match. The lock ships with the module.
4. **`Build` now depends on `TestAssemblies`, not just the named chains.** `nightly.yml` runs a bare `Build` and publishes the result to the PowerShell Gallery — the one unattended publishing lane would otherwise have been the only one not checking what it ships.
5. **The bundle is cached between local builds.** `Get-BundledDependency.ps1` skips the 9 MB download when the folder already matches the pin; `-Force` refetches. It never relaxes a check — a bundle failing the check is simply rebuilt from a verified download.
6. **`Get-WebView2ExpectedHash` is a new private function** the issue did not name. The load-time check needs different expected hashes depending on which folder the assemblies came from (lock for a bundle, install stamp for a download), and putting that branch inline in `Initialize-` read badly.
7. **`THIRD-PARTY-NOTICES.md` keeps a §2.1.** The SDK is in §1.3 as redistributed, but the fallback download is still real behaviour for a damaged bundle or a 32-bit process, and in that mode Fortigi genuinely does not redistribute it. Describing it in both places seemed more honest than picking one.

## Not done, on purpose

- The version bump to `1.0.4191.47` — that is #59's job.
- Bundling x86, or the WebView2 Runtime. Both rejected in the issue; nothing here changes that. `TestAssemblies` deliberately does **not** restore the `msedgewebview2.exe` requirement.
- `tests/Test-Variable.Test.ps1` (singular `.Test.ps1`, never collected) — noted in the issue as optional cleanup, left alone to keep this diff on-topic.
