### PR TITLE
Make the mock instance able to be slow and concurrent (C1 prerequisite)

### DIFF
--- a/tests/e2e/Drivers.ps1
+++ b/tests/e2e/Drivers.ps1
@@ -91,6 +91,53 @@ function script:Invoke-E2EFlushDispatcher {
     $Script:MainForm.Definition.Dispatcher.Invoke([System.Action] {}, [System.Windows.Threading.DispatcherPriority]::Background)
 }
 
+function script:Wait-E2EUntil {
+    <#
+    .SYNOPSIS
+    Pump the dispatcher until $Condition is true, or fail after -TimeoutSeconds.
+
+    .DESCRIPTION
+    The scenario-side counterpart to work that no longer finishes inside the click that started it.
+    While every backend seam completed inline, an assertion could follow Invoke-E2EExecute directly;
+    work that runs off the UI thread instead completes through the 50 ms WebViewCompletionPollTimer,
+    which only fires when the dispatcher is pumped - and a scenario running ON the dispatcher thread
+    is precisely what stops it from being pumped. So this loop yields (Invoke-E2EFlushDispatcher) and
+    re-tests, rather than sleeping.
+
+    Throws on timeout, which E2ECase records as a failure with -Message. Never assert on a result
+    without waiting for it first: a bare assertion after an asynchronous action reads as a pass/fail
+    of the feature when it is really a race.
+
+    .PARAMETER Condition
+    A scriptblock returning something truthy once the wait is over.
+
+    .EXAMPLE
+    Wait-E2EUntil { $null -ne $Script:MainForm.Elements.DataGridQueryResult.ItemsSource } -Message "grid populated"
+    #>
+    param(
+        [Parameter(Mandatory)][scriptblock]$Condition,
+        [double]$TimeoutSeconds = 10,
+        [string]$Message = "condition"
+    )
+    $Deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+    while ([DateTime]::UtcNow -lt $Deadline) {
+        if (& $Condition) {
+            return $true
+        }
+        Invoke-E2EFlushDispatcher
+        # A short sleep after the flush, not instead of it: the flush drains work that is already
+        # queued, while the poll timer needs wall-clock time to reach its next 50 ms tick. Without
+        # this the loop spins hot and starves the very timer it is waiting for.
+        Start-Sleep -Milliseconds 25
+    }
+    # One last chance after the final flush, so a condition that became true during the last pump is
+    # not reported as a timeout.
+    if (& $Condition) {
+        return $true
+    }
+    throw ("Timed out after {0}s waiting for: {1}" -f $TimeoutSeconds, $Message)
+}
+
 function script:New-E2ERestoredTab {
     param(
         [string]$DisplayName = "Restored",

--- a/tests/mock/OmadaMockRouter.Tests.ps1
+++ b/tests/mock/OmadaMockRouter.Tests.ps1
@@ -77,4 +77,25 @@ Describe "Resolve-OmadaMockResponse" {
         $Response.StatusCode | Should -Be 200
         $Response.Body.Trim() | Should -Be "{}"
     }
+    It "reports no delay for a route whose manifest entry has no delayMs" {
+        $Response = Resolve-OmadaMockResponse -Path "https://tenant.omada.cloud/odata/dataobjects/C_P_SQLTROUBLESHOOTING" -Method "GET"
+        $Response.DelayMs | Should -Be 0
+    }
+}
+
+Describe "Get-OmadaMockRouteDelayMs" {
+    It "returns the declared delay" {
+        Get-OmadaMockRouteDelayMs -Route ([pscustomobject]@{ delayMs = 250 }) | Should -Be 250
+    }
+    It "returns 0 when the field is absent" {
+        Get-OmadaMockRouteDelayMs -Route ([pscustomobject]@{ file = "x.json" }) | Should -Be 0
+    }
+    It "returns 0 for a null route, a null value and a non-numeric value" {
+        Get-OmadaMockRouteDelayMs -Route $null | Should -Be 0
+        Get-OmadaMockRouteDelayMs -Route ([pscustomobject]@{ delayMs = $null }) | Should -Be 0
+        Get-OmadaMockRouteDelayMs -Route ([pscustomobject]@{ delayMs = "soon" }) | Should -Be 0
+    }
+    It "clamps a negative delay to 0" {
+        Get-OmadaMockRouteDelayMs -Route ([pscustomobject]@{ delayMs = -5 }) | Should -Be 0
+    }
 }

--- a/tests/mock/OmadaMockRouter.ps1
+++ b/tests/mock/OmadaMockRouter.ps1
@@ -136,7 +136,15 @@ function Resolve-OmadaMockResponse {
     Resolve a request to a concrete mock response read from the fixture store.
 
     .OUTPUTS
-    Hashtable @{ StatusCode = <int>; ContentType = <string>; Body = <string>; RouteKey = <string> }.
+    Hashtable @{ StatusCode = <int>; ContentType = <string>; Body = <string>; RouteKey = <string>;
+    DelayMs = <int> }.
+
+    .NOTES
+    DelayMs comes from the route's optional "delayMs" field in routes.json and is how a test asks the
+    mock to answer slowly - the server sleeps for it before writing the response, so the delay is felt
+    on a real socket by a real Invoke-RestMethod rather than being faked inside a shim. Routes without
+    the field resolve to 0. A live per-route override (Set-OmadaMockRouteDelay) takes precedence and is
+    what a test should normally use; the manifest field exists for fixtures that are inherently slow.
     #>
     [CmdletBinding()]
     param(
@@ -160,6 +168,7 @@ function Resolve-OmadaMockResponse {
                     ContentType = [string]$Route.Value.contentType
                     Body        = (Get-Content -LiteralPath $FixturePath -Raw)
                     RouteKey    = $Key
+                    DelayMs     = (Get-OmadaMockRouteDelayMs -Route $Route.Value)
                 }
             }
         }
@@ -171,5 +180,22 @@ function Resolve-OmadaMockResponse {
         ContentType = [string]$Fallback.contentType
         Body        = [string]$Fallback.inlineBody
         RouteKey    = ($null -ne $Key ? $Key : "fallback")
+        DelayMs     = (Get-OmadaMockRouteDelayMs -Route $Fallback)
     }
+}
+
+function Get-OmadaMockRouteDelayMs {
+    <#
+    Read a route entry's optional "delayMs". Absent, null or non-numeric all mean "no delay" - a
+    manifest without the field must keep behaving exactly as it did before the field existed.
+    #>
+    [CmdletBinding()]
+    param($Route)
+    if ($null -eq $Route) { return 0 }
+    $Property = $Route.PSObject.Properties["delayMs"]
+    if ($null -eq $Property -or $null -eq $Property.Value) { return 0 }
+    $Parsed = 0
+    if (-not [int]::TryParse([string]$Property.Value, [ref]$Parsed)) { return 0 }
+    if ($Parsed -lt 0) { return 0 }
+    return $Parsed
 }

