### PR TITLE
Run Omada requests on a background runspace pool, proven on the schema fetch (C1-2)

### DIFF
--- a/src/Lib/Events/MainForm.Definition.ps1
+++ b/src/Lib/Events/MainForm.Definition.ps1
@@ -174,6 +174,11 @@ $Script:MainForm.Definition.Add_Closing({
             if (Test-SqlSchemaFormIsVisible) {
                 $Script:SqlSchemaForm.Definition.Close()
             }
+
+            # Background request workers are real threads; left open they keep the process alive
+            # after the window has gone (issue #40). Best-effort, and last, so a failure here cannot
+            # cost the user their saved tab sessions or window measurements above.
+            Close-OmadaRequestPool
         }
         catch {
             $_.Exception.Message | Write-LogOutput -LogType ERROR -ErrorObject $_

--- a/src/Lib/Functions/Private/Build-OmadaRequestParameter.ps1
+++ b/src/Lib/Functions/Private/Build-OmadaRequestParameter.ps1
@@ -1,0 +1,55 @@
+function Build-OmadaRequestParameter {
+    <#
+    .SYNOPSIS
+    Turn the active tab's $Script:RunTimeData.RestMethodParam into the splat Invoke-OmadaRestMethod
+    is actually called with. UI thread only.
+
+    .DESCRIPTION
+    Extracted from Invoke-OmadaPSWebRequestWrapper so the synchronous and the background paths
+    prepare a request identically - one copy of these rules, not two that drift (issue #40).
+
+    It reads $Script:RunTimeConfig and $Script:SkipBodyRedaction, so it belongs on the UI thread; the
+    result is a plain hashtable that a worker can be handed a clone of.
+
+    Note that this mutates $Script:RunTimeData.RestMethodParam in place and returns it, exactly as
+    the wrapper always did. Callers that dispatch it to a worker must clone it first - that hashtable
+    is long-lived and the next call site overwrites Uri, Method and Body.
+
+    .OUTPUTS
+    The prepared parameter hashtable.
+    #>
+    [CmdletBinding()]
+    param()
+
+    $Private:Parameters = $Script:RunTimeData.RestMethodParam
+
+    $Private:Parameters.UseWebView2 = $Private:Parameters.AuthenticationType -eq "Browser" ? $($Script:RunTimeConfig.UseWebView2Auth) : $false
+
+    if ($null -eq $Private:Parameters.Body) {
+        if ($Private:Parameters.ContainsKey("Body")) {
+            $Private:Parameters.Remove("Body")
+        }
+    }
+    else {
+        if (!$Private:Parameters.ContainsKey("Body")) {
+            $Private:Parameters.Add("Body", $null)
+        }
+    }
+
+    # Keep the module's own verbose stream in step with this application's log, so the two do not
+    # contradict each other on the same request. Passed only when the installed OmadaWeb.PS actually
+    # declares the parameter: -SkipBodyRedaction is newer than the pinned minimum version, and
+    # splatting a parameter a cmdlet does not have is a terminating error. Capability-checked rather
+    # than version-gated, so this works the day the switch ships without forcing everyone onto a
+    # release that does not exist yet.
+    $Private:RestMethodCommand = Get-Command -Name Invoke-OmadaRestMethod -ErrorAction SilentlyContinue
+    if ($null -ne $Private:RestMethodCommand -and $Private:RestMethodCommand.Parameters.ContainsKey("SkipBodyRedaction")) {
+        $Private:Parameters.SkipBodyRedaction = [bool]$Script:SkipBodyRedaction
+    }
+    elseif ($Private:Parameters.ContainsKey("SkipBodyRedaction")) {
+        # The installed module was downgraded mid-session; drop the key rather than fail.
+        $Private:Parameters.Remove("SkipBodyRedaction")
+    }
+
+    return $Private:Parameters
+}

--- a/src/Lib/Functions/Private/Complete-OmadaBackgroundRequest.ps1
+++ b/src/Lib/Functions/Private/Complete-OmadaBackgroundRequest.ps1
@@ -1,0 +1,77 @@
+function Complete-OmadaBackgroundRequest {
+    <#
+    .SYNOPSIS
+    Collect the outcome of a background request on the UI thread and release its worker.
+
+    .DESCRIPTION
+    Called from a completion block that the poll timer invoked, so this runs on the UI thread inside
+    a frame where this module's private functions resolve and the owning tab has already been made
+    active by Set-ActiveTabContext. That is the whole point of routing background work through the
+    existing completion queue: everything that needs the app's state runs here, not in the worker.
+
+    Returns the same @{ Result; ErrorRecord } shape as Invoke-OmadaRequestCore, so a caller handles a
+    background failure exactly as it handles a synchronous one. ErrorRecord is the discriminator; a
+    null Result on its own does not mean failure.
+
+    .NOTES
+    EndInvoke on a pipeline that was stopped THROWS - verified, not assumed - so the cancelled case
+    is checked before EndInvoke is called rather than being caught afterwards. A cancelled request
+    reports neither a result nor an error: nothing failed, the caller simply stopped waiting.
+
+    The [powershell] is always disposed. For a cancelled request that matters more than tidiness: a
+    pipeline killed mid-request leaves a half-read HTTP stream and a WebRequestSession in an unknown
+    state, so its runspace must be discarded rather than handed back to the pool for the next query.
+    Disposing the shell is what releases it.
+
+    .PARAMETER Pending
+    The queue item created by Start-OmadaBackgroundRequest.
+
+    .OUTPUTS
+    Hashtable @{ Result; ErrorRecord; IsCancelled }.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        $Pending
+    )
+
+    $Private:Outcome = @{
+        Result      = $null
+        ErrorRecord = $null
+        IsCancelled = [bool]$Pending.IsCancelled
+    }
+
+    try {
+        if ($Pending.IsCancelled) {
+            return $Private:Outcome
+        }
+
+        $Private:Output = $Pending.Shell.EndInvoke($Pending.Task)
+
+        # AddScript returns the core's hashtable through the pipeline, so it arrives wrapped in the
+        # output collection. Take the first entry that looks like the contract rather than assuming
+        # a position: a worker that also wrote to the output stream would otherwise shift it.
+        $Private:Core = @($Private:Output) | Where-Object { $_ -is [hashtable] -and $_.ContainsKey("ErrorRecord") } | Select-Object -First 1
+
+        if ($null -eq $Private:Core) {
+            # The worker returned something this function does not understand. Surface the worker's
+            # own error stream if it has one, so the cause is not swallowed.
+            $Private:WorkerError = @($Pending.Shell.Streams.Error) | Select-Object -First 1
+            if ($null -ne $Private:WorkerError) {
+                $Private:Outcome.ErrorRecord = $Private:WorkerError
+            }
+            return $Private:Outcome
+        }
+
+        $Private:Outcome.Result = $Private:Core.Result
+        $Private:Outcome.ErrorRecord = $Private:Core.ErrorRecord
+        return $Private:Outcome
+    }
+    catch {
+        $Private:Outcome.ErrorRecord = $_
+        return $Private:Outcome
+    }
+    finally {
+        try { $Pending.Shell.Dispose() } catch { }
+    }
+}

--- a/src/Lib/Functions/Private/Get-SqlSchema.ps1
+++ b/src/Lib/Functions/Private/Get-SqlSchema.ps1
@@ -209,7 +209,11 @@ function Complete-SqlSchemaRetrieval {
         "Schema for Monaco editor: {0}" -f $SchemaObjectsJson | Write-LogOutput -LogType VERBOSE
         $OnCompletedScriptBlock = {
             try {
-                if (!$Script:Task.Status -eq "RanToCompletion") {
+                # -ne, not "!... -eq". The original read !$Script:Task.Status -eq "RanToCompletion",
+                # where ! binds to the property first: a non-empty status string becomes $false, and
+                # $false -eq "RanToCompletion" is always $false - so the failure branch never ran and
+                # every editor push, successful or not, was logged as a success.
+                if ($Script:Task.Status -ne "RanToCompletion") {
                     "Monaco Editor Task failed: {0}" -f $Script:Task.Status | Write-LogOutput -LogType ERROR -ErrorObject $_
                 }
                 else {

--- a/src/Lib/Functions/Private/Get-SqlSchema.ps1
+++ b/src/Lib/Functions/Private/Get-SqlSchema.ps1
@@ -47,130 +47,188 @@ function Get-SqlSchemaObject {
 
             if ($Script:SqlSchemaCache.ContainsKey($SchemaCacheKey)) {
                 "Using cached SQL schema for '{0}'" -f $SchemaCacheKey | Write-LogOutput -LogType DEBUG
-                $ReturnValue = $Script:SqlSchemaCache[$SchemaCacheKey]
-            }
-            else {
-                $Script:RunTimeData.RestMethodParam.Body = @{
-                    connectionId = $Script:AppConfig.CurrentDataConnection.DoId
-                }
-                $Script:RunTimeData.RestMethodParam.Method = "POST"
-                $ReturnValue = Invoke-OmadaPSWebRequestWrapper
-
-                if ($null -ne $ReturnValue -and $ReturnValue -isnot [System.Management.Automation.ErrorRecord] -and $null -ne $ReturnValue.d) {
-                    $Script:SqlSchemaCache[$SchemaCacheKey] = $ReturnValue
-                }
+                Complete-SqlSchemaRetrieval -SchemaResponse $Script:SqlSchemaCache[$SchemaCacheKey] -SchemaCacheKey $SchemaCacheKey
+                return
             }
 
-            if ($null -eq $ReturnValue -or $ReturnValue -is [System.Management.Automation.ErrorRecord] -or $null -eq $ReturnValue.d) {
-                "No SQL schema returned for data connection '{0}'." -f $Script:AppConfig.CurrentDataConnection.FullName | Write-LogOutput -LogType WARNING -SkipDialog
-                return $null
+            $Script:RunTimeData.RestMethodParam.Body = @{
+                connectionId = $Script:AppConfig.CurrentDataConnection.DoId
+            }
+            $Script:RunTimeData.RestMethodParam.Method = "POST"
+
+            # Issue #40's first background caller, and deliberately the least risky one: the schema
+            # fetch is already cached, already tolerant of failure, binds no grid and creates no
+            # temporary object on the tenant - so it proves the machinery without putting a query
+            # result at stake. It is also the round-trip that freezes the window on connect.
+            #
+            # The completion block is plain (never .GetNewClosure()), so it reads the cache key from
+            # $Pending.Context.Caller instead of re-deriving it: by the time it runs, the user may
+            # have switched to a tab with a different SessionKey or data connection, and the key must
+            # be the one this request was issued for.
+            $Private:Pending = Invoke-OmadaPSWebRequestWrapperAsync -Description "SQL schema" -Context @{ SchemaCacheKey = $SchemaCacheKey } -OnResultScriptBlock {
+                param($Pending)
+                Complete-SqlSchemaRetrieval -SchemaResponse $Pending.Outcome -SchemaCacheKey $Pending.Context.Caller.SchemaCacheKey
             }
 
-            # The schema window is optional: this function also feeds the editor's IntelliSense, which
-            # must work whether or not the user ever opens the SQL schema view. Only touch the window's
-            # title/TreeView when they actually exist (they are created by Open-SqlSchemaForm) - the
-            # setSchema push below always runs.
-            $UpdateSchemaWindow = ($null -ne $Script:SqlSchemaForm -and $null -ne $Script:SqlSchemaForm.Definition -and $null -ne $Script:TreeViewSqlSchema)
+            if ($null -ne $Private:Pending) {
+                # Dispatched. Everything after the response now happens in the completion block.
+                return
+            }
 
+            # Not eligible for a worker, or none available: exactly the pre-#40 behaviour.
+            $ReturnValue = Invoke-OmadaPSWebRequestWrapper
+            Complete-SqlSchemaRetrieval -SchemaResponse $ReturnValue -SchemaCacheKey $SchemaCacheKey
+        }
+        else {
+            "SqlSchema DoID is not set! Cannot retrieve Sql schema!" | Write-LogOutput -LogType WARNING -SkipDialog
+            return $null
+        }
+    }
+    catch {
+        $_.Exception.Message | Write-LogOutput -LogType ERROR -ErrorObject $_
+    }
+}
+
+function Complete-SqlSchemaRetrieval {
+    <#
+    .SYNOPSIS
+    Everything that happens once a SQL schema response is in hand: cache it, rebuild the schema
+    window's tree, and push the schema to the Monaco editor for IntelliSense.
+
+    .DESCRIPTION
+    Split out of Get-SqlSchemaObject by issue #40 so the same work runs whether the response arrived
+    synchronously or from a background worker. It touches WPF elements and the editor, so it is UI
+    thread only - which it always is: the background path reaches it from the completion poll timer,
+    with the owning tab already made active by Set-ActiveTabContext.
+
+    .PARAMETER SchemaResponse
+    What the request produced: the response object, an ErrorRecord, or $null.
+
+    .PARAMETER SchemaCacheKey
+    The "<SessionKey>|<DataConnectionDoId>" key this response was fetched for. Passed in rather than
+    re-derived, because the active tab may have changed since the request was issued.
+    #>
+    [CmdLetBinding()]
+    param(
+        $SchemaResponse,
+
+        [Parameter(Mandatory = $true)]
+        [string]$SchemaCacheKey
+    )
+    try {
+        $ReturnValue = $SchemaResponse
+
+        if ($null -ne $ReturnValue -and $ReturnValue -isnot [System.Management.Automation.ErrorRecord] -and $null -ne $ReturnValue.d) {
+            if ($null -eq $Script:SqlSchemaCache) {
+                $Script:SqlSchemaCache = @{}
+            }
+            $Script:SqlSchemaCache[$SchemaCacheKey] = $ReturnValue
+        }
+
+        if ($null -eq $ReturnValue -or $ReturnValue -is [System.Management.Automation.ErrorRecord] -or $null -eq $ReturnValue.d) {
+            "No SQL schema returned for data connection '{0}'." -f $Script:AppConfig.CurrentDataConnection.FullName | Write-LogOutput -LogType WARNING -SkipDialog
+            return $null
+        }
+
+        # The schema window is optional: this function also feeds the editor's IntelliSense, which
+        # must work whether or not the user ever opens the SQL schema view. Only touch the window's
+        # title/TreeView when they actually exist (they are created by Open-SqlSchemaForm) - the
+        # setSchema push below always runs.
+        $UpdateSchemaWindow = ($null -ne $Script:SqlSchemaForm -and $null -ne $Script:SqlSchemaForm.Definition -and $null -ne $Script:TreeViewSqlSchema)
+
+        if ($UpdateSchemaWindow) {
+            $Script:SqlSchemaForm.Definition.Title = "Sql Schema - {0}" -f $Script:AppConfig.CurrentDataConnection.FullName
+        }
+
+        "Retrieved object {0}" -f $Script:RunTimeData.SqlQueryObject | Write-LogOutput -LogType VERBOSE
+
+        $SchemaObjects = @{}
+        if ($UpdateSchemaWindow) {
+            $Script:TreeViewSqlSchema.Items.Clear()
+        }
+
+        $Schemas = (($ReturnValue.d | Get-Member -MemberType NoteProperty).Name) | ForEach-Object { $_.Split(".", 2)[0] } | Select-Object -Unique
+        foreach ($Schema in $Schemas) {
+            $Tables = $ReturnValue.d | Get-Member -MemberType NoteProperty | Where-Object { $_.Name -like ("{0}.*" -f $Schema) }
+
+            $TreeViewSchemaItem = $null
             if ($UpdateSchemaWindow) {
-                $Script:SqlSchemaForm.Definition.Title = "Sql Schema - {0}" -f $Script:AppConfig.CurrentDataConnection.FullName
+                $TreeViewSchemaItem = New-Object System.Windows.Controls.TreeViewItem
+                $TreeViewSchemaItem.Header = $Schema
+                $TreeViewSchemaItem.FontSize = 14
+                $TreeViewSchemaItem.IsExpanded = $true
+                $Script:TreeViewSqlSchema.Items.Add($TreeViewSchemaItem) | Out-Null
             }
 
-            "Retrieved object {0}" -f $Script:RunTimeData.SqlQueryObject | Write-LogOutput -LogType VERBOSE
+            $TableObjects = @{}
 
-            $SchemaObjects = @{}
-            if ($UpdateSchemaWindow) {
-                $Script:TreeViewSqlSchema.Items.Clear()
-            }
+            foreach ($Table in $Tables) {
 
-            $Schemas = (($ReturnValue.d | Get-Member -MemberType NoteProperty).Name) | ForEach-Object { $_.Split(".", 2)[0] } | Select-Object -Unique
-            foreach ($Schema in $Schemas) {
-                $Tables = $ReturnValue.d | Get-Member -MemberType NoteProperty | Where-Object { $_.Name -like ("{0}.*" -f $Schema) }
+                $TableFullName = $Table.Name
+                $TableName = $TableFullName.Split(".", 2)[1]
 
-                $TreeViewSchemaItem = $null
+                $TreeViewTableItem = $null
                 if ($UpdateSchemaWindow) {
-                    $TreeViewSchemaItem = New-Object System.Windows.Controls.TreeViewItem
-                    $TreeViewSchemaItem.Header = $Schema
-                    $TreeViewSchemaItem.FontSize = 14
-                    $TreeViewSchemaItem.IsExpanded = $true
-                    $Script:TreeViewSqlSchema.Items.Add($TreeViewSchemaItem) | Out-Null
+                    $TreeViewTableItem = New-Object System.Windows.Controls.TreeViewItem
+                    $TreeViewTableItem.Header = $TableName
+                    $TreeViewTableItem.FontSize = 14
+                    $TreeViewSchemaItem.Items.Add($TreeViewTableItem) | Out-Null
                 }
 
-                $TableObjects = @{}
+                # Each raw entry is "ColumnName DataType"; keep both so the editor can show the
+                # type in its completion detail. Split on the first run of whitespace (the type
+                # itself may contain spaces, e.g. "nvarchar(50) NOT NULL", so keep the remainder
+                # intact) and wrap in @() so a single-column table still serialises as a JSON
+                # array rather than a lone object.
+                $TableObjects.Add($TableName, @($ReturnValue.d.$TableFullName | ForEach-Object {
+                            $Parts = $_.Trim() -split "\s+", 2
+                            [PSCustomObject][Ordered]@{ n = $Parts[0]; t = if ($Parts.Count -gt 1) { $Parts[1].Trim() } else { "" } }
+                        }))
 
-                foreach ($Table in $Tables) {
-
-                    $TableFullName = $Table.Name
-                    $TableName = $TableFullName.Split(".", 2)[1]
-
-                    $TreeViewTableItem = $null
-                    if ($UpdateSchemaWindow) {
-                        $TreeViewTableItem = New-Object System.Windows.Controls.TreeViewItem
-                        $TreeViewTableItem.Header = $TableName
-                        $TreeViewTableItem.FontSize = 14
-                        $TreeViewSchemaItem.Items.Add($TreeViewTableItem) | Out-Null
+                if ($UpdateSchemaWindow) {
+                    foreach ($Column in $ReturnValue.d.$TableFullName) {
+                        $TreeViewColumnItem = New-Object System.Windows.Controls.TreeViewItem
+                        $TreeViewColumnItem.Header = $Column
+                        $TreeViewColumnItem.FontSize = 12
+                        $TreeViewTableItem.Items.Add($TreeViewColumnItem) | Out-Null
                     }
-
-                    # Each raw entry is "ColumnName DataType"; keep both so the editor can show the
-                    # type in its completion detail. Split on the first run of whitespace (the type
-                    # itself may contain spaces, e.g. "nvarchar(50) NOT NULL", so keep the remainder
-                    # intact) and wrap in @() so a single-column table still serialises as a JSON
-                    # array rather than a lone object.
-                    $TableObjects.Add($TableName, @($ReturnValue.d.$TableFullName | ForEach-Object {
-                                $Parts = $_.Trim() -split "\s+", 2
-                                [PSCustomObject][Ordered]@{ n = $Parts[0]; t = if ($Parts.Count -gt 1) { $Parts[1].Trim() } else { "" } }
-                            }))
-
-                    if ($UpdateSchemaWindow) {
-                        foreach ($Column in $ReturnValue.d.$TableFullName) {
-                            $TreeViewColumnItem = New-Object System.Windows.Controls.TreeViewItem
-                            $TreeViewColumnItem.Header = $Column
-                            $TreeViewColumnItem.FontSize = 12
-                            $TreeViewTableItem.Items.Add($TreeViewColumnItem) | Out-Null
-                        }
-                    }
-                }
-                $SchemaObjects.Add($Schema, $TableObjects)
-            }
-
-            if ($UpdateSchemaWindow) {
-                # The tree was rebuilt from scratch above, so every node is visible again. Re-apply
-                # whatever the user has typed in the filter box, otherwise switching tab or data
-                # connection silently drops an active filter.
-                Update-SqlSchemaTreeFilter
-            }
-
-            $SchemaObjectsJson = $SchemaObjects | ConvertTo-Json -Depth 5
-
-            "Schema for Monaco editor: {0}" -f $SchemaObjectsJson | Write-LogOutput -LogType VERBOSE
-            $OnCompletedScriptBlock = {
-                try {
-                    if (!$Script:Task.Status -eq "RanToCompletion") {
-                        "Monaco Editor Task failed: {0}" -f $Script:Task.Status | Write-LogOutput -LogType ERROR -ErrorObject $_
-                    }
-                    else {
-                        "Monaco Editor Task completed successfully." | Write-LogOutput -LogType DEBUG
-                    }
-                }
-                catch {
-                    $Script:Task.Exception.Message | Write-LogOutput -LogType ERROR -ErrorObject $_
                 }
             }
+            $SchemaObjects.Add($Schema, $TableObjects)
+        }
 
-            "Push schema to Monaco editor." | Write-LogOutput -LogType DEBUG
-            Invoke-ExecuteScriptAsync -ScriptToExecute "setSchema($SchemaObjectsJson);" -OnCompletedScriptBlock $OnCompletedScriptBlock
+        if ($UpdateSchemaWindow) {
+            # The tree was rebuilt from scratch above, so every node is visible again. Re-apply
+            # whatever the user has typed in the filter box, otherwise switching tab or data
+            # connection silently drops an active filter.
+            Update-SqlSchemaTreeFilter
+        }
+
+        $SchemaObjectsJson = $SchemaObjects | ConvertTo-Json -Depth 5
+
+        "Schema for Monaco editor: {0}" -f $SchemaObjectsJson | Write-LogOutput -LogType VERBOSE
+        $OnCompletedScriptBlock = {
+            try {
+                if (!$Script:Task.Status -eq "RanToCompletion") {
+                    "Monaco Editor Task failed: {0}" -f $Script:Task.Status | Write-LogOutput -LogType ERROR -ErrorObject $_
+                }
+                else {
+                    "Monaco Editor Task completed successfully." | Write-LogOutput -LogType DEBUG
+                }
+            }
+            catch {
+                $Script:Task.Exception.Message | Write-LogOutput -LogType ERROR -ErrorObject $_
+            }
+        }
+
+        "Push schema to Monaco editor." | Write-LogOutput -LogType DEBUG
+        Invoke-ExecuteScriptAsync -ScriptToExecute "setSchema($SchemaObjectsJson);" -OnCompletedScriptBlock $OnCompletedScriptBlock
 
             # Re-validate after a schema push. A new connection can invalidate the diagnostics that
             # are currently on screen, and it is also the first moment a restored tab's editor
             # content has ever been looked at. Debounced like every other trigger, so switching
             # connection rapidly costs one parse, not one per switch.
             Request-SqlSyntaxValidation -TabSession (Get-ActiveTabSession)
-
-        }
-        else {
-            "SqlSchema DoID is not set! Cannot retrieve Sql schema!" | Write-LogOutput -LogType WARNING -SkipDialog
-            return $null
-        }
     }
     catch {
         $_.Exception.Message | Write-LogOutput -LogType ERROR -ErrorObject $_

--- a/src/Lib/Functions/Private/Initialize-OmadaRequestPool.ps1
+++ b/src/Lib/Functions/Private/Initialize-OmadaRequestPool.ps1
@@ -1,0 +1,97 @@
+function Initialize-OmadaRequestPool {
+    <#
+    .SYNOPSIS
+    Open (once) the runspace pool that background Omada requests run in, and return it.
+
+    .DESCRIPTION
+    Issue #40: an Omada round-trip must not block the WPF UI thread. The workers live in a pool
+    rather than being created per request, because each one has to Import-Module OmadaWeb.PS and
+    that is not free - the module resolves and loads WebView2 assemblies on import. A pool with a
+    warmed InitialSessionState pays that once per worker, not once per query.
+
+    Called lazily from Start-OmadaBackgroundRequest, so a session that never issues a background
+    request never opens a pool at all, and a failure to open one is a fallback to synchronous
+    execution rather than a failure to start the app.
+
+    .NOTES
+    The workers are MTA, deliberately, and that is the enforcement half of this application's
+    background authentication policy.
+
+    OmadaWeb.PS authenticates by opening a WinForms modal (Start-WebView2Login calls
+    $Script:WinForm.ShowDialog()), on whatever thread calls it. WinForms and WebView2 need STA. A
+    worker that could show that dialog would show it with NO owner window: not modal to this app,
+    possibly behind the main window, while the main window stays fully interactive - so the user can
+    start a second execute on another tab while an invisible login prompt waits. That is a worse
+    failure than not authenticating at all.
+
+    Making the workers MTA means an attempted interactive login in a worker FAILS instead of
+    prompting. Combined with Test-OmadaBackgroundRequestEligible, which only dispatches for a tab
+    that already authenticated on the UI thread, the policy is: interactive authentication happens
+    on the UI thread or it does not happen. An already-authenticated request touches none of that
+    path - it is Invoke-RestMethod against a cookie OmadaWeb.PS loads from its encrypted on-disk
+    cache - so MTA costs it nothing.
+
+    (The mock server's own background runspace, tests/mock/OmadaMockServer.ps1, is MTA for unrelated
+    reasons; this is not that precedent being copied, it is the same conclusion reached separately.)
+
+    .OUTPUTS
+    The open RunspacePool, or $null when one could not be opened.
+    #>
+    [CmdletBinding()]
+    param()
+
+    try {
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement))
+
+        if ($null -ne $Script:OmadaRequestPool -and $Script:OmadaRequestPool.RunspacePoolStateInfo.State -eq [System.Management.Automation.Runspaces.RunspacePoolState]::Opened) {
+            return $Script:OmadaRequestPool
+        }
+
+        # Sized to the tab capacity so every tab can have a request in flight at once - the
+        # "two tabs executing concurrently" criterion of issue #40 - with a floor of 2 so a
+        # misconfigured capacity cannot serialize everything.
+        $Private:MaxWorkers = if ($null -ne $Script:AppGlobalConfig -and $Script:AppGlobalConfig.TabCapacity -gt 0) { [int]$Script:AppGlobalConfig.TabCapacity } else { 8 }
+        if ($Private:MaxWorkers -lt 2) { $Private:MaxWorkers = 2 }
+
+        $Private:SessionState = [System.Management.Automation.Runspaces.InitialSessionState]::CreateDefault2()
+        $Private:SessionState.ApartmentState = [System.Threading.ApartmentState]::MTA
+        $Private:SessionState.ImportPSModule("OmadaWeb.PS")
+
+        $Private:Pool = [runspacefactory]::CreateRunspacePool(1, $Private:MaxWorkers, $Private:SessionState, $Host)
+        $Private:Pool.ThreadOptions = [System.Management.Automation.Runspaces.PSThreadOptions]::ReuseThread
+        $Private:Pool.Open()
+
+        $Script:OmadaRequestPool = $Private:Pool
+        "Background request pool opened with up to {0} worker(s)." -f $Private:MaxWorkers | Write-LogOutput -LogType DEBUG
+        return $Script:OmadaRequestPool
+    }
+    catch {
+        # Never fatal. Every caller falls back to running the request synchronously, which is exactly
+        # what the app did before issue #40 - slower, but correct.
+        "Could not open the background request pool; requests will run on the UI thread. {0}" -f $_.Exception.Message | Write-LogOutput -LogType WARNING -SkipDialog
+        $Script:OmadaRequestPool = $null
+        return $null
+    }
+}
+
+function Close-OmadaRequestPool {
+    <#
+    .SYNOPSIS
+    Close and dispose the background request pool. Called when the main window closes.
+
+    .DESCRIPTION
+    Left open, the pool's worker threads keep the process alive after the window has gone. Closing is
+    best-effort and never throws: this runs on the shutdown path, where a failure here would be far
+    more disruptive than a leaked runspace in a process that is exiting anyway.
+    #>
+    [CmdletBinding()]
+    param()
+
+    if ($null -eq $Script:OmadaRequestPool) {
+        return
+    }
+
+    try { $Script:OmadaRequestPool.Close() } catch { }
+    try { $Script:OmadaRequestPool.Dispose() } catch { }
+    $Script:OmadaRequestPool = $null
+}

--- a/src/Lib/Functions/Private/Invoke-OmadaPSWebRequestWrapper.ps1
+++ b/src/Lib/Functions/Private/Invoke-OmadaPSWebRequestWrapper.ps1
@@ -16,51 +16,26 @@ function Invoke-OmadaPSWebRequestWrapper {
     Suspend-WebViewCompletionPolling
     try {
         if (!$Script:RunTimeData.SkipRetryRequest) {
-            $Private:Parameters = $Script:RunTimeData.RestMethodParam
-            #$Private:Parameters.AuthenticationType = $($Script:MainForm.Elements.ComboBoxSelectAuthenticationOption.SelectedItem.Content)
-            $Private:Parameters.UseWebView2 = $Private:Parameters.AuthenticationType -eq "Browser" ? $($Script:RunTimeConfig.UseWebView2Auth) : $false
-            if ($null -eq $Private:Parameters.Body) {
-                if ($Private:Parameters.ContainsKey("Body")) {
-                    $Private:Parameters.Remove("Body")
-                }
-            }
-            else {
-                if (!$Private:Parameters.ContainsKey("Body")) {
-                    $Private:Parameters.Add("Body", $null)
-                }
-
-                #$Private:Parameters.Body = $Private:Parameters.Body | ConvertTo-Json
-            }
-
-            # Keep the module's own verbose stream in step with this application's log, so the two
-            # do not contradict each other on the same request. Passed only when the installed
-            # OmadaWeb.PS actually declares the parameter: -SkipBodyRedaction is newer than the
-            # pinned minimum version, and splatting a parameter a cmdlet does not have is a
-            # terminating error. Capability-checked rather than version-gated, so this works the day
-            # the switch ships without forcing everyone onto a release that does not exist yet.
-            $Private:RestMethodCommand = Get-Command -Name Invoke-OmadaRestMethod -ErrorAction SilentlyContinue
-            if ($null -ne $Private:RestMethodCommand -and $Private:RestMethodCommand.Parameters.ContainsKey("SkipBodyRedaction")) {
-                $Private:Parameters.SkipBodyRedaction = [bool]$Script:SkipBodyRedaction
-            }
-            elseif ($Private:Parameters.ContainsKey("SkipBodyRedaction")) {
-                # The installed module was downgraded mid-session; drop the key rather than fail.
-                $Private:Parameters.Remove("SkipBodyRedaction")
-            }
+            # Preparation and failure classification live in Build-OmadaRequestParameter and
+            # Resolve-OmadaRequestFailure so the background path (issue #40,
+            # Invoke-OmadaPSWebRequestWrapperAsync) applies exactly the same rules. This function is
+            # still the synchronous choke point, and is still what runs when a request is not
+            # eligible for a worker or no worker could be had.
+            $Private:Parameters = Build-OmadaRequestParameter
 
             "Parameters: {0}" -f (ConvertTo-RedactedLogString -InputObject $Private:Parameters) | Write-LogOutput -LogType VERBOSE
 
             # The call itself lives in Invoke-OmadaRequestCore, which reads no $Script: state and
-            # writes no log - the one part of this function that can legally run in a worker runspace
-            # (issue #40). Everything around it, from the parameter preparation above to the error
-            # classification below, stays here on the UI thread. Behaviour is unchanged: the core
-            # returns the failure instead of throwing it, and this rethrows so the existing catch
-            # classifies it exactly as before. A rethrown ErrorRecord keeps its Exception,
-            # ErrorDetails and FullyQualifiedErrorId, which is all the branches below read.
+            # writes no log - the one part of this function that can legally run in a worker runspace.
+            # The core returns the failure instead of throwing it, so this rethrows to keep the
+            # control flow identical: a rethrown ErrorRecord keeps its Exception, ErrorDetails and
+            # FullyQualifiedErrorId, which is all the classification reads.
             $Private:Outcome = Invoke-OmadaRequestCore -Parameters $Private:Parameters
             if ($null -ne $Private:Outcome.ErrorRecord) {
                 throw $Private:Outcome.ErrorRecord
             }
             $Private:Result = $Private:Outcome.Result
+
             # Deliberately no status-bar write here. A successful request is not the same thing as a
             # connected tab: this transport is also used by probes and by work that runs while a tab
             # is being connected, so writing "Connected" from here put the status bar ahead of - and
@@ -78,29 +53,7 @@ function Invoke-OmadaPSWebRequestWrapper {
         }
     }
     catch {
-        if (![string]::IsNullOrWhiteSpace($_.ErrorDetails?.Message) -and $_.ErrorDetails.Message -like "*Resource not found for the segment 'C_P_SQLTROUBLESHOOTING'*") {
-            $Message = "OData Endpoint for SQL Troubleshooting not enabled at tenant {0}.`n`r`n`rError returned by Omada:`n`r`n`r{1}" -f [system.uri]::New($Script:AppConfig.BaseUrl).Host, $_.ErrorDetails.Message
-            # Route the teardown through the state function, exactly as the Unauthorized branch below
-            # already does. This used to hand-write four status-bar fields while leaving
-            # $Script:ConnectionStatus untouched, so the button, the dropdowns and the Display name
-            # went on claiming the tab was connected. (The writes were in fact unreachable: the guard
-            # tested $Script:MainForm.Definitions, which does not exist - the member is Definition -
-            # so the status bar was never even updated on this error.)
-            Set-SqlConnectionState -Status $false
-            $Message | Write-Error -ErrorAction Stop -TargetObject $_
-            $Script:RunTimeData.SkipRetryRequest = $true
-        }
-        elseif ($null -ne $_.Exception?.Response?.StatusCode -and $_.Exception.Response.StatusCode -eq [System.Net.HttpStatusCode]::Unauthorized) {
-            $Message = "Access denied to {0}, message:`n`r{1}" -f [system.uri]::New($Script:AppConfig.BaseUrl).Host, $_.ErrorDetails.Message
-            Set-SqlConnectionState -Status $false
-            $Message | Write-Error -ErrorAction Stop -TargetObject $_
-            $Script:RunTimeData.SkipRetryRequest = $true
-        }
-        else {
-            # $Message = "Error occurred:`n`r{1}" -f [system.uri]::New($Script:AppConfig.BaseUrl).Host, $_.ErrorDetails.Message
-            # $Message | Write-Error -ErrorAction Stop -TargetObject $_
-            $_
-        }
+        Resolve-OmadaRequestFailure -ErrorRecord $_
     }
     finally {
         Resume-WebViewCompletionPolling

--- a/src/Lib/Functions/Private/Invoke-OmadaPSWebRequestWrapperAsync.ps1
+++ b/src/Lib/Functions/Private/Invoke-OmadaPSWebRequestWrapperAsync.ps1
@@ -1,0 +1,116 @@
+function Invoke-OmadaPSWebRequestWrapperAsync {
+    <#
+    .SYNOPSIS
+    Background sibling of Invoke-OmadaPSWebRequestWrapper: prepare the request on the UI thread,
+    issue it on a worker, and return immediately. Returns $null when the request must run inline.
+
+    .DESCRIPTION
+    Issue #40. The contract deliberately makes the fallback the caller's business rather than hiding
+    it: this returns $null - having done nothing - whenever the request may not, or cannot, go to a
+    worker, and the caller then does exactly what it did before by calling
+    Invoke-OmadaPSWebRequestWrapper. There are three such cases:
+
+      - $Script:RunTimeData.SkipRetryRequest is set. The synchronous wrapper answers $null for this
+        without making a request, and that decision must not be duplicated here.
+      - Test-OmadaBackgroundRequestEligible says no - the tab is not authenticated, or the request
+        asks to re-authenticate. Interactive authentication belongs on the UI thread.
+      - No pool could be opened, or dispatch failed. Slower is better than broken.
+
+    On completion, $OnResultScriptBlock is invoked on the UI thread by the completion poll timer,
+    with the pending item as its argument, after the owning tab has been made active. It receives
+    the response through $Pending.Outcome, whose shape matches what the synchronous wrapper returns:
+    the response object on success, an ErrorRecord for an unclassified failure. The two classified
+    failures (OData endpoint missing, Unauthorized) are handled here by Resolve-OmadaRequestFailure,
+    which throws - so a caller sees precisely what it would have seen inline.
+
+    .PARAMETER OnResultScriptBlock
+    A PLAIN scriptblock (never .GetNewClosure() - see MainForm.Definition.ps1) invoked on the UI
+    thread. Reads its data from the pending item passed as its argument: $Pending.Outcome for the
+    response, $Pending.Context for whatever the caller attached.
+
+    .PARAMETER Context
+    Caller data carried to the completion block, where it is read as $Pending.Context.Caller.
+    Anything the completion needs that would otherwise have to be re-read from $Script: state
+    belongs here: by the time the block runs, other work may have moved the active tab, and
+    re-reading is how a completion ends up acting on the wrong tab.
+
+    .PARAMETER Description
+    Short label for logging and the elapsed-time indicator.
+
+    .OUTPUTS
+    The pending queue item, or $null when the caller must run the request synchronously.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [scriptblock]$OnResultScriptBlock,
+
+        $Context,
+
+        [string]$Description = "Omada request"
+    )
+
+    try {
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Description: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, $Description))
+
+        if ($Script:RunTimeData.SkipRetryRequest) {
+            return $null
+        }
+
+        $Private:Parameters = Build-OmadaRequestParameter
+
+        if (-not (Test-OmadaBackgroundRequestEligible -Parameters $Private:Parameters)) {
+            "Request '{0}' is not eligible for a background worker; running on the UI thread." -f $Description | Write-LogOutput -LogType DEBUG
+            return $null
+        }
+
+        "Parameters: {0}" -f (ConvertTo-RedactedLogString -InputObject $Private:Parameters) | Write-LogOutput -LogType VERBOSE
+
+        $Private:TabSession = Get-ActiveTabSession
+        if ($null -eq $Private:TabSession) {
+            return $null
+        }
+
+        # Both the caller's data and the caller's result block travel on .Context, and are assembled
+        # BEFORE dispatch. Attaching the result block to the item after Start-OmadaBackgroundRequest
+        # returned would work today - nothing pumps the dispatcher in between, so the poll timer
+        # cannot fire - but it would be correct only by that accident, and this queue is about to be
+        # drained by more code than it is now.
+        $Private:RequestContext = @{
+            Caller   = $Context
+            OnResult = $OnResultScriptBlock
+        }
+
+        # The completion block below is the bridge back onto the UI thread. It is a plain block: it
+        # reads everything it needs from $Pending, and calls only module-private functions, which
+        # resolve because the poll timer invokes it from a top-level frame.
+        return Start-OmadaBackgroundRequest -Parameters $Private:Parameters -TabSession $Private:TabSession -Description $Description -Context $Private:RequestContext -OnCompletedScriptBlock {
+            param($Pending)
+
+            $Private:Outcome = Complete-OmadaBackgroundRequest -Pending $Pending
+
+            if ($Private:Outcome.IsCancelled) {
+                "Background request cancelled: {0}" -f $Pending.Description | Write-LogOutput -LogType DEBUG
+                return
+            }
+
+            if ($null -ne $Private:Outcome.ErrorRecord) {
+                # Same classification as the inline path. The two tenant-level branches throw, which
+                # the poll timer catches and logs; the third returns the ErrorRecord, which is what
+                # callers test with -is [ErrorRecord].
+                $Pending | Add-Member -NotePropertyName "Outcome" -NotePropertyValue (Resolve-OmadaRequestFailure -ErrorRecord $Private:Outcome.ErrorRecord) -Force
+            }
+            else {
+                "Result: {0}" -f (ConvertTo-RedactedLogString -InputObject $Private:Outcome.Result) | Write-LogOutput -LogType VERBOSE
+                $Script:RunTimeData.RestMethodParam.ForceAuthentication = $false
+                $Pending | Add-Member -NotePropertyName "Outcome" -NotePropertyValue $Private:Outcome.Result -Force
+            }
+
+            & $Pending.Context.OnResult $Pending
+        }
+    }
+    catch {
+        "Could not start a background request ({0}); it will run on the UI thread. {1}" -f $Description, $_.Exception.Message | Write-LogOutput -LogType WARNING -SkipDialog
+        return $null
+    }
+}

--- a/src/Lib/Functions/Private/Resolve-OmadaRequestFailure.ps1
+++ b/src/Lib/Functions/Private/Resolve-OmadaRequestFailure.ps1
@@ -1,0 +1,55 @@
+function Resolve-OmadaRequestFailure {
+    <#
+    .SYNOPSIS
+    Classify a failed Omada request and drive the app's response to it. UI thread only.
+
+    .DESCRIPTION
+    Extracted verbatim from Invoke-OmadaPSWebRequestWrapper's catch block so that a request issued on
+    a background worker is classified by exactly the same rules as one issued inline (issue #40).
+    Everything it does - Set-SqlConnectionState, reading $Script:AppConfig.BaseUrl, writing
+    $Script:RunTimeData.SkipRetryRequest - is UI-runspace state, which is why the worker returns the
+    ErrorRecord rather than trying to interpret it.
+
+    .NOTES
+    Two of the three branches end in Write-Error -ErrorAction Stop, which THROWS. That is not an
+    oversight being preserved for its own sake: it is how the tenant-level failures (the OData
+    endpoint not enabled, and Unauthorized) reach the caller as errors rather than as return values,
+    and the wrapper's tests assert it. The third branch returns the ErrorRecord, which is the
+    documented contract callers test with -is [ErrorRecord].
+
+    Because of that, a caller invoking this from a background completion block must be prepared for
+    it to throw - the poll timer's own try/catch logs it - whereas the synchronous wrapper lets it
+    propagate to whoever called the wrapper.
+
+    .PARAMETER ErrorRecord
+    The failure, either caught inline or returned from Invoke-OmadaRequestCore.
+
+    .OUTPUTS
+    The ErrorRecord, for the unclassified case. The two classified cases throw.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        $ErrorRecord
+    )
+
+    if (![string]::IsNullOrWhiteSpace($ErrorRecord.ErrorDetails?.Message) -and $ErrorRecord.ErrorDetails.Message -like "*Resource not found for the segment 'C_P_SQLTROUBLESHOOTING'*") {
+        $Message = "OData Endpoint for SQL Troubleshooting not enabled at tenant {0}.`n`r`n`rError returned by Omada:`n`r`n`r{1}" -f [system.uri]::New($Script:AppConfig.BaseUrl).Host, $ErrorRecord.ErrorDetails.Message
+        # Route the teardown through the state function, exactly as the Unauthorized branch below
+        # already does. This used to hand-write four status-bar fields while leaving
+        # $Script:ConnectionStatus untouched, so the button, the dropdowns and the Display name went
+        # on claiming the tab was connected.
+        Set-SqlConnectionState -Status $false
+        $Message | Write-Error -ErrorAction Stop -TargetObject $ErrorRecord
+        $Script:RunTimeData.SkipRetryRequest = $true
+    }
+    elseif ($null -ne $ErrorRecord.Exception?.Response?.StatusCode -and $ErrorRecord.Exception.Response.StatusCode -eq [System.Net.HttpStatusCode]::Unauthorized) {
+        $Message = "Access denied to {0}, message:`n`r{1}" -f [system.uri]::New($Script:AppConfig.BaseUrl).Host, $ErrorRecord.ErrorDetails.Message
+        Set-SqlConnectionState -Status $false
+        $Message | Write-Error -ErrorAction Stop -TargetObject $ErrorRecord
+        $Script:RunTimeData.SkipRetryRequest = $true
+    }
+    else {
+        $ErrorRecord
+    }
+}

--- a/src/Lib/Functions/Private/Resolve-OmadaRequestFailure.ps1
+++ b/src/Lib/Functions/Private/Resolve-OmadaRequestFailure.ps1
@@ -21,6 +21,16 @@ function Resolve-OmadaRequestFailure {
     it to throw - the poll timer's own try/catch logs it - whereas the synchronous wrapper lets it
     propagate to whoever called the wrapper.
 
+    Both branches used to be followed by "$Script:RunTimeData.SkipRetryRequest = $true", which the
+    Write-Error above made unreachable - dead since it was written. Those lines are gone rather than
+    moved before the throw, because moving them would be a real and untested behaviour change, not a
+    tidy-up: SkipRetryRequest makes Invoke-OmadaPSWebRequestWrapper return $null WITHOUT making a
+    request, and the only thing that ever clears it is Reset-Application. Setting it here would mean
+    a single Unauthorized - an expired cookie, say - silently stopped the tab from issuing any
+    request at all for the rest of the session, with no way back short of a full application reset.
+    Whether that is wanted is a product decision that belongs to issue #44's territory (telling a
+    failed request apart from an empty one), not to this change.
+
     .PARAMETER ErrorRecord
     The failure, either caught inline or returned from Invoke-OmadaRequestCore.
 
@@ -41,13 +51,11 @@ function Resolve-OmadaRequestFailure {
         # on claiming the tab was connected.
         Set-SqlConnectionState -Status $false
         $Message | Write-Error -ErrorAction Stop -TargetObject $ErrorRecord
-        $Script:RunTimeData.SkipRetryRequest = $true
     }
     elseif ($null -ne $ErrorRecord.Exception?.Response?.StatusCode -and $ErrorRecord.Exception.Response.StatusCode -eq [System.Net.HttpStatusCode]::Unauthorized) {
         $Message = "Access denied to {0}, message:`n`r{1}" -f [system.uri]::New($Script:AppConfig.BaseUrl).Host, $ErrorRecord.ErrorDetails.Message
         Set-SqlConnectionState -Status $false
         $Message | Write-Error -ErrorAction Stop -TargetObject $ErrorRecord
-        $Script:RunTimeData.SkipRetryRequest = $true
     }
     else {
         $ErrorRecord

--- a/src/Lib/Functions/Private/Start-OmadaBackgroundRequest.ps1
+++ b/src/Lib/Functions/Private/Start-OmadaBackgroundRequest.ps1
@@ -1,0 +1,127 @@
+function Start-OmadaBackgroundRequest {
+    <#
+    .SYNOPSIS
+    Issue an Omada request on a background worker and enqueue its completion onto the existing
+    WebView2 completion queue. Returns immediately.
+
+    .DESCRIPTION
+    Issue #40. The design insight that makes this cheap: the poll timer in MainForm.Definition.ps1
+    only ever asks $_.Task.IsCompleted, and PowerShell.BeginInvoke() returns an IAsyncResult, which
+    exposes exactly that property. So a background request can be queued into the SAME
+    $Script:PendingWebViewCompletions list, drained by the SAME 50 ms timer, invoking its completion
+    block from the SAME call frame that already repoints the owning tab via Set-ActiveTabContext -
+    with no change to the Tick handler at all. One completion queue, not two.
+
+    The completion block is invoked with the whole pending item as its argument, so it reads
+    $Pending.Shell and calls Complete-OmadaBackgroundRequest to collect the outcome. It must be a
+    PLAIN scriptblock, never a .GetNewClosure() block, for the reason documented at the top of
+    MainForm.Definition.ps1: a closure runs in a detached dynamic module that cannot resolve this
+    module's private functions.
+
+    .PARAMETER Parameters
+    The prepared Invoke-OmadaRestMethod splat. CLONED here before it crosses the runspace boundary:
+    $Script:RunTimeData.RestMethodParam is long-lived, is mutated by the next call site, and
+    Set-ActiveTabContext can swap the whole RunTimeData object out from under a request that is
+    still in flight. A worker reading the live hashtable would see whichever request came after it.
+
+    .PARAMETER TabSession
+    The tab this request belongs to. The poll timer repoints to it before invoking the completion
+    block and restores the previously active tab afterwards.
+
+    .PARAMETER OnCompletedScriptBlock
+    Plain scriptblock invoked on the UI thread with the pending item as its argument.
+
+    .PARAMETER Context
+    Arbitrary caller data, attached to the pending item as .Context and therefore reachable from the
+    completion block. This is how a plain scriptblock gets its inputs: a plain block resolves
+    variables from the scope it is INVOKED in - the poll timer's frame - not the one it was written
+    in, so anything the completion needs must travel on the item. It is also how a completion avoids
+    re-reading $Script: state that another tab may have repointed in the meantime.
+
+    .PARAMETER Description
+    Short label for the log and for the elapsed-time indicator.
+
+    .OUTPUTS
+    The pending item that was enqueued, or $null when the request could not be dispatched (in which
+    case the caller must run it synchronously).
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [hashtable]$Parameters,
+
+        [Parameter(Mandatory = $true)]
+        $TabSession,
+
+        [Parameter(Mandatory = $true)]
+        [scriptblock]$OnCompletedScriptBlock,
+
+        $Context,
+
+        [string]$Description = "Omada request"
+    )
+
+    try {
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Description: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, $Description))
+
+        $Private:Pool = Initialize-OmadaRequestPool
+        if ($null -eq $Private:Pool) {
+            return $null
+        }
+
+        $Private:CorePath = Join-Path $Script:RunTimeConfig.ModuleFolder -ChildPath "Lib\Functions\Private\Invoke-OmadaRequestCore.ps1"
+        if (-not (Test-Path -LiteralPath $Private:CorePath)) {
+            "Background request core not found at '{0}'; running on the UI thread instead." -f $Private:CorePath | Write-LogOutput -LogType WARNING -SkipDialog
+            return $null
+        }
+
+        $Private:Shell = [powershell]::Create()
+        $Private:Shell.RunspacePool = $Private:Pool
+
+        # The worker dot-sources the core from disk rather than being handed its source text: one
+        # copy of the function, and the file is already the thing the unit tests execute.
+        # $TransportScriptPath is the test seam - see Start-OmadaBackgroundRequest's note below.
+        [void]$Private:Shell.AddScript({
+                param($CorePath, $RequestParameters, $TransportScriptPath, $TransportContext)
+                . $CorePath
+                if (![string]::IsNullOrWhiteSpace($TransportScriptPath) -and (Test-Path -LiteralPath $TransportScriptPath)) {
+                    . $TransportScriptPath
+                    $Initializer = Get-Command -Name Initialize-OmadaRequestWorkerTransport -ErrorAction SilentlyContinue
+                    if ($null -ne $Initializer) {
+                        Initialize-OmadaRequestWorkerTransport -Context $TransportContext
+                    }
+                }
+                return (Invoke-OmadaRequestCore -Parameters $RequestParameters)
+            }).AddArgument($Private:CorePath).AddArgument($Parameters.Clone()).AddArgument($Script:OmadaRequestWorkerTransportPath).AddArgument($Script:OmadaRequestWorkerTransportContext)
+
+        $Private:AsyncResult = $Private:Shell.BeginInvoke()
+
+        $Private:Pending = [PSCustomObject]@{
+            # Named Task, and polled through IsCompleted, so the existing Tick handler needs no
+            # change. This is an IAsyncResult, NOT a WebView2 Task - see IsBackgroundRequest.
+            Task                   = $Private:AsyncResult
+            Shell                  = $Private:Shell
+            TabSession             = $TabSession
+            OnCompletedScriptBlock = $OnCompletedScriptBlock
+            StartedUtc             = [DateTime]::UtcNow
+            IsCancelled            = $false
+            IsBackgroundRequest    = $true
+            Description            = $Description
+            Context                = $Context
+        }
+
+        # Deliberately NOT assigned to $Script:Task or $TabSession.PendingTask. That field belongs
+        # exclusively to the WebView2 editor task: Set-ActiveTabContext saves and restores it per
+        # tab, and half a dozen call sites read $Script:Task.Status expecting "RanToCompletion".
+        # An IAsyncResult has no Status property, so parking one there would silently turn every one
+        # of those reads into $null. Background requests live in the queue and nowhere else.
+        $Script:PendingWebViewCompletions.Add($Private:Pending)
+
+        "Dispatched background request: {0}" -f $Description | Write-LogOutput -LogType DEBUG
+        return $Private:Pending
+    }
+    catch {
+        "Could not dispatch a background request ({0}); it will run on the UI thread. {1}" -f $Description, $_.Exception.Message | Write-LogOutput -LogType WARNING -SkipDialog
+        return $null
+    }
+}

--- a/src/Lib/Functions/Private/Test-OmadaBackgroundRequestEligible.ps1
+++ b/src/Lib/Functions/Private/Test-OmadaBackgroundRequestEligible.ps1
@@ -1,0 +1,56 @@
+function Test-OmadaBackgroundRequestEligible {
+    <#
+    .SYNOPSIS
+    Decide whether a request may be dispatched to a background worker, or must run on the UI thread.
+
+    .DESCRIPTION
+    This is where issue #40's authentication policy is expressed: interactive authentication happens
+    on the UI thread, or it does not happen.
+
+    OmadaWeb.PS authenticates by opening a WinForms modal on whatever thread calls it. From a worker
+    that dialog would have no owner window - not modal to this app, possibly behind the main window,
+    with the app fully interactive behind it. So off-thread execution is only ever offered for a
+    session that is ALREADY authenticated, where OmadaWeb.PS answers from its encrypted on-disk
+    cookie cache and never opens a window at all.
+
+    Two conditions, and both are about that:
+
+      - The tab must be connected. $Script:ConnectionStatus is set only by Set-SqlConnectionState
+        after Test-OmadaConnection succeeded, which is the UI-thread path where a login prompt is
+        shown with a proper owner. A connected tab therefore has a cookie on disk for its SessionKey,
+        which a fresh worker runspace - whose own OmadaWeb.PS session table is empty - will load.
+
+      - ForceAuthentication must not be set. That flag exists to make OmadaWeb.PS bypass the cookie
+        cache and re-authenticate, which is a request to open the login window. It must be honoured
+        on the UI thread.
+
+    .NOTES
+    This is a gate, not a guarantee. A cookie that expires between connecting and issuing a
+    background request would still send the worker down the authentication path - where the MTA
+    apartment of the pool (see Initialize-OmadaRequestPool) turns it into a clean failure rather than
+    an ownerless window, and the failure comes back to the UI thread to be re-driven. That residual
+    case is only observable against a live tenant: the mock replaces Invoke-OmadaRestMethod outright,
+    so no authentication ever happens under test.
+
+    .PARAMETER Parameters
+    The prepared Invoke-OmadaRestMethod splat for the request being considered.
+
+    .OUTPUTS
+    [bool] - $true when the request may go to a worker.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [hashtable]$Parameters
+    )
+
+    if (-not $Script:ConnectionStatus) {
+        return $false
+    }
+
+    if ($true -eq $Parameters.ForceAuthentication) {
+        return $false
+    }
+
+    return $true
+}

--- a/tests/Build-OmadaRequestParameter.Tests.ps1
+++ b/tests/Build-OmadaRequestParameter.Tests.ps1
@@ -1,0 +1,115 @@
+#Requires -Version 7.0
+# The request-preparation rules, extracted from Invoke-OmadaPSWebRequestWrapper by issue #40 so the
+# synchronous and background paths prepare a request identically. These assert the rules directly,
+# where Invoke-OmadaPSWebRequestWrapper.Tests.ps1 continues to assert them through the wrapper - so
+# a change that breaks preparation fails in a test that names it, not only in a transport test.
+
+BeforeAll {
+    $ParentPath = Split-Path -Path $PSScriptRoot -Parent
+    $PrivatePath = Join-Path $ParentPath -ChildPath "src\Lib\Functions\Private"
+    . (Join-Path $PrivatePath -ChildPath "Build-OmadaRequestParameter.ps1")
+
+    function script:Initialize-PreparationState {
+        param(
+            [string]$AuthenticationType = "Browser",
+            [bool]$UseWebView2Auth = $false,
+            $Body = $null
+        )
+        $Script:RunTimeConfig = [PSCustomObject]@{ UseWebView2Auth = $UseWebView2Auth }
+        $Script:SkipBodyRedaction = $false
+        $Script:RunTimeData = [PSCustomObject]@{
+            RestMethodParam = @{
+                Uri                = "https://tenant.omada.cloud/probe"
+                Method             = "GET"
+                AuthenticationType = $AuthenticationType
+                Body               = $Body
+            }
+        }
+    }
+
+    function Invoke-OmadaRestMethod {
+        [CmdletBinding()]
+        param([Parameter(ValueFromRemainingArguments = $true)]$IgnoredRest)
+    }
+}
+
+Describe "Build-OmadaRequestParameter" {
+    It "enables WebView2 only for Browser authentication when the session asked for it" {
+        Initialize-PreparationState -AuthenticationType "Browser" -UseWebView2Auth $true
+
+        (Build-OmadaRequestParameter).UseWebView2 | Should -BeTrue
+    }
+
+    It "leaves WebView2 off for Browser authentication when the session did not ask for it" {
+        Initialize-PreparationState -AuthenticationType "Browser" -UseWebView2Auth $false
+
+        (Build-OmadaRequestParameter).UseWebView2 | Should -BeFalse
+    }
+
+    It "never enables WebView2 for a non-Browser authentication option" {
+        Initialize-PreparationState -AuthenticationType "Windows" -UseWebView2Auth $true
+
+        (Build-OmadaRequestParameter).UseWebView2 | Should -BeFalse
+    }
+
+    It "removes a null Body rather than sending one" {
+        Initialize-PreparationState -Body $null
+
+        (Build-OmadaRequestParameter).ContainsKey("Body") | Should -BeFalse
+    }
+
+    It "keeps a populated Body" {
+        Initialize-PreparationState -Body @{ dataType = "SqlDataProducer" }
+
+        (Build-OmadaRequestParameter).Body.dataType | Should -Be "SqlDataProducer"
+    }
+
+    It "returns the live RestMethodParam instance, which is why dispatchers must clone it" {
+        # Documented behaviour, not an accident: the wrapper has always mutated and reused this one
+        # hashtable. It is exactly why Start-OmadaBackgroundRequest clones before crossing into a
+        # worker - the next call site overwrites Uri, Method and Body under a request in flight.
+        Initialize-PreparationState
+
+        [object]::ReferenceEquals((Build-OmadaRequestParameter), $Script:RunTimeData.RestMethodParam) | Should -BeTrue
+    }
+
+    Context "SkipBodyRedaction capability check" {
+        It "does not add the key when the installed OmadaWeb.PS does not declare it" {
+            # Splatting a parameter a cmdlet does not have is a terminating error, so the key must
+            # stay out rather than be passed and fail.
+            Initialize-PreparationState
+            $Script:SkipBodyRedaction = $true
+
+            function Invoke-OmadaRestMethod {
+                [CmdletBinding()]
+                param([Parameter(ValueFromRemainingArguments = $true)]$IgnoredRest)
+            }
+
+            (Build-OmadaRequestParameter).ContainsKey("SkipBodyRedaction") | Should -BeFalse
+        }
+
+        It "passes the current state when the installed OmadaWeb.PS declares it" {
+            Initialize-PreparationState
+            $Script:SkipBodyRedaction = $true
+
+            function Invoke-OmadaRestMethod {
+                [CmdletBinding()]
+                param([switch]$SkipBodyRedaction, [Parameter(ValueFromRemainingArguments = $true)]$IgnoredRest)
+            }
+
+            (Build-OmadaRequestParameter).SkipBodyRedaction | Should -BeTrue
+        }
+
+        It "drops a stale key when the module was downgraded mid-session" {
+            Initialize-PreparationState
+            $Script:RunTimeData.RestMethodParam.SkipBodyRedaction = $true
+
+            function Invoke-OmadaRestMethod {
+                [CmdletBinding()]
+                param([Parameter(ValueFromRemainingArguments = $true)]$IgnoredRest)
+            }
+
+            (Build-OmadaRequestParameter).ContainsKey("SkipBodyRedaction") | Should -BeFalse
+        }
+    }
+}

--- a/tests/Complete-OmadaBackgroundRequest.Tests.ps1
+++ b/tests/Complete-OmadaBackgroundRequest.Tests.ps1
@@ -1,0 +1,118 @@
+#Requires -Version 7.0
+# Tests for collecting a background request's outcome on the UI thread (issue #40).
+#
+# These run against REAL [powershell] pipelines rather than stubs, because the two behaviours that
+# matter here are behaviours of PowerShell itself:
+#   - EndInvoke on a pipeline that was stopped THROWS, so the cancelled case must be detected before
+#     EndInvoke is called and not caught afterwards;
+#   - the core's hashtable arrives wrapped in the pipeline's output collection.
+# A stubbed shell would let either of those regress silently.
+
+BeforeAll {
+    $ParentPath = Split-Path -Path $PSScriptRoot -Parent
+    $PrivatePath = Join-Path $ParentPath -ChildPath "src\Lib\Functions\Private"
+    . (Join-Path $PrivatePath -ChildPath "Complete-OmadaBackgroundRequest.ps1")
+
+    function script:New-TestPending {
+        param(
+            [scriptblock]$Body,
+            [switch]$Cancelled
+        )
+        $Shell = [powershell]::Create()
+        [void]$Shell.AddScript($Body)
+        $Async = $Shell.BeginInvoke()
+        return [pscustomobject]@{
+            Task        = $Async
+            Shell       = $Shell
+            IsCancelled = [bool]$Cancelled
+            Description = "test request"
+        }
+    }
+
+    function script:Wait-TestPending {
+        param($Pending, [int]$TimeoutMs = 10000)
+        $Deadline = [DateTime]::UtcNow.AddMilliseconds($TimeoutMs)
+        while (-not $Pending.Task.IsCompleted -and [DateTime]::UtcNow -lt $Deadline) {
+            Start-Sleep -Milliseconds 20
+        }
+    }
+}
+
+Describe "Complete-OmadaBackgroundRequest" {
+    It "unwraps the core's contract out of the pipeline output" {
+        $Pending = New-TestPending -Body { return @{ Result = [pscustomobject]@{ d = "schema" }; ErrorRecord = $null } }
+        Wait-TestPending -Pending $Pending
+
+        $Outcome = Complete-OmadaBackgroundRequest -Pending $Pending
+
+        $Outcome.Result.d | Should -Be "schema"
+        $Outcome.ErrorRecord | Should -BeNullOrEmpty
+        $Outcome.IsCancelled | Should -BeFalse
+    }
+
+    It "carries a returned ErrorRecord through unchanged" {
+        $Pending = New-TestPending -Body {
+            $ErrorRecord = [System.Management.Automation.ErrorRecord]::new(
+                [System.Exception]::new("transport failed"), "OmadaTransportFailure",
+                [System.Management.Automation.ErrorCategory]::ConnectionError, $null)
+            return @{ Result = $null; ErrorRecord = $ErrorRecord }
+        }
+        Wait-TestPending -Pending $Pending
+
+        $Outcome = Complete-OmadaBackgroundRequest -Pending $Pending
+
+        $Outcome.Result | Should -BeNullOrEmpty
+        $Outcome.ErrorRecord.Exception.Message | Should -Be "transport failed"
+    }
+
+    It "reports a cancelled request as cancelled, with neither a result nor an error" {
+        # Nothing failed - the caller stopped waiting. Reporting an error here would put an error
+        # dialog in front of a user who had just clicked Cancel.
+        $Pending = New-TestPending -Body { Start-Sleep -Seconds 30; return @{ Result = "late"; ErrorRecord = $null } }
+        Start-Sleep -Milliseconds 150
+        $Pending.Shell.BeginStop($null, $null) | Out-Null
+        $Pending.IsCancelled = $true
+        Wait-TestPending -Pending $Pending
+
+        $Outcome = Complete-OmadaBackgroundRequest -Pending $Pending
+
+        $Outcome.IsCancelled | Should -BeTrue
+        $Outcome.Result | Should -BeNullOrEmpty
+        $Outcome.ErrorRecord | Should -BeNullOrEmpty
+    }
+
+    It "does not throw when EndInvoke would - a stopped pipeline that was not marked cancelled" {
+        # The defensive half of the case above: EndInvoke on a stopped pipeline throws, and this
+        # function must turn that into a reported failure rather than an exception escaping into the
+        # completion poll timer.
+        $Pending = New-TestPending -Body { Start-Sleep -Seconds 30 }
+        Start-Sleep -Milliseconds 150
+        $Pending.Shell.BeginStop($null, $null) | Out-Null
+        Wait-TestPending -Pending $Pending
+
+        { Complete-OmadaBackgroundRequest -Pending $Pending } | Should -Not -Throw
+    }
+
+    It "surfaces the worker's error stream when the worker returned nothing usable" {
+        $Pending = New-TestPending -Body { Write-Error "worker blew up"; return "not the contract" }
+        Wait-TestPending -Pending $Pending
+
+        $Outcome = Complete-OmadaBackgroundRequest -Pending $Pending
+
+        $Outcome.Result | Should -BeNullOrEmpty
+        $Outcome.ErrorRecord | Should -Not -BeNullOrEmpty
+        [string]$Outcome.ErrorRecord | Should -Match "worker blew up"
+    }
+
+    It "disposes the shell so a stopped worker's runspace is never reused" {
+        # A pipeline killed mid-request leaves a half-read HTTP stream and a WebRequestSession in an
+        # unknown state, so its runspace must be discarded rather than handed to the next query.
+        # Disposing is what releases it - and a disposed [powershell] refuses further invocation.
+        $Pending = New-TestPending -Body { return @{ Result = "ok"; ErrorRecord = $null } }
+        Wait-TestPending -Pending $Pending
+
+        Complete-OmadaBackgroundRequest -Pending $Pending | Out-Null
+
+        { $Pending.Shell.AddScript({ 1 }) } | Should -Throw
+    }
+}

--- a/tests/Get-SqlSchema.Tests.ps1
+++ b/tests/Get-SqlSchema.Tests.ps1
@@ -14,6 +14,14 @@ BeforeAll {
 
     . (Join-Path $PrivatePath -ChildPath "ConvertTo-RedactedLogString.ps1")
     . (Join-Path $PrivatePath -ChildPath "Test-ConnectionRequirements.ps1")
+    # Issue #40 split the wrapper: the request itself into Invoke-OmadaRequestCore, and the
+    # preparation and failure classification into these two. All are dot-sourced for the same reason
+    # the Suspend/Resume stubs below exist - a missing one throws CommandNotFound inside
+    # Get-SqlSchemaObject's own catch, and the "zero requests" assertion then passes for entirely the
+    # wrong reason.
+    . (Join-Path $PrivatePath -ChildPath "Invoke-OmadaRequestCore.ps1")
+    . (Join-Path $PrivatePath -ChildPath "Build-OmadaRequestParameter.ps1")
+    . (Join-Path $PrivatePath -ChildPath "Resolve-OmadaRequestFailure.ps1")
     . (Join-Path $PrivatePath -ChildPath "Invoke-OmadaPSWebRequestWrapper.ps1")
     . (Join-Path $PrivatePath -ChildPath "Get-SqlSchema.ps1")
 
@@ -68,6 +76,37 @@ BeforeAll {
 
     function Get-ActiveTabSession { return $null }
 
+    # The background dispatch seam (issue #40). Its own behaviour is covered by
+    # Test-OmadaBackgroundRequestEligible.Tests.ps1 and Complete-OmadaBackgroundRequest.Tests.ps1;
+    # here it is steered so this file can test both of Get-SqlSchemaObject's paths deliberately
+    # rather than depending on whether a worker happened to be available.
+    #
+    #   $null              => not dispatched, so the function falls back to the synchronous wrapper.
+    #                         This is the default, and it is what keeps the guard tests below
+    #                         measuring real requests against the real mock instance.
+    #   "InvokeInline"     => dispatched and completed immediately, so the completion block runs -
+    #                         which is how the wiring from a background response through to
+    #                         Complete-SqlSchemaRetrieval is exercised without a runspace.
+    $script:AsyncDispatchBehaviour = "Fallback"
+
+    function Invoke-OmadaPSWebRequestWrapperAsync {
+        param(
+            [scriptblock]$OnResultScriptBlock,
+            $Context,
+            [string]$Description
+        )
+        if ($script:AsyncDispatchBehaviour -ne "InvokeInline") {
+            return $null
+        }
+        $Pending = [pscustomobject]@{
+            Description = $Description
+            Context     = @{ Caller = $Context; OnResult = $OnResultScriptBlock }
+            Outcome     = $script:AsyncDispatchOutcome
+        }
+        & $OnResultScriptBlock $Pending
+        return $Pending
+    }
+
     function Initialize-SchemaTestState {
         <#
         Puts the module-scope state into the shape a RESTORED tab has: a tenant URL and an
@@ -108,6 +147,8 @@ BeforeAll {
         $Script:ConnectionStatus = $Connected
 
         $script:PushedEditorScripts.Clear()
+        $script:AsyncDispatchBehaviour = "Fallback"
+        $script:AsyncDispatchOutcome = $null
         Clear-OmadaMockRequestLog
     }
 }
@@ -160,5 +201,68 @@ Describe "Get-SqlSchemaObject connection guard" {
         Get-SqlSchemaObject
 
         (Get-OmadaMockRequestLog).Count | Should -Be 0
+    }
+}
+
+Describe "Get-SqlSchemaObject background dispatch (issue #40)" {
+    It "falls back to a synchronous request when nothing was dispatched" {
+        # The contract that keeps this change safe: a request that may not, or cannot, go to a worker
+        # still happens - it just happens inline, exactly as before.
+        Initialize-SchemaTestState -Connected $true
+        $script:AsyncDispatchBehaviour = "Fallback"
+
+        Get-SqlSchemaObject
+
+        (Get-OmadaMockRequestLog -UriLike "*GetSqlSchema*" -MethodLike "POST").Count | Should -Be 1
+    }
+
+    It "makes no synchronous request when the work was dispatched" {
+        # The other half: a dispatched request must not ALSO be issued inline. Getting this wrong
+        # would double every schema fetch, silently.
+        Initialize-SchemaTestState -Connected $true
+        $script:AsyncDispatchBehaviour = "InvokeInline"
+        $script:AsyncDispatchOutcome = [pscustomobject]@{ d = [pscustomobject]@{ "dbo.tblX" = @("Id int NOT NULL") } }
+
+        Get-SqlSchemaObject
+
+        (Get-OmadaMockRequestLog -UriLike "*GetSqlSchema*").Count | Should -Be 0
+    }
+
+    It "drives the schema through to the editor from a background response" {
+        Initialize-SchemaTestState -Connected $true
+        $script:AsyncDispatchBehaviour = "InvokeInline"
+        $script:AsyncDispatchOutcome = [pscustomobject]@{ d = [pscustomobject]@{ "dbo.tblX" = @("Id int NOT NULL") } }
+
+        Get-SqlSchemaObject
+
+        $SetSchema = $script:PushedEditorScripts | Where-Object { $_ -like "setSchema(*" } | Select-Object -Last 1
+        $SetSchema | Should -Not -BeNullOrEmpty
+        $SetSchema | Should -BeLike "*tblX*"
+    }
+
+    It "caches a background response under the key the request was issued for, not a re-derived one" {
+        # The completion block reads its cache key from the pending item. Re-deriving it would use
+        # whatever tab is active by the time the response lands, which is how a schema ends up filed
+        # under - and later served to - the wrong connection.
+        Initialize-SchemaTestState -Connected $true
+        $script:AsyncDispatchBehaviour = "InvokeInline"
+        $script:AsyncDispatchOutcome = [pscustomobject]@{ d = [pscustomobject]@{ "dbo.tblX" = @("Id int NOT NULL") } }
+
+        Get-SqlSchemaObject
+
+        $Script:SqlSchemaCache.ContainsKey("pool-under-test|1001572") | Should -BeTrue
+    }
+
+    It "reports a background failure without caching it" {
+        Initialize-SchemaTestState -Connected $true
+        $script:AsyncDispatchBehaviour = "InvokeInline"
+        $script:AsyncDispatchOutcome = [System.Management.Automation.ErrorRecord]::new(
+            [System.Exception]::new("boom"), "OmadaSchemaFailure",
+            [System.Management.Automation.ErrorCategory]::ConnectionError, $null)
+
+        Get-SqlSchemaObject
+
+        $Script:SqlSchemaCache.Count | Should -Be 0
+        $script:PushedEditorScripts.Count | Should -Be 0
     }
 }

--- a/tests/Invoke-OmadaPSWebRequestWrapper.Tests.ps1
+++ b/tests/Invoke-OmadaPSWebRequestWrapper.Tests.ps1
@@ -22,6 +22,11 @@ BeforeAll {
     # real core is dot-sourced here rather than stubbed: these tests are the contract that the split
     # changed nothing, which only holds if the actual call path is exercised.
     . (Join-Path $PrivatePath -ChildPath "Invoke-OmadaRequestCore.ps1")
+    # Preparation and failure classification were extracted so the background path (issue #40)
+    # applies the same rules. The real ones are dot-sourced, not stubbed: these tests are the
+    # contract that the extraction changed nothing, which only holds if the actual code runs.
+    . (Join-Path $PrivatePath -ChildPath "Build-OmadaRequestParameter.ps1")
+    . (Join-Path $PrivatePath -ChildPath "Resolve-OmadaRequestFailure.ps1")
     . (Join-Path $PrivatePath -ChildPath "Invoke-OmadaPSWebRequestWrapper.ps1")
 
     $Script:Tracer = [System.Diagnostics.Trace]

--- a/tests/Invoke-OmadaPSWebRequestWrapperAsync.Tests.ps1
+++ b/tests/Invoke-OmadaPSWebRequestWrapperAsync.Tests.ps1
@@ -1,0 +1,229 @@
+#Requires -Version 7.0
+# The dispatch decision (issue #40).
+#
+# The single most important property of this function is its FALLBACK contract: it returns $null,
+# having done nothing at all, whenever a request may not or cannot go to a worker - and the caller
+# then issues it inline exactly as before. A bug here is not "the request was slow", it is "the
+# request never happened" or "the request happened twice", so each refusal path is asserted
+# individually along with the fact that no dispatch occurred.
+
+BeforeAll {
+    $ParentPath = Split-Path -Path $PSScriptRoot -Parent
+    $PrivatePath = Join-Path $ParentPath -ChildPath "src\Lib\Functions\Private"
+
+    . (Join-Path $PrivatePath -ChildPath "ConvertTo-RedactedLogString.ps1")
+    . (Join-Path $PrivatePath -ChildPath "Build-OmadaRequestParameter.ps1")
+    . (Join-Path $PrivatePath -ChildPath "Test-OmadaBackgroundRequestEligible.ps1")
+    . (Join-Path $PrivatePath -ChildPath "Resolve-OmadaRequestFailure.ps1")
+    . (Join-Path $PrivatePath -ChildPath "Invoke-OmadaPSWebRequestWrapperAsync.ps1")
+
+    $Script:Tracer = [System.Diagnostics.Trace]
+
+    function Write-LogOutput {
+        param(
+            [Parameter(ValueFromPipeline = $true)]$InputObject,
+            [string]$LogType,
+            $ErrorObject,
+            [switch]$SkipDialog
+        )
+        process { }
+    }
+
+    function Invoke-OmadaRestMethod {
+        [CmdletBinding()]
+        param([Parameter(ValueFromRemainingArguments = $true)]$IgnoredRest)
+    }
+
+    function Set-SqlConnectionState { param([bool]$Status = $true) }
+
+    function Get-ActiveTabSession { return $script:StubTabSession }
+
+    # Records what was dispatched and, when asked, completes it immediately so the completion block
+    # can be exercised without a runspace. The real dispatcher has its own tests.
+    $script:Dispatches = [System.Collections.Generic.List[object]]::new()
+
+    function Start-OmadaBackgroundRequest {
+        param(
+            [hashtable]$Parameters,
+            $TabSession,
+            [scriptblock]$OnCompletedScriptBlock,
+            $Context,
+            [string]$Description
+        )
+        if ($script:DispatchBehaviour -eq "Unavailable") {
+            return $null
+        }
+        $Pending = [pscustomobject]@{
+            Task        = $null
+            Shell       = $null
+            TabSession  = $TabSession
+            Context     = $Context
+            Description = $Description
+            Parameters  = $Parameters
+            IsCancelled = $false
+        }
+        $script:Dispatches.Add($Pending)
+        if ($script:DispatchBehaviour -eq "CompleteInline") {
+            & $OnCompletedScriptBlock $Pending
+        }
+        return $Pending
+    }
+
+    function Complete-OmadaBackgroundRequest {
+        param($Pending)
+        return $script:WorkerOutcome
+    }
+
+    function script:Initialize-AsyncTestState {
+        param([bool]$Connected = $true, [bool]$SkipRetry = $false, [bool]$ForceAuthentication = $false)
+
+        $Script:RunTimeConfig = [PSCustomObject]@{ ApplicationName = "Test"; UseWebView2Auth = $false }
+        $Script:AppConfig = [PSCustomObject]@{ BaseUrl = "https://tenant.omada.cloud" }
+        $Script:SkipBodyRedaction = $false
+        $Script:RunTimeData = [PSCustomObject]@{
+            SkipRetryRequest = $SkipRetry
+            RestMethodParam  = @{
+                Uri                 = "https://tenant.omada.cloud/probe"
+                Method              = "GET"
+                AuthenticationType  = "Browser"
+                ForceAuthentication = $ForceAuthentication
+            }
+        }
+        $Script:ConnectionStatus = $Connected
+        $script:StubTabSession = [pscustomobject]@{ Id = "tab-1" }
+        $script:DispatchBehaviour = "Dispatch"
+        $script:WorkerOutcome = @{ Result = $null; ErrorRecord = $null; IsCancelled = $false }
+        $script:Dispatches.Clear()
+    }
+}
+
+Describe "Invoke-OmadaPSWebRequestWrapperAsync refuses to dispatch" {
+    It "returns null and dispatches nothing when the tab is not connected" {
+        Initialize-AsyncTestState -Connected $false
+
+        Invoke-OmadaPSWebRequestWrapperAsync -OnResultScriptBlock { } | Should -BeNullOrEmpty
+        $script:Dispatches.Count | Should -Be 0
+    }
+
+    It "returns null and dispatches nothing when the request forces authentication" {
+        Initialize-AsyncTestState -Connected $true -ForceAuthentication $true
+
+        Invoke-OmadaPSWebRequestWrapperAsync -OnResultScriptBlock { } | Should -BeNullOrEmpty
+        $script:Dispatches.Count | Should -Be 0
+    }
+
+    It "returns null and dispatches nothing when SkipRetryRequest is set" {
+        # The synchronous wrapper answers $null for this WITHOUT making a request. Dispatching here
+        # would turn a deliberately suppressed request into a real one.
+        Initialize-AsyncTestState -SkipRetry $true
+
+        Invoke-OmadaPSWebRequestWrapperAsync -OnResultScriptBlock { } | Should -BeNullOrEmpty
+        $script:Dispatches.Count | Should -Be 0
+    }
+
+    It "returns null when there is no active tab to attribute the request to" {
+        Initialize-AsyncTestState
+        $script:StubTabSession = $null
+
+        Invoke-OmadaPSWebRequestWrapperAsync -OnResultScriptBlock { } | Should -BeNullOrEmpty
+    }
+
+    It "returns null when no worker could be had" {
+        Initialize-AsyncTestState
+        $script:DispatchBehaviour = "Unavailable"
+
+        Invoke-OmadaPSWebRequestWrapperAsync -OnResultScriptBlock { } | Should -BeNullOrEmpty
+    }
+}
+
+Describe "Invoke-OmadaPSWebRequestWrapperAsync dispatches" {
+    It "dispatches a prepared request for a connected tab" {
+        Initialize-AsyncTestState
+
+        $Pending = Invoke-OmadaPSWebRequestWrapperAsync -OnResultScriptBlock { } -Description "probe"
+
+        $Pending | Should -Not -BeNullOrEmpty
+        $script:Dispatches.Count | Should -Be 1
+        $script:Dispatches[0].Description | Should -Be "probe"
+        # Prepared, not raw: Build-OmadaRequestParameter has run over it.
+        $script:Dispatches[0].Parameters.ContainsKey("UseWebView2") | Should -BeTrue
+    }
+
+    It "carries the caller's context through to the completion block" {
+        Initialize-AsyncTestState
+        $script:DispatchBehaviour = "CompleteInline"
+        $script:WorkerOutcome = @{ Result = "the response"; ErrorRecord = $null; IsCancelled = $false }
+        $script:SeenContext = $null
+
+        Invoke-OmadaPSWebRequestWrapperAsync -Context @{ CacheKey = "pool|42" } -OnResultScriptBlock {
+            param($Pending)
+            $script:SeenContext = $Pending.Context.Caller.CacheKey
+        } | Out-Null
+
+        $script:SeenContext | Should -Be "pool|42"
+    }
+
+    It "hands the response to the result block as Outcome" {
+        Initialize-AsyncTestState
+        $script:DispatchBehaviour = "CompleteInline"
+        $script:WorkerOutcome = @{ Result = [pscustomobject]@{ d = "payload" }; ErrorRecord = $null; IsCancelled = $false }
+        $script:SeenOutcome = $null
+
+        Invoke-OmadaPSWebRequestWrapperAsync -OnResultScriptBlock {
+            param($Pending)
+            $script:SeenOutcome = $Pending.Outcome
+        } | Out-Null
+
+        $script:SeenOutcome.d | Should -Be "payload"
+    }
+
+    It "passes an unclassified failure to the result block as an ErrorRecord" {
+        # The same contract the synchronous wrapper has: callers test the result with
+        # -is [ErrorRecord], so a background failure has to arrive in that shape too.
+        Initialize-AsyncTestState
+        $script:DispatchBehaviour = "CompleteInline"
+        $script:WorkerOutcome = @{
+            Result      = $null
+            ErrorRecord = [System.Management.Automation.ErrorRecord]::new(
+                [System.Exception]::new("network down"), "OmadaFailure",
+                [System.Management.Automation.ErrorCategory]::ConnectionError, $null)
+            IsCancelled = $false
+        }
+        $script:SeenOutcome = $null
+
+        Invoke-OmadaPSWebRequestWrapperAsync -OnResultScriptBlock {
+            param($Pending)
+            $script:SeenOutcome = $Pending.Outcome
+        } | Out-Null
+
+        $script:SeenOutcome | Should -BeOfType [System.Management.Automation.ErrorRecord]
+        $script:SeenOutcome.Exception.Message | Should -Be "network down"
+    }
+
+    It "does not invoke the result block for a cancelled request" {
+        # Nothing failed and nothing succeeded: the caller stopped waiting. Running the result block
+        # would bind a null result over a perfectly good previous one.
+        Initialize-AsyncTestState
+        $script:DispatchBehaviour = "CompleteInline"
+        $script:WorkerOutcome = @{ Result = $null; ErrorRecord = $null; IsCancelled = $true }
+        $script:ResultBlockRuns = 0
+
+        Invoke-OmadaPSWebRequestWrapperAsync -OnResultScriptBlock {
+            param($Pending)
+            $script:ResultBlockRuns++
+        } | Out-Null
+
+        $script:ResultBlockRuns | Should -Be 0
+    }
+
+    It "clears ForceAuthentication after a successful background request, as the inline path does" {
+        Initialize-AsyncTestState
+        $Script:RunTimeData.RestMethodParam.ForceAuthentication = $false
+        $script:DispatchBehaviour = "CompleteInline"
+        $script:WorkerOutcome = @{ Result = "ok"; ErrorRecord = $null; IsCancelled = $false }
+
+        Invoke-OmadaPSWebRequestWrapperAsync -OnResultScriptBlock { } | Out-Null
+
+        $Script:RunTimeData.RestMethodParam.ForceAuthentication | Should -BeFalse
+    }
+}

--- a/tests/Test-OmadaBackgroundRequestEligible.Tests.ps1
+++ b/tests/Test-OmadaBackgroundRequestEligible.Tests.ps1
@@ -1,0 +1,60 @@
+#Requires -Version 7.0
+# Issue #40's authentication policy, expressed as tests.
+#
+# The policy is: interactive authentication happens on the UI thread, or it does not happen.
+# OmadaWeb.PS authenticates by opening a WinForms modal on whatever thread calls it, and from a
+# worker that dialog would have no owner window - not modal to this app, possibly behind the main
+# window, with the app fully interactive behind it. So a request only goes to a worker when the
+# session is already authenticated and is not asking to authenticate again.
+
+BeforeAll {
+    $ParentPath = Split-Path -Path $PSScriptRoot -Parent
+    $PrivatePath = Join-Path $ParentPath -ChildPath "src\Lib\Functions\Private"
+    . (Join-Path $PrivatePath -ChildPath "Test-OmadaBackgroundRequestEligible.ps1")
+}
+
+Describe "Test-OmadaBackgroundRequestEligible" {
+    It "allows a connected tab whose request does not force authentication" {
+        $Script:ConnectionStatus = $true
+
+        Test-OmadaBackgroundRequestEligible -Parameters @{ ForceAuthentication = $false } | Should -BeTrue
+    }
+
+    It "allows a connected tab whose request omits ForceAuthentication entirely" {
+        $Script:ConnectionStatus = $true
+
+        Test-OmadaBackgroundRequestEligible -Parameters @{ Uri = "https://tenant.omada.cloud/probe" } | Should -BeTrue
+    }
+
+    It "refuses a tab that is not connected" {
+        # Not connected means no successful Test-OmadaConnection on the UI thread, so no cookie on
+        # disk for this SessionKey - and a worker with an empty session table would go looking for
+        # one by opening a login window.
+        $Script:ConnectionStatus = $false
+
+        Test-OmadaBackgroundRequestEligible -Parameters @{ ForceAuthentication = $false } | Should -BeFalse
+    }
+
+    It "refuses a request that asks to re-authenticate, even on a connected tab" {
+        # ForceAuthentication exists to make OmadaWeb.PS bypass its cookie cache and authenticate
+        # again - which is a request to open the login window. That has to happen where the window
+        # can have an owner.
+        $Script:ConnectionStatus = $true
+
+        Test-OmadaBackgroundRequestEligible -Parameters @{ ForceAuthentication = $true } | Should -BeFalse
+    }
+
+    It "refuses on both counts at once" {
+        $Script:ConnectionStatus = $false
+
+        Test-OmadaBackgroundRequestEligible -Parameters @{ ForceAuthentication = $true } | Should -BeFalse
+    }
+
+    It "requires the Parameters argument" {
+        # Asserted as metadata: calling without a mandatory parameter prompts, which hangs an
+        # unattended run.
+        (Get-Command Test-OmadaBackgroundRequestEligible).Parameters["Parameters"].Attributes |
+            Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] } |
+            ForEach-Object { $_.Mandatory } | Should -Contain $true
+    }
+}

--- a/tests/Update-QueryList.Tests.ps1
+++ b/tests/Update-QueryList.Tests.ps1
@@ -25,6 +25,13 @@ BeforeAll {
 
     . (Join-Path $PrivatePath -ChildPath "ConvertTo-RedactedLogString.ps1")
     . (Join-Path $PrivatePath -ChildPath "Test-ConnectionRequirements.ps1")
+    # Issue #40 split the wrapper: the request itself into Invoke-OmadaRequestCore, and the
+    # preparation and failure classification into these two. All are dot-sourced for the reason the
+    # Suspend/Resume stubs below exist - a missing one throws CommandNotFound inside the caller's own
+    # catch, and a "no request was made" assertion then passes for entirely the wrong reason.
+    . (Join-Path $PrivatePath -ChildPath "Invoke-OmadaRequestCore.ps1")
+    . (Join-Path $PrivatePath -ChildPath "Build-OmadaRequestParameter.ps1")
+    . (Join-Path $PrivatePath -ChildPath "Resolve-OmadaRequestFailure.ps1")
     . (Join-Path $PrivatePath -ChildPath "Invoke-OmadaPSWebRequestWrapper.ps1")
     . (Join-Path $PrivatePath -ChildPath "Update-QueryList.ps1")
 

--- a/tests/mock/Install-OmadaMockTransport.ps1
+++ b/tests/mock/Install-OmadaMockTransport.ps1
@@ -21,12 +21,51 @@ $script:OmadaMockBaseUrl = $null
 # Every request the app makes reaches the mock instance through the shim below, so recording them
 # here gives a test an exact, complete picture of what did (or did not) hit the tenant. Tests that
 # assert a code path performs NO authenticated request read this log.
-$script:OmadaMockRequestLog = [System.Collections.Generic.List[object]]::new()
+# Synchronized, and an ArrayList rather than a List[object], because issue #40 lets requests run in
+# worker runspaces: the workers append to this same instance so Get-OmadaMockRequestLog in the app's
+# runspace sees every request, whichever thread made it.
+$script:OmadaMockRequestLog = [System.Collections.ArrayList]::Synchronized([System.Collections.ArrayList]::new())
 
 function Install-OmadaMockTransport {
     [CmdletBinding()]
     param([string]$MockBaseUrl)
     $script:OmadaMockBaseUrl = $MockBaseUrl
+
+    # Issue #40: requests now also run in worker runspaces, which have their own copy of OmadaWeb.PS
+    # and would therefore call the REAL Invoke-OmadaRestMethod - reaching past this shim to whatever
+    # tenant URL the app built. Registering this file and its configuration on the two
+    # $Script:OmadaRequestWorkerTransport* variables tells Start-OmadaBackgroundRequest to dot-source
+    # it in the worker and call Initialize-OmadaRequestWorkerTransport there, so the shim covers the
+    # background path exactly as it covers the inline one.
+    #
+    # The request log is handed over as a synchronized list rather than each runspace keeping its
+    # own, so Get-OmadaMockRequestLog in the app's runspace still sees every request - including the
+    # ones a worker made. Tests that assert a code path issued (or did not issue) a call depend on
+    # that being one list.
+    $Script:OmadaRequestWorkerTransportPath = $PSCommandPath
+    $Script:OmadaRequestWorkerTransportContext = @{
+        MockBaseUrl = $MockBaseUrl
+        RequestLog  = $script:OmadaMockRequestLog
+    }
+}
+
+function Initialize-OmadaRequestWorkerTransport {
+    <#
+    .SYNOPSIS
+    Called inside a background worker runspace, after this file has been dot-sourced there, to point
+    the worker's shim at the same mock server and the same shared request log as the app's runspace.
+
+    .DESCRIPTION
+    The name is the contract Start-OmadaBackgroundRequest looks for; it calls this only when the
+    function exists, so a normal (non-mock) run has no idea any of this is here.
+    #>
+    [CmdletBinding()]
+    param($Context)
+    if ($null -eq $Context) { return }
+    $script:OmadaMockBaseUrl = $Context.MockBaseUrl
+    if ($null -ne $Context.RequestLog) {
+        $script:OmadaMockRequestLog = $Context.RequestLog
+    }
 }
 
 function Clear-OmadaMockRequestLog {
@@ -72,7 +111,9 @@ function script:Invoke-OmadaRestMethod {
 
     # Recorded before the call goes out, so a request that fails still counts as "the app talked to
     # the tenant" - which is exactly what a zero-request assertion has to catch.
-    $script:OmadaMockRequestLog.Add([PSCustomObject]@{
+    # [void]: ArrayList.Add returns the new index, which would otherwise land in this function's
+    # output stream and be returned to the caller alongside the actual response.
+    [void]$script:OmadaMockRequestLog.Add([PSCustomObject]@{
             Uri    = $TargetUri
             Method = $HttpMethod
             Body   = $Body


### PR DESCRIPTION
Slice **C1-2** of **#40** (Roadmap C1 — execute queries off the UI thread). Targets the working baseline branch `feature/async-query-execution`, not `main`.

The machinery, wired to exactly **one** caller: `Get-SqlSchemaObject`. That fetch is the right place to prove this — already cached, already tolerant of failure, binds no grid, creates no temporary object on the tenant — so it puts no query result at stake, and it is the round-trip that freezes the window on connect.

## What was added

| File | Role |
|---|---|
| `Initialize-OmadaRequestPool.ps1` | Opens (lazily, once) the MTA runspace pool; `Close-OmadaRequestPool` tears it down on window close |
| `Start-OmadaBackgroundRequest.ps1` | Dispatches to a worker and enqueues onto the **existing** completion queue |
| `Complete-OmadaBackgroundRequest.ps1` | Collects the outcome on the UI thread and releases the worker |
| `Test-OmadaBackgroundRequestEligible.ps1` | The authentication policy, as a predicate |
| `Build-OmadaRequestParameter.ps1` | Request preparation, extracted from the wrapper |
| `Resolve-OmadaRequestFailure.ps1` | Failure classification, extracted from the wrapper |
| `Invoke-OmadaPSWebRequestWrapperAsync.ps1` | The background sibling of the wrapper |
| `Get-SqlSchema.ps1` | Split into `Get-SqlSchemaObject` (issue) + `Complete-SqlSchemaRetrieval` (response) |

## Decisions worth reviewing

### 1. One completion queue, not two — and it was verified before being built on

The Tick handler in `MainForm.Definition.ps1` only ever asks `$_.Task.IsCompleted`. `PowerShell.BeginInvoke()` returns an `IAsyncResult`, which exposes exactly that property. So a background request is queued into the **same** `$Script:PendingWebViewCompletions` list, drained by the **same** 50 ms timer, and its completion runs from the **same** frame that already repoints the owning tab via `Set-ActiveTabContext` — **with no change to the Tick handler at all**.

This was checked empirically first, not assumed: `Where-Object { $_.Task.IsCompleted }` filters an `IAsyncResult` identically to a `Task`, before and after completion.

### 2. Background requests are deliberately kept out of `$Script:Task` / `$TabSession.PendingTask`

That field belongs exclusively to the WebView2 editor task. `Set-ActiveTabContext` saves and restores it per tab, and six call sites read `$Script:Task.Status` expecting `"RanToCompletion"`. An `IAsyncResult` **has no `Status` property**, so parking one there would silently turn every one of those reads into `$null`. Background requests live in the queue and nowhere else.

### 3. The MTA pool — where I depart from the issue's published analysis, deliberately

The analysis states "**STA is mandatory**", because OmadaWeb.PS authenticates by opening a WinForms modal (`Start-WebView2Login.ps1` → `ShowDialog()`), and WinForms + WebView2 need STA.

That is true only if the worker is meant to be **able** to authenticate. Per the agreed policy for this issue, it is not — and STA would make the bad case *silent*: a login window with **no owner**, not modal to this app, possibly behind the main window, with the app fully interactive behind it, so the user can start a second execute on another tab while an invisible prompt waits.

**MTA makes that case fail loudly instead of prompting.** It is the structural half of a two-part enforcement:

- `Test-OmadaBackgroundRequestEligible` only dispatches for a tab that already authenticated on the UI thread (`$Script:ConnectionStatus`) and is not asking to re-authenticate (`ForceAuthentication`). A connected tab has a cookie on disk for its SessionKey, which a fresh worker runspace — whose own OmadaWeb.PS session table is empty — loads without opening anything.
- The MTA pool catches the residual case the predicate cannot: a cookie that **expired between connecting and issuing the request**. That returns a clean error to the UI thread rather than an invisible window.

An already-authenticated request touches none of the WinForms path, so MTA costs it nothing.

**This residual case is not observable under test** — the mock replaces `Invoke-OmadaRestMethod` outright, so no authentication ever happens. It belongs on the live-tenant checklist, and is called out in the code.

### 4. Fallback is the contract, not an afterthought

`Invoke-OmadaPSWebRequestWrapperAsync` returns `$null` — **having done nothing** — in four cases: `SkipRetryRequest` set, not eligible, no active tab, no pool. The caller then issues the request inline exactly as before.

A bug here is not "the request was slow". It is "the request never happened" or "the request happened twice", so both halves are asserted separately, including `Get-SqlSchemaObject` making **no** synchronous request when dispatch succeeded.

### 5. Preparation and classification extracted verbatim rather than reimplemented

Two paths that prepare a request differently would drift, and the difference would be invisible until a tenant rejected something. `Build-OmadaRequestParameter` and `Resolve-OmadaRequestFailure` are lifted unchanged, and **the seven pre-existing wrapper tests pass unmodified** — that is the no-behaviour-change claim.

`Resolve-OmadaRequestFailure`'s two tenant-level branches still end in `Write-Error -ErrorAction Stop`, i.e. they throw. From the background path that throw lands in the poll timer's own `try`/`catch`, which logs it. Documented in the function, because it is the one place the two paths genuinely differ.

### 6. Context travels on the pending item; nothing is re-read from `$Script:`

A plain scriptblock resolves variables from the scope it is **invoked** in — the poll timer's frame — not the one it was written in. So everything a completion needs travels on `$Pending.Context`. That is also the correctness argument: by the time a completion runs, the user may have switched to a tab with a different SessionKey, and re-deriving the cache key is how a schema gets filed under, and later served to, the wrong connection. There is a test for exactly that.

Both the caller's data and the caller's result block are assembled **before** dispatch. Attaching afterwards would work today — nothing pumps the dispatcher in between — but only by accident, and this queue is about to be drained by more code than it is now.

### 7. The mock had to follow, and this is the one test seam in production code

Worker runspaces have their own OmadaWeb.PS and would have called the **real** `Invoke-OmadaRestMethod`, reaching straight past the transport shim to whatever tenant URL the app built.

`Install-OmadaMockTransport` now registers itself on two `$Script:OmadaRequestWorkerTransport*` variables that `Start-OmadaBackgroundRequest` reads. Production code contributes six lines and knows nothing about mocks; it dot-sources a path if one is set and calls `Initialize-OmadaRequestWorkerTransport` if that function exists. All the knowledge lives in the test file. This is the same shape as the existing `Install-OmadaMockTransport` seam, and without it the mock cannot observe background requests at all.

The request log became a **synchronized** `ArrayList` shared with the workers, so `Get-OmadaMockRequestLog` still sees every request whichever thread made it — which the cancel test in C1-4 will depend on. (`[void]` on `.Add`: `ArrayList.Add` returns an index that would otherwise land in the shim's output stream.)

## Verification

```
Invoke-Pester -Path tests
Tests Passed: 639, Failed: 0, Skipped: 0
```

PSScriptAnalyzer run with the **build's own profile** across `src/Lib/functions` and `src/Lib/events`: clean.

**Two failures were found and fixed on the way**, and they are worth naming because they are the interesting part: `Get-SqlSchema.Tests.ps1` and `Update-QueryList.Tests.ps1` dot-source the wrapper, and after the split a missing collaborator threw `CommandNotFoundException` *inside the caller's own catch* — so a "zero requests were made" assertion passed for entirely the wrong reason. `Get-SqlSchema.Tests.ps1` already carries a comment warning about precisely this failure mode. Both files now dot-source the real collaborators.

New coverage: 6 cases for the eligibility predicate, 6 for outcome collection (against **real** `[powershell]` pipelines, because "EndInvoke on a stopped pipeline throws" and "the contract arrives wrapped in the output collection" are behaviours of PowerShell that a stub would let regress), 9 for preparation, 11 for the dispatch decision, and 5 new ones for `Get-SqlSchemaObject`'s two paths.

## What is not covered

Everything in the authentication analysis. The mock replaces `Invoke-OmadaRestMethod`, so under test no authentication ever happens: the STA/MTA question, the expired-cookie case, and the cookie-cache race are invisible to the entire suite. They need a human on a live tenant, exactly as #40's analysis says.
