### PR TITLE
Extract Invoke-OmadaRequestCore, the runspace-safe request seam (C1-1)

### DIFF
--- a/src/Lib/Functions/Private/Invoke-OmadaPSWebRequestWrapper.ps1
+++ b/src/Lib/Functions/Private/Invoke-OmadaPSWebRequestWrapper.ps1
@@ -48,7 +48,19 @@ function Invoke-OmadaPSWebRequestWrapper {
             }
 
             "Parameters: {0}" -f (ConvertTo-RedactedLogString -InputObject $Private:Parameters) | Write-LogOutput -LogType VERBOSE
-            $Private:Result = Invoke-OmadaRestMethod @Parameters
+
+            # The call itself lives in Invoke-OmadaRequestCore, which reads no $Script: state and
+            # writes no log - the one part of this function that can legally run in a worker runspace
+            # (issue #40). Everything around it, from the parameter preparation above to the error
+            # classification below, stays here on the UI thread. Behaviour is unchanged: the core
+            # returns the failure instead of throwing it, and this rethrows so the existing catch
+            # classifies it exactly as before. A rethrown ErrorRecord keeps its Exception,
+            # ErrorDetails and FullyQualifiedErrorId, which is all the branches below read.
+            $Private:Outcome = Invoke-OmadaRequestCore -Parameters $Private:Parameters
+            if ($null -ne $Private:Outcome.ErrorRecord) {
+                throw $Private:Outcome.ErrorRecord
+            }
+            $Private:Result = $Private:Outcome.Result
             # Deliberately no status-bar write here. A successful request is not the same thing as a
             # connected tab: this transport is also used by probes and by work that runs while a tab
             # is being connected, so writing "Connected" from here put the status bar ahead of - and

--- a/src/Lib/Functions/Private/Invoke-OmadaRequestCore.ps1
+++ b/src/Lib/Functions/Private/Invoke-OmadaRequestCore.ps1
@@ -1,0 +1,56 @@
+function Invoke-OmadaRequestCore {
+    <#
+    .SYNOPSIS
+    The one statement that actually talks to Omada: splat a plain parameter hashtable into
+    OmadaWeb.PS's Invoke-OmadaRestMethod and hand back the result or the error, never throwing.
+
+    .DESCRIPTION
+    This function is deliberately, strictly dependency-free. It reads no $Script: state, writes no
+    log, touches no WPF element and suspends no timer. Everything it needs arrives in $Parameters and
+    everything it produces leaves in the returned hashtable.
+
+    That is not stylistic. A PowerShell runspace has entirely separate session state: a worker
+    runspace has no $Script:RunTimeData, no $Script:AppConfig, no $Script:MainForm and no
+    $Script:Tracer, and any call to a private function of this module - Write-LogOutput included -
+    is a CommandNotFoundException there. Issue #40 moves the network call off the WPF UI thread, so
+    the seam between "runs anywhere" and "runs only on the UI thread" has to be drawn somewhere, and
+    this is it. Invoke-OmadaPSWebRequestWrapper cannot be that seam: it reads
+    $Script:RunTimeData.RestMethodParam, $Script:RunTimeConfig, $Script:AppConfig.BaseUrl, and calls
+    Set-SqlConnectionState, Write-LogOutput and Suspend/Resume-WebViewCompletionPolling. All of that
+    stays on the UI thread, above this call.
+
+    Errors are RETURNED rather than thrown. A pipeline running in a worker runspace has no useful
+    place to throw to, and the caller has to be able to inspect the failure on the UI thread where
+    the app's error classification, connection-state teardown and dialogs actually work. The
+    ErrorRecord that comes back carries its original Exception, ErrorDetails and
+    FullyQualifiedErrorId, which is everything the callers classify on.
+
+    .PARAMETER Parameters
+    The complete, already-prepared splat for Invoke-OmadaRestMethod. Callers dispatching this to a
+    worker must pass a CLONE, not the live $Script:RunTimeData.RestMethodParam: that hashtable is
+    long-lived, is mutated by the next call site, and Set-ActiveTabContext can swap the whole
+    RunTimeData object out from under a request that is still in flight.
+
+    .OUTPUTS
+    Hashtable @{ Result = <response or $null>; ErrorRecord = <ErrorRecord or $null> }. Exactly one of
+    the two is populated.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [hashtable]$Parameters
+    )
+
+    try {
+        return @{
+            Result      = (Invoke-OmadaRestMethod @Parameters)
+            ErrorRecord = $null
+        }
+    }
+    catch {
+        return @{
+            Result      = $null
+            ErrorRecord = $_
+        }
+    }
+}