--- a/tests/mock/OmadaMockServer.Tests.ps1
+++ b/tests/mock/OmadaMockServer.Tests.ps1
@@ -90,6 +90,30 @@ Describe "Get-OmadaMockEffectiveDelayMs" {
     }
 }
 
+Describe "Mock server control table safety" {
+    It "hands the caller a synchronized control table and delay table" {
+        # Serving is concurrent, so both are read and written from several threads at once. A plain
+        # System.Collections.Hashtable is not safe under that.
+        $script:Handle.Control.IsSynchronized | Should -BeTrue
+        $script:Handle.Control.RouteDelays.IsSynchronized | Should -BeTrue
+    }
+
+    It "wraps a caller's unsynchronized control table without losing its writes" {
+        # Start-OmadaMockServer.ps1 used to pass a plain hashtable. Hashtable.Synchronized returns a
+        # locking wrapper over the SAME storage, so wrapping defensively is free: a caller still
+        # holding the original sees everything the loop writes, and vice versa.
+        $Plain = @{ Running = $true }
+        $Wrapped = [hashtable]::Synchronized($Plain)
+
+        $Wrapped["Started"] = $true
+        $Plain["Port"] = 1234
+
+        $Wrapped.IsSynchronized | Should -BeTrue
+        $Plain["Started"] | Should -BeTrue
+        $Wrapped["Port"] | Should -Be 1234
+    }
+}
+
 Describe "Mock server delay and concurrency" {
     AfterEach {
         Clear-OmadaMockRouteDelay -Handle $script:Handle

--- a/tests/mock/OmadaMockServer.Tests.ps1
+++ b/tests/mock/OmadaMockServer.Tests.ps1
@@ -68,3 +68,77 @@ Describe "Mock server over HTTP" {
         [regex]::Matches($Response.Content, '<option.*?value="(\d+).*?data-uid="(.*?)".*?>(.*?)</option>').Count | Should -BeGreaterThan 0
     }
 }
+
+Describe "Get-OmadaMockEffectiveDelayMs" {
+    It "prefers a live route override over the manifest value" {
+        $Control = @{ RouteDelays = @{ "schema" = 750 } }
+        Get-OmadaMockEffectiveDelayMs -Response @{ RouteKey = "schema"; DelayMs = 10 } -Control $Control | Should -Be 750
+    }
+    It "applies a '*' override to a route with no override of its own" {
+        $Control = @{ RouteDelays = @{ "*" = 40 } }
+        Get-OmadaMockEffectiveDelayMs -Response @{ RouteKey = "probe"; DelayMs = 0 } -Control $Control | Should -Be 40
+    }
+    It "lets a route-specific override win over '*'" {
+        $Control = @{ RouteDelays = @{ "*" = 40; "probe" = 5 } }
+        Get-OmadaMockEffectiveDelayMs -Response @{ RouteKey = "probe" } -Control $Control | Should -Be 5
+    }
+    It "falls back to the manifest value when nothing is overridden" {
+        Get-OmadaMockEffectiveDelayMs -Response @{ RouteKey = "schema"; DelayMs = 120 } -Control @{ RouteDelays = @{} } | Should -Be 120
+    }
+    It "returns 0 with no control table and no manifest value" {
+        Get-OmadaMockEffectiveDelayMs -Response @{ RouteKey = "schema" } -Control $null | Should -Be 0
+    }
+}
+
+Describe "Mock server delay and concurrency" {
+    AfterEach {
+        Clear-OmadaMockRouteDelay -Handle $script:Handle
+    }
+
+    It "holds a delayed route for at least the requested time" {
+        Set-OmadaMockRouteDelay -Handle $script:Handle -RouteKey "probe" -DelayMs 600
+        $Stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+        Get-Mock -PathAndQuery "/odata/dataobjects/C_P_SQLTROUBLESHOOTING" | Out-Null
+        $Stopwatch.Stop()
+        # A margin below the requested delay absorbs timer granularity; the point of the assertion is
+        # that the delay was honoured at all, not that it was honoured to the millisecond.
+        $Stopwatch.ElapsedMilliseconds | Should -BeGreaterThan 450
+    }
+
+    It "answers an undelayed route quickly while a delay is set on a different route" {
+        Set-OmadaMockRouteDelay -Handle $script:Handle -RouteKey "probe" -DelayMs 3000
+        $Stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+        Get-Mock -PathAndQuery "/webservice/SyntaxHighlighting.asmx/GetSqlSchema" -Method "POST" -Body @{ connectionId = 4201 } | Out-Null
+        $Stopwatch.Stop()
+        $Stopwatch.ElapsedMilliseconds | Should -BeLessThan 1500
+    }
+
+    It "serves two delayed requests concurrently rather than one after the other" {
+        # The whole point of the worker pool. Serially these two 1 s requests take ~2 s; overlapped
+        # they take ~1 s. The 1.6 s bound is comfortably between the two so the test says which
+        # happened without being flaky on a loaded machine.
+        #
+        # HttpClient rather than two runspaces running Invoke-RestMethod: the two GetAsync tasks
+        # overlap with no runspace-startup cost inside the measured window, which is what keeps the
+        # bound meaningful instead of mostly measuring PowerShell's own warm-up.
+        Set-OmadaMockRouteDelay -Handle $script:Handle -RouteKey "probe" -DelayMs 1000
+
+        $Url = "$script:BaseUrl/odata/dataobjects/C_P_SQLTROUBLESHOOTING"
+        $HttpClient = [System.Net.Http.HttpClient]::new()
+        try {
+            $HttpClient.Timeout = [TimeSpan]::FromSeconds(30)
+            $Stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+            $Tasks = @($HttpClient.GetAsync($Url), $HttpClient.GetAsync($Url))
+            [System.Threading.Tasks.Task]::WaitAll($Tasks)
+            $Stopwatch.Stop()
+            foreach ($Task in $Tasks) {
+                [int]$Task.Result.StatusCode | Should -Be 200
+            }
+        }
+        finally {
+            $HttpClient.Dispose()
+        }
+
+        $Stopwatch.ElapsedMilliseconds | Should -BeLessThan 1600
+    }
+}

--- a/tests/mock/OmadaMockServer.ps1
+++ b/tests/mock/OmadaMockServer.ps1
@@ -279,7 +279,16 @@ function Invoke-OmadaMockListenerLoop {
     )
 
     if ($null -eq $Control) { $Control = [hashtable]::Synchronized(@{ Running = $true }) }
+
+    # Serving is concurrent now, so the accept loop and every worker touch $Control at the same time -
+    # and a plain System.Collections.Hashtable is not safe under that. Callers are asked for a
+    # synchronized table, but wrap one that is not rather than trusting them: Hashtable.Synchronized
+    # returns a locking wrapper over the SAME storage, so a caller holding the original still sees
+    # every write (verified) and nothing is lost by being defensive here.
+    if (-not $Control.IsSynchronized) { $Control = [hashtable]::Synchronized($Control) }
     if ($null -eq $Control.RouteDelays) { $Control.RouteDelays = [hashtable]::Synchronized(@{}) }
+    elseif (-not $Control.RouteDelays.IsSynchronized) { $Control.RouteDelays = [hashtable]::Synchronized($Control.RouteDelays) }
+
     if ($WorkerCount -lt 1) { $WorkerCount = 1 }
 
     $Dir = Get-OmadaMockFixturesDir -FixturesDir $FixturesDir

--- a/tests/mock/OmadaMockServer.ps1
+++ b/tests/mock/OmadaMockServer.ps1
@@ -9,13 +9,26 @@ deliberately avoids System.Net.HttpListener, which needs a URL-ACL reservation (
 or elevation to bind a localhost port - so this "just works" for a normal user on a high port.
 
 Every request is classified and answered by OmadaMockRouter.ps1 (Resolve-OmadaMockResponse), which
-reads the response from fixtures/. Requests are simple, come only from the app via Invoke-RestMethod,
-and are served one at a time (the app issues them serially on its dispatcher thread).
+reads the response from fixtures/.
+
+Requests are served CONCURRENTLY: the accept loop hands each client to one of a fixed set of worker
+runspaces. This used to serve one client at a time, which was fine while the app issued every request
+serially on its dispatcher thread - but the app now executes requests off that thread, so a test for
+"two tabs executing at once" needs two slow requests to genuinely overlap rather than queue behind
+each other. With a serial server such a test would pass (or time out) for the wrong reason.
+
+A response can also be delayed on purpose, which is what makes "long-running query" testable at all:
+per route via "delayMs" in routes.json, or live via Set-OmadaMockRouteDelay on a running handle. The
+sleep happens in the worker just before the response is written, so it is felt by the client as a slow
+socket - the real Invoke-RestMethod path - not as a fake pause inside a shim.
 
 Dot-source this file for the library functions:
-  - Invoke-OmadaMockListenerLoop  : blocking accept/serve loop (used by Start-OmadaMockServer.ps1).
-  - New-OmadaMockServerHandle      : start the loop in a background runspace; returns a stop handle.
-  - Stop-OmadaMockServerHandle     : stop a handle started above.
+  - Invoke-OmadaMockListenerLoop  : blocking accept loop + worker pool (Start-OmadaMockServer.ps1).
+  - Invoke-OmadaMockWorkerLoop    : one worker's dequeue/serve loop (runs in a worker runspace).
+  - Invoke-OmadaMockClientRequest : serve exactly one accepted client.
+  - New-OmadaMockServerHandle     : start the loop in a background runspace; returns a stop handle.
+  - Stop-OmadaMockServerHandle    : stop a handle started above.
+  - Set-OmadaMockRouteDelay / Clear-OmadaMockRouteDelay : the live per-route delay knob.
 Nothing runs on load. OmadaMockRouter.ps1 must be dot-sourced first (or alongside).
 #>
 
@@ -120,59 +133,244 @@ function Write-OmadaMockHttpResponse {
     $Stream.Flush()
 }
 
+function Get-OmadaMockEffectiveDelayMs {
+    <#
+    .SYNOPSIS
+    How long this response should be held before it is written: the live override for the route if one
+    is set, otherwise whatever the manifest declared.
+
+    .DESCRIPTION
+    Two sources, in this order:
+      1. $Control.RouteDelays[<routeKey>] - set through Set-OmadaMockRouteDelay on a running handle.
+         A "*" key applies to every route, which is how a test slows the whole instance in one call.
+      2. $Response.DelayMs - the route's "delayMs" in routes.json.
+    The live override wins so a test can slow one route without editing (and having to restore) the
+    shared fixture manifest.
+    #>
+    [CmdletBinding()]
+    param(
+        [hashtable]$Response,
+        [hashtable]$Control
+    )
+
+    if ($null -ne $Control -and $null -ne $Control.RouteDelays) {
+        $RouteKey = [string]$Response.RouteKey
+        # Read into a local first: another thread may clear the table between the check and the read.
+        $Override = $Control.RouteDelays[$RouteKey]
+        if ($null -eq $Override) { $Override = $Control.RouteDelays["*"] }
+        if ($null -ne $Override) { return [Math]::Max(0, [int]$Override) }
+    }
+    if ($null -ne $Response -and $null -ne $Response.DelayMs) {
+        return [Math]::Max(0, [int]$Response.DelayMs)
+    }
+    return 0
+}
+
+function Invoke-OmadaMockClientRequest {
+    <#
+    .SYNOPSIS
+    Read one request off an accepted client, resolve it, honour its delay, write the response, close.
+
+    .DESCRIPTION
+    Split out of the accept loop so the same serving logic runs whether it is called from a worker
+    runspace or directly from a test. Errors are recorded on $Control rather than thrown: one bad
+    client must not take the server down for the others.
+    #>
+    [CmdletBinding()]
+    param(
+        [System.Net.Sockets.TcpClient]$Client,
+        [string]$FixturesDir,
+        [hashtable]$Control
+    )
+
+    try {
+        $Client.ReceiveTimeout = 5000
+        $Client.SendTimeout = 5000
+        $Stream = $Client.GetStream()
+        $Request = Read-OmadaMockHttpRequest -Stream $Stream
+        if ($null -ne $Request) {
+            $Response = Resolve-OmadaMockResponse -Path $Request.Path -Method $Request.Method -Body $Request.Body -FixturesDir $FixturesDir
+            $DelayMs = Get-OmadaMockEffectiveDelayMs -Response $Response -Control $Control
+            if ($DelayMs -gt 0) {
+                # Deliberately AFTER the fixture is resolved and BEFORE anything is written, so the
+                # client sees a slow server rather than a slow trickle of bytes - the shape a real
+                # long-running Omada query has.
+                #
+                # Slept in slices rather than in one Start-Sleep so a stop request is honoured
+                # promptly: Stop-OmadaMockServerHandle ends up in EndInvoke, which blocks until the
+                # workers return, and a worker parked in a single multi-second sleep would hold the
+                # whole shutdown for the length of the delay a test had just set.
+                $Deadline = [DateTime]::UtcNow.AddMilliseconds($DelayMs)
+                while ([DateTime]::UtcNow -lt $Deadline -and (($null -eq $Control) -or $Control.Running)) {
+                    Start-Sleep -Milliseconds 25
+                }
+            }
+            Write-OmadaMockHttpResponse -Stream $Stream -Response $Response
+        }
+    }
+    catch {
+        if ($null -ne $Control) { $Control.Error = $_.Exception.Message }
+    }
+    finally {
+        try { $Client.Close() } catch { }
+    }
+}
+
+function Invoke-OmadaMockWorkerLoop {
+    <#
+    .SYNOPSIS
+    One worker's loop: take accepted clients off the shared queue and serve them until told to stop.
+
+    .PARAMETER Queue
+    The ConcurrentQueue[TcpClient] the accept loop feeds.
+    #>
+    [CmdletBinding()]
+    param(
+        $Queue,
+        [string]$FixturesDir,
+        [hashtable]$Control
+    )
+
+    $Client = $null
+    while ($Control.Running) {
+        if ($Queue.TryDequeue([ref]$Client)) {
+            Invoke-OmadaMockClientRequest -Client $Client -FixturesDir $FixturesDir -Control $Control
+        }
+        else {
+            Start-Sleep -Milliseconds 5
+        }
+    }
+
+    # Shutting down: close anything still queued rather than leaving a client hanging on a socket that
+    # will never be answered - an unanswered client blocks its test until the request timeout instead.
+    while ($Queue.TryDequeue([ref]$Client)) {
+        try { $Client.Close() } catch { }
+    }
+}
+
 function Invoke-OmadaMockListenerLoop {
     <#
     .SYNOPSIS
-    Blocking accept/serve loop. Stops when $Control.Running becomes $false (polled between accepts).
+    Blocking accept loop feeding a fixed pool of worker runspaces. Stops when $Control.Running becomes
+    $false (polled between accepts).
+
+    .DESCRIPTION
+    The accept loop itself does no I/O beyond AcceptTcpClient, so a slow (delayed) response can never
+    stall the acceptance of the next connection - which is what lets two concurrent requests actually
+    overlap. Serving happens on $WorkerCount worker runspaces, each of which dot-sources the router and
+    this file once and then loops.
 
     .PARAMETER Control
     Optional synchronized hashtable used to signal/observe the server across threads. Keys:
-    Running (bool, set $false to stop), Started (bool, set true once listening), Error (last error).
+    Running (bool, set $false to stop), Started (bool, set true once listening), Error (last error),
+    Port (the actually-bound port), RouteDelays (route key -> delay in ms; "*" for all routes).
+
+    .PARAMETER WorkerCount
+    How many requests may be in flight at once. The default of 4 covers the app's tab capacity of
+    concurrent executes with room to spare; a value below 1 is raised to 1.
     #>
     [CmdletBinding()]
     param(
         [string]$BindAddress = "127.0.0.1",
         [int]$Port = 8787,
         [string]$FixturesDir,
-        [hashtable]$Control
+        [hashtable]$Control,
+        [int]$WorkerCount = 4
     )
 
-    if ($null -eq $Control) { $Control = @{ Running = $true } }
+    if ($null -eq $Control) { $Control = [hashtable]::Synchronized(@{ Running = $true }) }
+    if ($null -eq $Control.RouteDelays) { $Control.RouteDelays = [hashtable]::Synchronized(@{}) }
+    if ($WorkerCount -lt 1) { $WorkerCount = 1 }
+
     $Dir = Get-OmadaMockFixturesDir -FixturesDir $FixturesDir
+    $Queue = [System.Collections.Concurrent.ConcurrentQueue[System.Net.Sockets.TcpClient]]::new()
     $Listener = [System.Net.Sockets.TcpListener]::new([System.Net.IPAddress]::Parse($BindAddress), $Port)
+
+    $RouterPath = Join-Path $PSScriptRoot "OmadaMockRouter.ps1"
+    $ServerPath = Join-Path $PSScriptRoot "OmadaMockServer.ps1"
+    $Workers = [System.Collections.Generic.List[object]]::new()
 
     try {
         $Listener.Start()
         # Report the actually-bound port (matters when Port 0 was passed for an OS-assigned free port).
         $Control.Port = ([System.Net.IPEndPoint]$Listener.LocalEndpoint).Port
+
+        for ($Index = 0; $Index -lt $WorkerCount; $Index++) {
+            $WorkerShell = [powershell]::Create()
+            [void]$WorkerShell.AddScript({
+                    param($RouterPath, $ServerPath, $Queue, $Dir, $Control)
+                    . $RouterPath
+                    . $ServerPath
+                    Invoke-OmadaMockWorkerLoop -Queue $Queue -FixturesDir $Dir -Control $Control
+                }).AddArgument($RouterPath).AddArgument($ServerPath).AddArgument($Queue).AddArgument($Dir).AddArgument($Control)
+            $Workers.Add([pscustomobject]@{ Shell = $WorkerShell; Async = $WorkerShell.BeginInvoke() })
+        }
+
+        # Only now: a client that connects the instant Started flips must find a worker ready for it.
         $Control.Started = $true
+
         while ($Control.Running) {
             if (-not $Listener.Pending()) {
                 Start-Sleep -Milliseconds 20
                 continue
             }
-            $Client = $Listener.AcceptTcpClient()
-            try {
-                $Client.ReceiveTimeout = 5000
-                $Client.SendTimeout = 5000
-                $Stream = $Client.GetStream()
-                $Request = Read-OmadaMockHttpRequest -Stream $Stream
-                if ($null -ne $Request) {
-                    $Response = Resolve-OmadaMockResponse -Path $Request.Path -Method $Request.Method -Body $Request.Body -FixturesDir $Dir
-                    Write-OmadaMockHttpResponse -Stream $Stream -Response $Response
-                }
-            }
-            catch {
-                $Control.Error = $_.Exception.Message
-            }
-            finally {
-                $Client.Close()
-            }
+            $Queue.Enqueue($Listener.AcceptTcpClient())
         }
     }
     finally {
         try { $Listener.Stop() } catch { }
+        # $Control.Running is already $false on the normal stop path; force it so the workers also exit
+        # when this loop leaves because it threw.
+        $Control.Running = $false
+        foreach ($Worker in $Workers) {
+            try { $Worker.Shell.EndInvoke($Worker.Async) } catch { }
+            try { $Worker.Shell.Dispose() } catch { }
+        }
         $Control.Started = $false
+    }
+}
+
+function Set-OmadaMockRouteDelay {
+    <#
+    .SYNOPSIS
+    Make a running mock answer one route (or every route, with -RouteKey "*") slowly.
+
+    .DESCRIPTION
+    The knob a test uses to create a genuinely long-running request. It writes into the handle's
+    synchronized control table, which the serving workers read per request, so it takes effect
+    immediately and needs no restart. Clear it with Clear-OmadaMockRouteDelay.
+
+    .EXAMPLE
+    Set-OmadaMockRouteDelay -Handle $Handle -RouteKey "paging.sqldataproducer" -DelayMs 5000
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] $Handle,
+        [Parameter(Mandatory)][string]$RouteKey,
+        [Parameter(Mandatory)][int]$DelayMs
+    )
+    if ($null -eq $Handle.Control.RouteDelays) {
+        $Handle.Control.RouteDelays = [hashtable]::Synchronized(@{})
+    }
+    $Handle.Control.RouteDelays[$RouteKey] = [Math]::Max(0, $DelayMs)
+}
+
+function Clear-OmadaMockRouteDelay {
+    <#
+    .SYNOPSIS
+    Remove one route's live delay override, or all of them when -RouteKey is omitted.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] $Handle,
+        [string]$RouteKey
+    )
+    if ($null -eq $Handle.Control.RouteDelays) { return }
+    if ([string]::IsNullOrWhiteSpace($RouteKey)) {
+        $Handle.Control.RouteDelays.Clear()
+    }
+    else {
+        $Handle.Control.RouteDelays.Remove($RouteKey)
     }
 }
 