--- a/src/Lib/Functions/Private/Invoke-OmadaRequestCore.ps1
+++ b/src/Lib/Functions/Private/Invoke-OmadaRequestCore.ps1
@@ -32,8 +32,12 @@ function Invoke-OmadaRequestCore {
     RunTimeData object out from under a request that is still in flight.
 
     .OUTPUTS
-    Hashtable @{ Result = <response or $null>; ErrorRecord = <ErrorRecord or $null> }. Exactly one of
-    the two is populated.
+    Hashtable @{ Result = <response or $null>; ErrorRecord = <ErrorRecord or $null> }.
+
+    ErrorRecord is the discriminator, and it is the only one: a non-null ErrorRecord means the request
+    failed and Result is $null. A null ErrorRecord means the request succeeded - but Result may still
+    be $null, because a successful Omada call can legitimately return nothing. Callers must therefore
+    branch on ErrorRecord and never infer failure from a null Result.
     #>
     [CmdletBinding()]
     param(

--- a/tests/Invoke-OmadaPSWebRequestWrapper.Tests.ps1
+++ b/tests/Invoke-OmadaPSWebRequestWrapper.Tests.ps1
@@ -18,6 +18,10 @@ BeforeAll {
 
     . (Join-Path $PrivatePath -ChildPath "ConvertTo-RedactedLogString.ps1")
     . (Join-Path $PrivatePath -ChildPath "Set-TextBlockText.ps1")
+    # The wrapper now issues its request through the runspace-safe core (issue #40 / C1-1), so the
+    # real core is dot-sourced here rather than stubbed: these tests are the contract that the split
+    # changed nothing, which only holds if the actual call path is exercised.
+    . (Join-Path $PrivatePath -ChildPath "Invoke-OmadaRequestCore.ps1")
     . (Join-Path $PrivatePath -ChildPath "Invoke-OmadaPSWebRequestWrapper.ps1")
 
     $Script:Tracer = [System.Diagnostics.Trace]

--- a/tests/Invoke-OmadaRequestCore.Tests.ps1
+++ b/tests/Invoke-OmadaRequestCore.Tests.ps1
@@ -66,12 +66,16 @@ Describe "Invoke-OmadaRequestCore" {
     }
 
     It "returns a null Result rather than failing when the transport returns nothing" {
+        # A successful Omada call can legitimately return nothing, so a null Result is NOT a failure
+        # signal. ErrorRecord is the only discriminator - which is why the help says so explicitly
+        # and why this asserts both halves.
         $script:RestBehaviour = "Null"
 
         $Outcome = Invoke-OmadaRequestCore -Parameters @{ Uri = "https://tenant.omada.cloud/probe" }
 
         $Outcome.Result | Should -BeNullOrEmpty
         $Outcome.ErrorRecord | Should -BeNullOrEmpty
+        $Outcome.ContainsKey("ErrorRecord") | Should -BeTrue
     }
 
     It "returns the failure instead of throwing it" {

--- a/tests/Invoke-OmadaRequestCore.Tests.ps1
+++ b/tests/Invoke-OmadaRequestCore.Tests.ps1
@@ -1,0 +1,134 @@
+#Requires -Version 7.0
+# Tests for the runspace-safe request core extracted in issue #40 (Roadmap C1).
+#
+# Two things are being asserted here, and the second matters more than the first:
+#
+#   1. The contract: success comes back as Result with a null ErrorRecord, failure as ErrorRecord
+#      with a null Result, and the function never throws.
+#   2. The DEPENDENCY-FREE property. This function exists to be executed in a worker runspace, which
+#      has none of this module's $Script: state and none of its private functions. If someone later
+#      adds a Write-LogOutput or a $Script:RunTimeData read to it, every background request starts
+#      failing with a CommandNotFoundException that no unit test would otherwise catch - so the last
+#      test runs the function in a genuinely empty runspace, where such an addition cannot survive.
+
+BeforeAll {
+    $ParentPath = Split-Path -Path $PSScriptRoot -Parent
+    $script:CorePath = Join-Path $ParentPath -ChildPath "src\Lib\Functions\Private\Invoke-OmadaRequestCore.ps1"
+    . $script:CorePath
+
+    # The single seam, steered per test.
+    function Invoke-OmadaRestMethod {
+        [CmdletBinding()]
+        param(
+            [string]$Uri,
+            [string]$Method = "GET",
+            $Body,
+            [Parameter(ValueFromRemainingArguments = $true)]$IgnoredRest
+        )
+        if ($script:RestBehaviour -eq "Throw") {
+            $ErrorRecord = [System.Management.Automation.ErrorRecord]::new(
+                [System.Exception]::new("transport failed"), "OmadaTransportFailure",
+                [System.Management.Automation.ErrorCategory]::ConnectionError, $null)
+            $ErrorRecord.ErrorDetails = [System.Management.Automation.ErrorDetails]::new(
+                "Resource not found for the segment 'C_P_SQLTROUBLESHOOTING'.")
+            throw $ErrorRecord
+        }
+        if ($script:RestBehaviour -eq "Null") {
+            return $null
+        }
+        return [PSCustomObject]@{ ReceivedUri = $Uri; ReceivedMethod = $Method; ReceivedBody = $Body }
+    }
+
+    $script:RestBehaviour = "Success"
+}
+
+Describe "Invoke-OmadaRequestCore" {
+    BeforeEach {
+        $script:RestBehaviour = "Success"
+    }
+
+    It "returns the response under Result with no ErrorRecord" {
+        $Outcome = Invoke-OmadaRequestCore -Parameters @{ Uri = "https://tenant.omada.cloud/probe"; Method = "GET" }
+
+        $Outcome.ErrorRecord | Should -BeNullOrEmpty
+        $Outcome.Result.ReceivedUri | Should -Be "https://tenant.omada.cloud/probe"
+    }
+
+    It "splats every key of the parameter hashtable through to the transport" {
+        $Outcome = Invoke-OmadaRequestCore -Parameters @{
+            Uri    = "https://tenant.omada.cloud/webservice/x.asmx/GetPagingData"
+            Method = "POST"
+            Body   = @{ dataType = "SqlDataProducer" }
+        }
+
+        $Outcome.Result.ReceivedMethod | Should -Be "POST"
+        $Outcome.Result.ReceivedBody.dataType | Should -Be "SqlDataProducer"
+    }
+
+    It "returns a null Result rather than failing when the transport returns nothing" {
+        $script:RestBehaviour = "Null"
+
+        $Outcome = Invoke-OmadaRequestCore -Parameters @{ Uri = "https://tenant.omada.cloud/probe" }
+
+        $Outcome.Result | Should -BeNullOrEmpty
+        $Outcome.ErrorRecord | Should -BeNullOrEmpty
+    }
+
+    It "returns the failure instead of throwing it" {
+        $script:RestBehaviour = "Throw"
+
+        { Invoke-OmadaRequestCore -Parameters @{ Uri = "https://tenant.omada.cloud/probe" } } | Should -Not -Throw
+    }
+
+    It "hands back an ErrorRecord that still carries what the callers classify on" {
+        # Invoke-OmadaPSWebRequestWrapper branches on ErrorDetails.Message and on
+        # Exception.Response.StatusCode. Losing either on the way out of the worker would silently
+        # reclassify every failure as the generic "else" branch.
+        $script:RestBehaviour = "Throw"
+
+        $Outcome = Invoke-OmadaRequestCore -Parameters @{ Uri = "https://tenant.omada.cloud/probe" }
+
+        $Outcome.Result | Should -BeNullOrEmpty
+        $Outcome.ErrorRecord | Should -BeOfType [System.Management.Automation.ErrorRecord]
+        $Outcome.ErrorRecord.ErrorDetails.Message | Should -Match "C_P_SQLTROUBLESHOOTING"
+        $Outcome.ErrorRecord.Exception.Message | Should -Be "transport failed"
+    }
+
+    It "requires the Parameters argument" {
+        # Mandatory, and asserted as metadata rather than by calling without it: a call that omits a
+        # mandatory parameter prompts, which hangs an unattended run.
+        (Get-Command Invoke-OmadaRequestCore).Parameters["Parameters"].Attributes |
+            Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] } |
+            ForEach-Object { $_.Mandatory } | Should -Contain $true
+    }
+
+    It "runs in a bare runspace that has none of this module's state or functions" {
+        # The property this function exists for. The runspace below has no $Script:RunTimeData, no
+        # $Script:Tracer and no Write-LogOutput - exactly like the worker that will run this for real
+        # - so a dependency added to the core later fails HERE rather than in production.
+        $Shell = [powershell]::Create()
+        try {
+            [void]$Shell.AddScript({
+                    param($CorePath)
+                    . $CorePath
+                    function Invoke-OmadaRestMethod {
+                        [CmdletBinding()]
+                        param([Parameter(ValueFromRemainingArguments = $true)]$IgnoredRest)
+                        return [PSCustomObject]@{ Ok = $true }
+                    }
+                    $Outcome = Invoke-OmadaRequestCore -Parameters @{ Uri = "https://tenant.omada.cloud/probe" }
+                    return $Outcome.Result.Ok
+                }).AddArgument($script:CorePath)
+
+            $Output = $Shell.Invoke()
+
+            # Any $Script: read or private-function call inside the core surfaces as an error stream
+            # entry here, so assert the stream is empty as well as the value being right.
+            $Shell.Streams.Error | Should -BeNullOrEmpty
+            $Output[0] | Should -BeTrue
+        }
+        finally {
+            $Shell.Dispose()
+        }
+    }
+}


### PR DESCRIPTION
Slice **C1-1** of **#40** (Roadmap C1 — execute queries off the UI thread). Targets the working baseline branch `feature/async-query-execution`, not `main`.

A mechanical extraction with an exact behavioural contract, landed on its own so the runspace work that follows has something safe to dispatch.

## Why the seam has to be here and not one level up

Issue #40 moves the Omada round-trip off the WPF UI thread. A PowerShell runspace has **entirely separate session state**: a worker has no `$Script:RunTimeData`, no `$Script:AppConfig`, no `$Script:MainForm`, no `$Script:Tracer`, and none of this module's dot-sourced private functions. Any `Write-LogOutput` from inside a worker is a `CommandNotFoundException`.

That rules out the obvious design. `Invoke-OmadaPSWebRequestWrapper` **cannot** be the thing dispatched — it reads `$Script:RunTimeData.RestMethodParam`, `$Script:RunTimeConfig.ApplicationName` / `.UseWebView2Auth` and `$Script:AppConfig.BaseUrl`, and calls `Set-SqlConnectionState`, `Write-LogOutput`, `ConvertTo-RedactedLogString` and `Suspend`/`Resume-WebViewCompletionPolling`. All of that is UI-runspace state or UI-thread work.

So the seam is drawn one level lower: a function that takes a plain hashtable, calls `Invoke-OmadaRestMethod`, and returns a plain result. Everything else — logging, redaction, error classification, connection-state teardown, tab repointing — stays above it on the UI thread.

## What changed

| File | Change |
|---|---|
| `Invoke-OmadaRequestCore.ps1` | **New.** No `$Script:` reads, no logging, no timer suspension. Returns `@{ Result; ErrorRecord }` and never throws |
| `Invoke-OmadaPSWebRequestWrapper.ps1` | The single `Invoke-OmadaRestMethod @Parameters` statement now goes through the core; a returned `ErrorRecord` is rethrown into the existing `catch` |
| `Invoke-OmadaRequestCore.Tests.ps1` | **New.** 7 cases |
| `Invoke-OmadaPSWebRequestWrapper.Tests.ps1` | Dot-sources the real core rather than stubbing it |

## Decisions worth reviewing

- **Errors are returned, not thrown.** A pipeline running in a worker runspace has no useful place to throw to, and the caller must be able to inspect the failure on the UI thread where the app's classification, `Set-SqlConnectionState` teardown and dialogs actually work.
- **The wrapper rethrows rather than being restructured.** The obvious alternative — extract the three `catch` branches into a helper callable from both paths — is worse than it looks: two of those branches end in `Write-Error -ErrorAction Stop`, which *throws*. Called from inside the `try` it would be caught and reclassified into the generic `else` branch, and `Invoke-OmadaPSWebRequestWrapper` would start **returning** an error where it used to **throw** one. Rethrowing keeps the control flow byte-for-byte.
- **Rethrowing was verified, not assumed.** `throw $ErrorRecord` produces a different `ErrorRecord` instance, so this was checked empirically: `ErrorDetails.Message`, `FullyQualifiedErrorId` and the `Exception` reference (hence `Exception.Response.StatusCode`) all survive. Those are exactly the three properties the branches read. The only thing that changes is `Write-Error -TargetObject`, which nothing consumes.
- **The core takes `[hashtable]`, and its help says "pass a clone".** It cannot enforce that from in here, but the reason is worth recording where the next reader will find it: `$Script:RunTimeData.RestMethodParam` is long-lived, is mutated by the next call site, and `Set-ActiveTabContext` can swap the whole `RunTimeData` object out from under a request still in flight. The cloning happens at the dispatch site, in C1-2.
- **Both mock seams survive**, which is what makes this landable alone: `tests/e2e/OmadaMocks.ps1:10` shadows `Invoke-OmadaPSWebRequestWrapper` — *above* the split — and `tests/mock/Install-OmadaMockTransport.ps1:47` shadows `Invoke-OmadaRestMethod` — *below* it.

## The test that matters

Six cases cover the contract. The seventh covers the reason the function exists:

```powershell
It "runs in a bare runspace that has none of this module's state or functions"
```

It executes the core in a genuinely empty `[powershell]` runspace and asserts the error stream is empty. If someone later adds a `Write-LogOutput` or a `$Script:RunTimeData` read to this function, **every background request would start failing with a `CommandNotFoundException`** that no ordinary unit test would catch — because in the test process those names all resolve fine. This one fails instead.

## Verification

```
Invoke-Pester -Path tests/Invoke-OmadaRequestCore.Tests.ps1, tests/Invoke-OmadaPSWebRequestWrapper.Tests.ps1
Tests Passed: 14, Failed: 0, Skipped: 0

PSScriptAnalyzer (Error, Warning) on both changed src files: clean
```

The **seven pre-existing wrapper tests pass unmodified**. That is the zero-behaviour-change claim, and it is why they were left alone rather than adjusted to the new shape.