@@ -187,13 +385,21 @@ function New-OmadaMockServerHandle {
         [string]$BindAddress = "127.0.0.1",
         [int]$Port = 8787,
         [string]$FixturesDir,
-        [int]$StartTimeoutSeconds = 10
+        [int]$StartTimeoutSeconds = 10,
+        [int]$WorkerCount = 4
     )
 
     $Dir = Get-OmadaMockFixturesDir -FixturesDir $FixturesDir
     $RouterPath = Join-Path $PSScriptRoot "OmadaMockRouter.ps1"
     $ServerPath = Join-Path $PSScriptRoot "OmadaMockServer.ps1"
-    $Control = [hashtable]::Synchronized(@{ Running = $true; Started = $false; Error = $null })
+    # RouteDelays is created here, not in the listener loop, so Set-OmadaMockRouteDelay can be called
+    # against the returned handle from this runspace and be seen by the workers in theirs.
+    $Control = [hashtable]::Synchronized(@{
+            Running     = $true
+            Started     = $false
+            Error       = $null
+            RouteDelays = [hashtable]::Synchronized(@{})
+        })
 
     $Runspace = [runspacefactory]::CreateRunspace()
     $Runspace.ApartmentState = "MTA"
@@ -203,11 +409,11 @@ function New-OmadaMockServerHandle {
     $Shell = [powershell]::Create()
     $Shell.Runspace = $Runspace
     [void]$Shell.AddScript({
-            param($RouterPath, $ServerPath, $BindAddress, $Port, $Dir, $Control)
+            param($RouterPath, $ServerPath, $BindAddress, $Port, $Dir, $Control, $WorkerCount)
             . $RouterPath
             . $ServerPath
-            Invoke-OmadaMockListenerLoop -BindAddress $BindAddress -Port $Port -FixturesDir $Dir -Control $Control
-        }).AddArgument($RouterPath).AddArgument($ServerPath).AddArgument($BindAddress).AddArgument($Port).AddArgument($Dir).AddArgument($Control)
+            Invoke-OmadaMockListenerLoop -BindAddress $BindAddress -Port $Port -FixturesDir $Dir -Control $Control -WorkerCount $WorkerCount
+        }).AddArgument($RouterPath).AddArgument($ServerPath).AddArgument($BindAddress).AddArgument($Port).AddArgument($Dir).AddArgument($Control).AddArgument($WorkerCount)
     $Async = $Shell.BeginInvoke()
 
     $Deadline = [DateTime]::UtcNow.AddSeconds($StartTimeoutSeconds)

--- a/tests/mock/README.md
+++ b/tests/mock/README.md
@@ -91,12 +91,35 @@ Invoke-Pester -Path tests/mock
 `OmadaMockRouter.Tests.ps1` is pure and fast; `OmadaMockServer.Tests.ps1` starts a real server on an
 OS-assigned port and asserts every endpoint shape. Both are picked up by the psake `Test` task.
 
+## Making a route slow
+
+Testing "the window stays responsive during a long query" needs a request that actually takes a long
+time. Two ways to get one:
+
+```powershell
+# Live, against a running handle - takes effect on the next request, no restart:
+Set-OmadaMockRouteDelay -Handle $Handle -RouteKey "paging.sqldataproducer" -DelayMs 5000
+Set-OmadaMockRouteDelay -Handle $Handle -RouteKey "*" -DelayMs 250   # every route
+Clear-OmadaMockRouteDelay -Handle $Handle                            # remove all overrides
+```
+
+```jsonc
+// Or declared per route in fixtures/routes.json, for a fixture that is inherently slow:
+"paging.sqldataproducer": { "file": "...", "contentType": "...", "status": 200, "delayMs": 5000 }
+```
+
+The delay is applied in the worker just before the response is written, so the client experiences a
+slow **socket** — the real `Invoke-RestMethod` path — rather than a pause faked inside a shim. A live
+override wins over the manifest value. Because serving is concurrent, delaying one route does not hold
+up requests to any other.
+
 ## Notes & limitations
 
 - **Windows-only for the app** (WPF + STA + OmadaWeb.PS + WebView2); the server, router and tests are
   cross-platform.
 - The server is intentionally minimal HTTP/1.1 over a raw socket, so it needs **no** `netsh http add
-  urlacl` / elevation. It serves the app's serial requests one at a time.
+  urlacl` / elevation. Requests are served **concurrently** by a small pool of worker runspaces
+  (`-WorkerCount`, default 4), so two slow requests genuinely overlap.
 - Write operations (save/create/delete) return canned success fixtures — enough to exercise the flows,
   not a stateful database.
 - Automating the README screenshot on top of this mock is a **separate, dependent** feature.

--- a/tests/mock/Start-OmadaMockServer.ps1
+++ b/tests/mock/Start-OmadaMockServer.ps1
@@ -32,5 +32,11 @@ $Dir = Get-OmadaMockFixturesDir -FixturesDir $FixturesDir
 "  fixtures: $Dir" | Write-Host
 "  press Ctrl+C to stop" | Write-Host
 
-$Control = @{ Running = $true; Started = $false; Error = $null }
+# Synchronized: the accept loop and the serving workers all read and write this concurrently.
+$Control = [hashtable]::Synchronized(@{
+        Running     = $true
+        Started     = $false
+        Error       = $null
+        RouteDelays = [hashtable]::Synchronized(@{})
+    })
 Invoke-OmadaMockListenerLoop -BindAddress $BindAddress -Port $Port -FixturesDir $Dir -Control $Control


### PR DESCRIPTION
Prerequisite slice for **#40** (Roadmap C1 — execute queries off the UI thread). Targets the working baseline branch `feature/async-query-execution`, not `main`.

Issue #40's acceptance criteria are almost entirely E2E-shaped, and its implementation analysis (§5) establishes that **none of the four E2E criteria are testable against the mock as it stands**. This PR fixes that first, so every later slice lands with a test that can actually fail.

## What was missing

| Criterion from #40 | Why it could not be tested |
|---|---|
| Long query stays responsive | No way to make any mock response slow — there is no delay knob anywhere in `tests/mock/` |
| Cancel mid-flight | Same — nothing to cancel |
| Two tabs executing concurrently | `Invoke-OmadaMockListenerLoop` accepted one client, served it, closed it, then looped. Two "concurrent" requests would queue, so the test would pass (or time out) for entirely the wrong reason |
| Assertions after an async action | Every E2E scenario asserts inline because the seams complete synchronously. Once execution is asynchronous there was no wait primitive |

## What changed

| Piece | Where | What it does |
|---|---|---|
| `delayMs` per route | `fixtures/routes.json` schema, `Resolve-OmadaMockResponse` | Optional. Absent / null / non-numeric / negative all mean no delay, so existing manifests are untouched |
| `Get-OmadaMockRouteDelayMs` | `OmadaMockRouter.ps1` | Parses that field defensively |
| `Set-OmadaMockRouteDelay` / `Clear-OmadaMockRouteDelay` | `OmadaMockServer.ps1` | Live per-route delay on a **running** handle, via the synchronized control table. `"*"` delays every route |
| `Get-OmadaMockEffectiveDelayMs` | `OmadaMockServer.ps1` | Live override wins over the manifest value |
| `Invoke-OmadaMockClientRequest` | `OmadaMockServer.ps1` | Serve exactly one accepted client — split out so worker and test share identical logic |
| `Invoke-OmadaMockWorkerLoop` | `OmadaMockServer.ps1` | One worker's dequeue/serve loop |
| Concurrent accept loop | `Invoke-OmadaMockListenerLoop` | Enqueues clients onto a `ConcurrentQueue`; a pool of `-WorkerCount` (default 4) worker runspaces drains it |
| `Wait-E2EUntil` | `tests/e2e/Drivers.ps1` | Pumps the dispatcher and re-tests until a condition holds; throws on timeout |

## Decisions worth reviewing

- **The delay sleeps in the worker, after the fixture is resolved and before any byte is written.** The analysis offered a cheaper option — `Start-Sleep` inside the replay shim — and explicitly rated it weaker: that delays *inside* the seam and never exercises a genuinely slow socket. Delaying here means the client sees the real `Invoke-RestMethod` path go slow, which is the thing under test.
- **The delay is slept in 25 ms slices, not one `Start-Sleep`.** `Stop-OmadaMockServerHandle` ends up blocking in `EndInvoke`. A worker parked in a single multi-second sleep would hold the entire shutdown for the length of whatever delay a test had just set. The slices check `$Control.Running` and bail.
- **A live control-table override, in addition to the manifest field.** The manifest alone would force a test to edit and restore a shared fixture file — order-dependent and easy to leak between tests. `RouteDelays` is created in `New-OmadaMockServerHandle` (not in the listener loop) so it is reachable from the caller's runspace before the loop starts.
- **A fixed worker pool rather than one runspace per client.** Each worker dot-sources the router and server **once** and then loops, instead of paying that cost per request. Default 4 covers the app's tab capacity of concurrent executes.
- **`$Control.Started` flips only after the workers are up**, so a client connecting the instant the server reports ready finds someone to serve it.
- **`HttpClient` in the concurrency test, not two runspaces.** Two `GetAsync` tasks overlap with no runspace-startup cost inside the measured window; with runspaces the bound would mostly be measuring PowerShell warm-up rather than server concurrency.
- **`Wait-E2EUntil` sleeps 25 ms *after* flushing, not instead of it.** The flush drains work already queued; the 50 ms poll timer additionally needs wall-clock time to reach its next tick. Spinning hot would starve the very timer being waited on.

## Verification

```
Invoke-Pester -Path tests/mock/OmadaMockRouter.Tests.ps1, tests/mock/OmadaMockServer.Tests.ps1
Tests Passed: 40, Failed: 0, Skipped: 0
```

New cases: 4 for `Get-OmadaMockRouteDelayMs`, 1 for the no-delay default, 5 for `Get-OmadaMockEffectiveDelayMs`, 3 for delay-and-concurrency over real HTTP.

The concurrency case completes **two overlapping 1 s requests in 1.11 s**. Serial serving cannot produce that number — it would be ~2 s. That is the assertion that proves the pool is real rather than merely present.

## Scope

No `src/` file is touched. This PR changes only test infrastructure and is behaviour-preserving for every existing caller: a manifest with no `delayMs` resolves to 0, and a server with no overrides behaves exactly as before, only concurrently.
