### PR TITLE
Execute the query off the UI thread, with a live elapsed time (C1-3)

### DIFF
--- a/src/Lib/Events/MainForm.Definition.ps1
+++ b/src/Lib/Events/MainForm.Definition.ps1
@@ -66,6 +66,11 @@ $Script:WebViewCompletionPollTimer.Add_Tick({
                 if ($true -eq $Pending.IsBackgroundRequest -and $null -ne $Pending.TabSession -and
                     -not ($Script:Tabs | Where-Object { $_.Id -eq $Pending.TabSession.Id })) {
                     "Dropping a completion for a tab that no longer exists." | Write-LogOutput -LogType DEBUG
+                    # Disposed here because the completion block - which is what normally calls
+                    # Complete-OmadaBackgroundRequest, and disposing is what that does in its finally -
+                    # is precisely what this branch skips. Without it the worker's runspace is never
+                    # released back to the pool.
+                    try { $Pending.Shell.Dispose() } catch { }
                     continue
                 }
 

--- a/src/Lib/Events/MainForm.Definition.ps1
+++ b/src/Lib/Events/MainForm.Definition.ps1
@@ -12,8 +12,18 @@ $Script:PendingWebViewCompletions = [System.Collections.Generic.List[object]]::n
 
 $Script:WebViewCompletionPollTimer = New-Object System.Windows.Threading.DispatcherTimer
 $Script:WebViewCompletionPollTimer.Interval = [TimeSpan]::FromMilliseconds(50)
+$Script:WebViewCompletionTickCount = 0
 $Script:WebViewCompletionPollTimer.Add_Tick({
         try {
+            # Elapsed-time indicator for background requests (issue #40), driven from THIS timer
+            # rather than a second one: this is already the only place that knows about pending work,
+            # and it is already suspended around modal dialogs. Every 20th tick is once a second,
+            # which is as often as a duration in seconds can visibly change.
+            $Script:WebViewCompletionTickCount++
+            if ($Script:WebViewCompletionTickCount % 20 -eq 0) {
+                Update-BackgroundRequestElapsedTime -Pending $Script:PendingWebViewCompletions
+            }
+
             $Completed = @($Script:PendingWebViewCompletions | Where-Object { $_.Task.IsCompleted })
             foreach ($Pending in $Completed) {
                 [void]$Script:PendingWebViewCompletions.Remove($Pending)
@@ -43,6 +53,19 @@ $Script:WebViewCompletionPollTimer.Add_Tick({
                 $CompletedScriptBlock = $Pending.OnCompletedScriptBlock
 
                 if (-not (Test-WebViewCompletionCallback -Callback $CompletedScriptBlock)) {
+                    continue
+                }
+
+                # Second line of defence behind Remove-PendingBackgroundRequest (issue #40). A
+                # completion whose tab has been closed must not run: Set-ActiveTabContext below would
+                # repoint every "current tab" global onto a tab that is gone, and the restore in the
+                # finally cannot undo it - Get-ActiveTabSession returns $null when the closed tab was
+                # the active one, so the restore is skipped and the app is left pointing at a dead
+                # tab. Only background requests are checked; a $null TabSession still means "the
+                # block manages its own context", which is a different and legitimate case.
+                if ($true -eq $Pending.IsBackgroundRequest -and $null -ne $Pending.TabSession -and
+                    -not ($Script:Tabs | Where-Object { $_.Id -eq $Pending.TabSession.Id })) {
+                    "Dropping a completion for a tab that no longer exists." | Write-LogOutput -LogType DEBUG
                     continue
                 }
 

--- a/src/Lib/Events/MainFormTabContent.Elements.ButtonExecuteQuery.ps1
+++ b/src/Lib/Events/MainFormTabContent.Elements.ButtonExecuteQuery.ps1
@@ -11,15 +11,29 @@ $Script:MainForm.Elements.ButtonExecuteQuery.Add_Click({
             $Script:MainForm.Elements.ButtonShowOutput.IsEnabled = $false
             $Script:MainForm.Elements.ButtonSaveOutputFile.IsEnabled = $false
 
-            # Let the "Executing Query..." popup actually paint before this handler goes on to block.
+            # Let the "Executing Query..." popup actually paint before this handler continues.
             # This used to be Start-Sleep -Milliseconds 100, which cannot work: Start-Sleep parks the
             # dispatcher thread without pumping it, so the render pass the popup is waiting for never
             # runs - the window simply froze 100 ms longer with nothing new on screen.
             # (Show-PopupWindow uses .Show(), not .ShowDialog(), so nothing else pumps for it either.)
             # Invoking an empty action at Background priority drains everything of higher priority
-            # first - Render included - which is exactly the pass that draws the popup. Same primitive
-            # the E2E harness uses as Invoke-E2EFlushDispatcher.
-            $Script:MainForm.Definition.Dispatcher.Invoke([System.Action] {}, [System.Windows.Threading.DispatcherPriority]::Background)
+            # first - Render included - which is exactly the pass that draws the popup.
+            #
+            # Suspended around the pump, and this is not optional. Pumping the dispatcher is exactly
+            # what lets the WebViewCompletionPollTimer fire, and a completion drained here runs
+            # Set-ActiveTabContext - repointing $Script:MainForm.Elements, $Script:RunTimeData and
+            # $Script:AppConfig - in the middle of this handler, after it has already disabled the
+            # buttons on the tab it started with. Observed: the buttons stayed disabled on the OLD
+            # element bag while the execute ran against a different one. The suspend keeps the render
+            # pass (which is all this needs) and denies the timer, which is the same reasoning
+            # Suspend-WebViewCompletionPolling was written for.
+            Suspend-WebViewCompletionPolling
+            try {
+                $Script:MainForm.Definition.Dispatcher.Invoke([System.Action] {}, [System.Windows.Threading.DispatcherPriority]::Background)
+            }
+            finally {
+                Resume-WebViewCompletionPolling
+            }
 
             if (!(Test-ConnectionRequirements) -or [string]::IsNullOrWhiteSpace($Script:AppConfig.CurrentSqlQuery.DoId)) {
                 "Omada Url not set or Query not selected, cannot retrieve data!" | Write-LogOutput -LogType WARNING

--- a/src/Lib/Functions/Private/Complete-TabClose.ps1
+++ b/src/Lib/Functions/Private/Complete-TabClose.ps1
@@ -24,6 +24,11 @@ function Complete-TabClose {
 
         $ClosingIndex = $Script:Tabs.IndexOf($TabToClose)
 
+        # Before anything is disposed: drop this tab's in-flight background requests (issue #40).
+        # A completion that fires after the tab is gone repoints every "current tab" global onto a
+        # dead tab and writes into disposed elements - see Remove-PendingBackgroundRequest.
+        Remove-PendingBackgroundRequest -TabSession $TabToClose
+
         if ($null -ne $TabToClose.WebView.Object) {
             try {
                 $TabToClose.WebView.Object.Dispose()

--- a/src/Lib/Functions/Private/Get-SqlSchema.ps1
+++ b/src/Lib/Functions/Private/Get-SqlSchema.ps1
@@ -67,14 +67,14 @@ function Get-SqlSchemaObject {
             # failure, and abandonment when its tab is closed - and a key left behind on the
             # abandonment path would block that pool and database from ever fetching its schema again
             # for the rest of the session. The queue cannot get out of step with itself.
-            # "-not IsCompleted" matters: an item whose worker has finished but which the poll timer
-            # has not drained yet is NOT in flight. Its result has not reached the cache and never
-            # will until a completion runs, so treating it as in flight would refuse the fetch and
-            # leave the caller with no schema at all.
+            # Any matching item on the queue counts, including one whose worker has already finished
+            # but which the poll timer has not drained yet. Its completion is queued and about to
+            # populate the cache and push the schema to the editor, so the caller's intent is already
+            # being served - dispatching again in that window would be a duplicate request for
+            # exactly the answer that is moments away.
             if (@($Script:PendingWebViewCompletions | Where-Object {
                         $_.Description -eq $Script:SqlSchemaRequestDescription -and
-                        $_.Context.Caller.SchemaCacheKey -eq $SchemaCacheKey -and
-                        -not $_.Task.IsCompleted
+                        $_.Context.Caller.SchemaCacheKey -eq $SchemaCacheKey
                     }).Count -gt 0) {
                 "SQL schema for '{0}' is already being retrieved; not requesting it twice." -f $SchemaCacheKey | Write-LogOutput -LogType DEBUG
                 return

--- a/src/Lib/Functions/Private/Get-SqlSchema.ps1
+++ b/src/Lib/Functions/Private/Get-SqlSchema.ps1
@@ -1,3 +1,8 @@
+# The label a schema request carries on the completion queue. A constant because it is matched, not
+# just displayed: Get-SqlSchemaObject reads the queue through it to decide whether a fetch for the
+# same pool and database is already outstanding.
+$Script:SqlSchemaRequestDescription = "SQL schema"
+
 function Get-SqlSchemaObject {
     [CmdLetBinding()]
     param()
@@ -51,6 +56,30 @@ function Get-SqlSchemaObject {
                 return
             }
 
+            # The cache alone stopped being enough once this fetch went off-thread (issue #40): the
+            # cache is only populated when the response LANDS, so two calls close together - a
+            # connect immediately followed by a data-connection change, say - would both miss it and
+            # both hit the tenant. This preserves the once-per-pool-per-database contract the cache
+            # was written for.
+            #
+            # Read straight off the completion queue rather than kept in a side table of "keys in
+            # flight". A side table has to be cleared on every path a request can leave by - success,
+            # failure, and abandonment when its tab is closed - and a key left behind on the
+            # abandonment path would block that pool and database from ever fetching its schema again
+            # for the rest of the session. The queue cannot get out of step with itself.
+            # "-not IsCompleted" matters: an item whose worker has finished but which the poll timer
+            # has not drained yet is NOT in flight. Its result has not reached the cache and never
+            # will until a completion runs, so treating it as in flight would refuse the fetch and
+            # leave the caller with no schema at all.
+            if (@($Script:PendingWebViewCompletions | Where-Object {
+                        $_.Description -eq $Script:SqlSchemaRequestDescription -and
+                        $_.Context.Caller.SchemaCacheKey -eq $SchemaCacheKey -and
+                        -not $_.Task.IsCompleted
+                    }).Count -gt 0) {
+                "SQL schema for '{0}' is already being retrieved; not requesting it twice." -f $SchemaCacheKey | Write-LogOutput -LogType DEBUG
+                return
+            }
+
             $Script:RunTimeData.RestMethodParam.Body = @{
                 connectionId = $Script:AppConfig.CurrentDataConnection.DoId
             }
@@ -65,13 +94,14 @@ function Get-SqlSchemaObject {
             # $Pending.Context.Caller instead of re-deriving it: by the time it runs, the user may
             # have switched to a tab with a different SessionKey or data connection, and the key must
             # be the one this request was issued for.
-            $Private:Pending = Invoke-OmadaPSWebRequestWrapperAsync -Description "SQL schema" -Context @{ SchemaCacheKey = $SchemaCacheKey } -OnResultScriptBlock {
+            $Private:Pending = Invoke-OmadaPSWebRequestWrapperAsync -Description $Script:SqlSchemaRequestDescription -Context @{ SchemaCacheKey = $SchemaCacheKey } -OnResultScriptBlock {
                 param($Pending)
                 Complete-SqlSchemaRetrieval -SchemaResponse $Pending.Outcome -SchemaCacheKey $Pending.Context.Caller.SchemaCacheKey
             }
 
             if ($null -ne $Private:Pending) {
-                # Dispatched. Everything after the response now happens in the completion block.
+                # Dispatched. Everything after the response now happens in the completion block, and
+                # the item's presence on the queue is itself the "already in flight" record.
                 return
             }
 

--- a/src/Lib/Functions/Private/Invoke-ExecuteQuery.ps1
+++ b/src/Lib/Functions/Private/Invoke-ExecuteQuery.ps1
@@ -59,14 +59,7 @@ function Invoke-ExecuteQuery {
                             $Private:Confirmed = Open-ChoiceForm -Title "Syntax errors" -Message (Get-SqlSyntaxWarningMessage -Diagnostic $Private:SyntaxDiagnostic) -LeftButtonText "Execute anyway" -RightButtonText "Cancel"
                             if ($Private:Confirmed -ne $true) {
                                 "Execution cancelled by the user after the syntax check." | Write-LogOutput -LogType DEBUG
-                                $Script:MainForm.Elements.ButtonSaveQuery.IsEnabled = $true
-                                $Script:MainForm.Elements.ButtonExecuteQuery.IsEnabled = $true
-                                if ($null -ne $Script:PopupWindowExecuteQuery) {
-                                    $Script:PopupWindowExecuteQuery.Close()
-                                }
-                                if ($null -ne $Script:RunTimeData.StopWatch) {
-                                    $Script:RunTimeData.StopWatch.Stop()
-                                }
+                                Reset-ExecuteQueryUiState
                                 return
                             }
                         }
@@ -110,50 +103,40 @@ function Invoke-ExecuteQuery {
                     "Retrieve query output, please wait..." | Write-LogOutput
                     $Script:RunTimeData.RestMethodParam.Method = "POST"
                     $Script:RunTimeData.QueryResult = $null
-                    $Script:RunTimeData.QueryResult = Invoke-OmadaPSWebRequestWrapper
 
-                    if ($null -ne $Private:TempQueryDoId) {
-                        Remove-SqlQueryObject -DoId $Private:TempQueryDoId
+                    # The headline of issue #40: THIS is the call that freezes the window, and it is
+                    # the one that now runs on a background worker. Everything above it - reading the
+                    # editor, the syntax gate, saving the query, creating the temporary object - is
+                    # still synchronous, and deliberately so: those are short calls, and two of them
+                    # can open a modal dialog, which belongs on the UI thread. Moving the remaining
+                    # round-trips off-thread is C1-5, a separate slice with a much larger blast radius.
+                    #
+                    # Everything the completion needs travels on the context. It must not re-read
+                    # $Script: state: by the time the response lands the user may be looking at
+                    # another tab, and $Private:Result (the Save-Query outcome) and the temporary
+                    # object id do not exist anywhere else.
+                    $Private:Pending = Invoke-OmadaPSWebRequestWrapperAsync -Description "Execute query" -Context @{
+                        SaveResult    = $Private:Result
+                        TempQueryDoId = $Private:TempQueryDoId
+                    } -OnResultScriptBlock {
+                        param($Pending)
+                        Complete-ExecuteQueryResult -QueryResult $Pending.Outcome -SaveResult $Pending.Context.Caller.SaveResult -TempQueryDoId $Pending.Context.Caller.TempQueryDoId
+                    }
+
+                    if ($null -ne $Private:Pending) {
+                        # Dispatched. Ownership of the temporary object passes to the completion, so
+                        # this frame must forget it - otherwise the catch below would delete an object
+                        # the in-flight query is still executing against.
                         $Private:TempQueryDoId = $null
+                        return
                     }
 
-                    $Script:DataGridQueryResultColumnSelectionAnchor = $null
-
-                    if ($null -ne $Script:RunTimeData.QueryResult -and ($Script:RunTimeData.QueryResult.d.Rows | Measure-Object).Count -le 0) {
-                        "Query did not return any results!" | Write-LogOutput -LogType WARNING
-                        $Script:MainForm.Elements.TextBlockStatusBarRows | Set-TextBlockText -Text "0 rows"
-                        $Script:MainForm.Elements.DataGridQueryResult.ItemsSource = $null
-                    }
-                    else {
-                        $Script:MainForm.Elements.DataGridQueryResult.AutoGenerateColumns = $true
-                        try {
-                            $Script:MainForm.Elements.DataGridQueryResult.ItemsSource = @($Script:RunTimeData.QueryResult.d.Rows)
-                        }
-                        catch {
-                            #Work-around issue that Omada can return invalid JSON keys.
-                            $Script:MainForm.Elements.DataGridQueryResult.ItemsSource = @(($Script:RunTimeData.QueryResult | ConvertTo-Json -Depth 10 | Invoke-SanitizeJsonKeys | ConvertFrom-Json -Depth 10).d.Rows)
-                        }
-                        "Result: {0}" -f (Get-LogResultShape -InputObject $Script:RunTimeData.QueryResult.d.rows) | Write-LogOutput -LogType VERBOSE2
-                        $Script:MainForm.Elements.ButtonShowOutput.IsEnabled = $true
-                        $Script:MainForm.Elements.ButtonSaveOutputFile.IsEnabled = $true
-                        "{0} record(s) retrieved!" -f $Script:RunTimeData.QueryResult.d.Records | Write-LogOutput
-
-                        $Script:MainForm.Elements.TextBlockStatusBarRows | Set-TextBlockText -Text ("{0:n0} rows" -f [Int]$Script:RunTimeData.QueryResult.d.Records)
-                        $Private:Result.Id, $Private:Result.DisplayName | Set-ConfigProperty -Property "CurrentSqlQuery"
-                        if ($Private:Result.DisplayName -ne $Script:RunTimeData.CurrentSqlQuery.DisplayName) {
-                            "New display name, Current: {0}, New: {1}" -f $Script:RunTimeData.CurrentSqlQuery.DisplayName, $Private:Result.DisplayName | Write-LogOutput -LogType DEBUG
-                            "Force update query list" | Write-LogOutput -LogType DEBUG
-                            Update-QueryList -ForceRefresh
-                            if ($null -ne $ComboBoxSelectQueryItem) {
-                                $ComboBoxSelectQueryItem = $Script:MainForm.Elements.ComboBoxSelectQuery.Items | Where-Object { $_.Content -like "*$($Script:AppConfig.CurrentSqlQuery.DoId)" }
-
-                                $ComboBoxSelectQueryItem = New-Object System.Windows.Controls.ComboBoxItem
-                                $ComboBoxSelectQueryItem.Content = $Script:AppConfig.CurrentSqlQuery.FullName
-                                $Script:MainForm.Elements.ComboBoxSelectQuery.Items.Add($ComboBoxSelectQueryItem) | Out-Null
-                            }
-                            $Script:MainForm.Elements.ComboBoxSelectQuery.SelectedItem = $ComboBoxSelectQueryItem
-                        }
-                    }
+                    # Not eligible for a worker, or none available: run it inline, exactly as before.
+                    $Private:QueryResult = Invoke-OmadaPSWebRequestWrapper
+                    $Private:CompletedTempQueryDoId = $Private:TempQueryDoId
+                    $Private:TempQueryDoId = $null
+                    Complete-ExecuteQueryResult -QueryResult $Private:QueryResult -SaveResult $Private:Result -TempQueryDoId $Private:CompletedTempQueryDoId
+                    return
                 }
                 elseif ($Script:Task.Status -eq "Faulted") {
                     "Task failed: {0}" -f $Script:Task.Status | Write-LogOutput -LogType ERROR
@@ -161,43 +144,152 @@ function Invoke-ExecuteQuery {
                 else {
                     "Task result: {0}" -f $Script:Task.Status | Write-LogOutput -LogType DEBUG
                 }
-                $Script:MainForm.Elements.ButtonSaveQuery.IsEnabled = $true
-                $Script:MainForm.Elements.ButtonExecuteQuery.IsEnabled = $true
-                if ($null -ne $Script:PopupWindowExecuteQuery) {
-                    $Script:PopupWindowExecuteQuery.Close()
-                }
-
-                if ($null -ne $Script:RunTimeData.StopWatch) {
-                    $Script:RunTimeData.StopWatch.Stop()
-                    "Elapsed time: {0}" -f $Script:RunTimeData.StopWatch.Elapsed.ToString() | Write-LogOutput -LogType Debug
-                    $Script:MainForm.Elements.TextBlockStatusBarQueryTime.Text = $Script:RunTimeData.StopWatch.Elapsed.ToString()
-                }
+                Reset-ExecuteQueryUiState
             }
             catch {
                 if ($null -ne $Private:TempQueryDoId) {
                     Remove-SqlQueryObject -DoId $Private:TempQueryDoId
                 }
-                $Script:MainForm.Elements.ButtonSaveQuery.IsEnabled = $true
-                $Script:MainForm.Elements.ButtonExecuteQuery.IsEnabled = $true
-                if ($null -ne $Script:PopupWindowExecuteQuery) {
-                    $Script:PopupWindowExecuteQuery.Close()
-                }
+                Reset-ExecuteQueryUiState
                 $_.Exception.Message | Write-LogOutput -LogType ERROR -ErrorObject $_
             }
         }
         Invoke-ExecuteScriptWithResultAsync -ScriptToExecute $ScriptToExecute -OnCompletedScriptBlock $OnCompletedScriptBlock
     }
     catch {
-        if ($null -ne $Script:RunTimeData.StopWatch) {
-            $Script:RunTimeData.StopWatch.Stop()
-            $Script:MainForm.Elements.TextBlockStatusBarQueryTime.Text = $Script:RunTimeData.StopWatch.Elapsed.ToString()
-        }
+        Reset-ExecuteQueryUiState
+        $_.Exception.Message | Write-LogOutput -LogType ERROR -ErrorObject $_
+    }
+}
+
+function Reset-ExecuteQueryUiState {
+    <#
+    .SYNOPSIS
+    Return the active tab to a state where the user can execute again: buttons re-enabled, the
+    "Executing Query..." popup closed, the stopwatch stopped and its final value on the status bar.
+
+    .DESCRIPTION
+    The same teardown was written out five times across Invoke-ExecuteQuery, in slightly different
+    forms - one of them forgot the stopwatch, another forgot the status bar. Issue #40 adds a sixth
+    caller (the completion of a background request) and C1-4 will add a seventh (Cancel), which is
+    more copies than a block this easy to get subtly wrong should have.
+
+    Deliberately does NOT touch DataGridQueryResult: a failed or abandoned execute must leave the
+    previous result on screen rather than blanking it.
+
+    .PARAMETER SkipStatusBarTime
+    Stop the stopwatch without writing its value to the status bar. Used where the elapsed time is
+    not meaningful - a run that never issued a request.
+    #>
+    [CmdLetBinding()]
+    param(
+        [switch]$SkipStatusBarTime
+    )
+
+    try {
         $Script:MainForm.Elements.ButtonSaveQuery.IsEnabled = $true
         $Script:MainForm.Elements.ButtonExecuteQuery.IsEnabled = $true
+
         if ($null -ne $Script:PopupWindowExecuteQuery) {
             $Script:PopupWindowExecuteQuery.Close()
+            $Script:PopupWindowExecuteQuery = $null
         }
 
+        if ($null -ne $Script:RunTimeData.StopWatch) {
+            $Script:RunTimeData.StopWatch.Stop()
+            if (-not $SkipStatusBarTime) {
+                "Elapsed time: {0}" -f $Script:RunTimeData.StopWatch.Elapsed.ToString() | Write-LogOutput -LogType DEBUG
+                $Script:MainForm.Elements.TextBlockStatusBarQueryTime.Text = $Script:RunTimeData.StopWatch.Elapsed.ToString()
+            }
+        }
+    }
+    catch {
+        $_.Exception.Message | Write-LogOutput -LogType ERROR -ErrorObject $_
+    }
+}
+
+function Complete-ExecuteQueryResult {
+    <#
+    .SYNOPSIS
+    Everything that happens once a query result is in hand: clean up the temporary object, bind the
+    grid, update the status bar and the query list, and return the UI to a usable state.
+
+    .DESCRIPTION
+    Split out of Invoke-ExecuteQuery by issue #40 so identical work runs whether the response arrived
+    from a background worker or inline. UI thread only, which it always is: the background path
+    reaches it from the completion poll timer, with the owning tab already made active by
+    Set-ActiveTabContext.
+
+    .PARAMETER QueryResult
+    What the request produced: the response object, an ErrorRecord, or $null.
+
+    .PARAMETER SaveResult
+    The object Save-Query returned earlier in this execution. Passed in rather than re-read, because
+    it exists nowhere else and the frame that produced it has long since returned.
+
+    .PARAMETER TempQueryDoId
+    The temporary TMP_<guid> object created for an "execute selection" run, or $null. Deleted here,
+    and deleted whatever the outcome - a result that never arrived still leaves an object behind on
+    the tenant.
+    #>
+    [CmdLetBinding()]
+    param(
+        $QueryResult,
+        $SaveResult,
+        $TempQueryDoId
+    )
+
+    try {
+        $Script:RunTimeData.QueryResult = $QueryResult
+
+        if ($null -ne $TempQueryDoId) {
+            Remove-SqlQueryObject -DoId $TempQueryDoId
+        }
+
+        $Script:DataGridQueryResultColumnSelectionAnchor = $null
+
+        if ($null -ne $Script:RunTimeData.QueryResult -and ($Script:RunTimeData.QueryResult.d.Rows | Measure-Object).Count -le 0) {
+            "Query did not return any results!" | Write-LogOutput -LogType WARNING
+            $Script:MainForm.Elements.TextBlockStatusBarRows | Set-TextBlockText -Text "0 rows"
+            $Script:MainForm.Elements.DataGridQueryResult.ItemsSource = $null
+        }
+        else {
+            $Script:MainForm.Elements.DataGridQueryResult.AutoGenerateColumns = $true
+            try {
+                $Script:MainForm.Elements.DataGridQueryResult.ItemsSource = @($Script:RunTimeData.QueryResult.d.Rows)
+            }
+            catch {
+                #Work-around issue that Omada can return invalid JSON keys.
+                $Script:MainForm.Elements.DataGridQueryResult.ItemsSource = @(($Script:RunTimeData.QueryResult | ConvertTo-Json -Depth 10 | Invoke-SanitizeJsonKeys | ConvertFrom-Json -Depth 10).d.Rows)
+            }
+            "Result: {0}" -f (Get-LogResultShape -InputObject $Script:RunTimeData.QueryResult.d.rows) | Write-LogOutput -LogType VERBOSE2
+            $Script:MainForm.Elements.ButtonShowOutput.IsEnabled = $true
+            $Script:MainForm.Elements.ButtonSaveOutputFile.IsEnabled = $true
+            "{0} record(s) retrieved!" -f $Script:RunTimeData.QueryResult.d.Records | Write-LogOutput
+
+            $Script:MainForm.Elements.TextBlockStatusBarRows | Set-TextBlockText -Text ("{0:n0} rows" -f [Int]$Script:RunTimeData.QueryResult.d.Records)
+            $SaveResult.Id, $SaveResult.DisplayName | Set-ConfigProperty -Property "CurrentSqlQuery"
+            if ($SaveResult.DisplayName -ne $Script:RunTimeData.CurrentSqlQuery.DisplayName) {
+                "New display name, Current: {0}, New: {1}" -f $Script:RunTimeData.CurrentSqlQuery.DisplayName, $SaveResult.DisplayName | Write-LogOutput -LogType DEBUG
+                "Force update query list" | Write-LogOutput -LogType DEBUG
+                Update-QueryList -ForceRefresh
+                if ($null -ne $ComboBoxSelectQueryItem) {
+                    $ComboBoxSelectQueryItem = $Script:MainForm.Elements.ComboBoxSelectQuery.Items | Where-Object { $_.Content -like "*$($Script:AppConfig.CurrentSqlQuery.DoId)" }
+
+                    $ComboBoxSelectQueryItem = New-Object System.Windows.Controls.ComboBoxItem
+                    $ComboBoxSelectQueryItem.Content = $Script:AppConfig.CurrentSqlQuery.FullName
+                    $Script:MainForm.Elements.ComboBoxSelectQuery.Items.Add($ComboBoxSelectQueryItem) | Out-Null
+                }
+                $Script:MainForm.Elements.ComboBoxSelectQuery.SelectedItem = $ComboBoxSelectQueryItem
+            }
+        }
+
+        Reset-ExecuteQueryUiState
+    }
+    catch {
+        # The temporary object is already gone by here - it is deleted before anything that can throw
+        # - so this only has to put the UI back.
+        Reset-ExecuteQueryUiState
         $_.Exception.Message | Write-LogOutput -LogType ERROR -ErrorObject $_
     }
 }

--- a/src/Lib/Functions/Private/Invoke-ExecuteQuery.ps1
+++ b/src/Lib/Functions/Private/Invoke-ExecuteQuery.ps1
@@ -273,14 +273,23 @@ function Complete-ExecuteQueryResult {
                 "New display name, Current: {0}, New: {1}" -f $Script:RunTimeData.CurrentSqlQuery.DisplayName, $SaveResult.DisplayName | Write-LogOutput -LogType DEBUG
                 "Force update query list" | Write-LogOutput -LogType DEBUG
                 Update-QueryList -ForceRefresh
-                if ($null -ne $ComboBoxSelectQueryItem) {
-                    $ComboBoxSelectQueryItem = $Script:MainForm.Elements.ComboBoxSelectQuery.Items | Where-Object { $_.Content -like "*$($Script:AppConfig.CurrentSqlQuery.DoId)" }
 
-                    $ComboBoxSelectQueryItem = New-Object System.Windows.Controls.ComboBoxItem
-                    $ComboBoxSelectQueryItem.Content = $Script:AppConfig.CurrentSqlQuery.FullName
-                    $Script:MainForm.Elements.ComboBoxSelectQuery.Items.Add($ComboBoxSelectQueryItem) | Out-Null
+                # Find-or-create, then select - the pattern Save-Query and Complete-TabMaterialization
+                # already use. This block used to test "$null -ne $ComboBoxSelectQueryItem" against a
+                # variable that had never been assigned, so the body was unreachable and the line
+                # after it selected $null: executing a renamed query silently CLEARED the query
+                # dropdown instead of re-selecting the renamed entry.
+                $Private:ComboBoxSelectQueryItem = $Script:MainForm.Elements.ComboBoxSelectQuery.Items |
+                    Where-Object { $_.Content -like "*$($Script:AppConfig.CurrentSqlQuery.DoId)" } |
+                    Select-Object -First 1
+
+                if ($null -eq $Private:ComboBoxSelectQueryItem) {
+                    $Private:ComboBoxSelectQueryItem = New-Object System.Windows.Controls.ComboBoxItem
+                    $Private:ComboBoxSelectQueryItem.Content = $Script:AppConfig.CurrentSqlQuery.FullName
+                    $Script:MainForm.Elements.ComboBoxSelectQuery.Items.Add($Private:ComboBoxSelectQueryItem) | Out-Null
                 }
-                $Script:MainForm.Elements.ComboBoxSelectQuery.SelectedItem = $ComboBoxSelectQueryItem
+
+                $Script:MainForm.Elements.ComboBoxSelectQuery.SelectedItem = $Private:ComboBoxSelectQueryItem
             }
         }
 

--- a/src/Lib/Functions/Private/Remove-PendingBackgroundRequest.ps1
+++ b/src/Lib/Functions/Private/Remove-PendingBackgroundRequest.ps1
@@ -1,0 +1,71 @@
+function Remove-PendingBackgroundRequest {
+    <#
+    .SYNOPSIS
+    Abandon and discard every background request belonging to a tab that is going away.
+
+    .DESCRIPTION
+    Found while building issue #40's E2E coverage, and it is a real defect rather than a tidiness
+    measure. Nothing has ever removed a closing tab's entries from
+    $Script:PendingWebViewCompletions. That was survivable while the queue only held WebView2 editor
+    tasks - a completion for a disposed control does very little - but a background request's
+    completion does a great deal: the poll timer calls Set-ActiveTabContext with the item's
+    TabSession, which repoints $Script:MainForm.Elements, $Script:RunTimeData, $Script:AppConfig and
+    $Script:ConnectionStatus onto a tab that no longer exists, and then invokes a completion block
+    that writes results into disposed WPF elements. The restore in the timer's finally cannot save
+    it either: Get-ActiveTabSession returns $null when the closing tab was the active one, and the
+    restore is skipped.
+
+    So a query left running on a tab the user then closes would quietly redirect the whole
+    application's UI state onto the dead tab.
+
+    The pipeline is stopped rather than merely dropped, so the worker is not left holding a runspace
+    for a result nobody will read; the shell is disposed for the same reason
+    Complete-OmadaBackgroundRequest disposes it - a pipeline killed mid-request leaves a half-read
+    HTTP stream and a WebRequestSession in an unknown state, and its runspace must not be handed back
+    to the pool.
+
+    Editor tasks (items with no StartedUtc) are left alone: they are not ours to stop, they carry no
+    worker, and the existing behaviour around them is unchanged.
+
+    .PARAMETER TabSession
+    The tab being closed.
+    #>
+    [CmdLetBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        $TabSession
+    )
+
+    try {
+        if ($null -eq $Script:PendingWebViewCompletions) {
+            return
+        }
+
+        $Private:Orphaned = @($Script:PendingWebViewCompletions | Where-Object {
+                $null -ne $_.StartedUtc -and $null -ne $_.TabSession -and $_.TabSession.Id -eq $TabSession.Id
+            })
+
+        foreach ($Private:Item in $Private:Orphaned) {
+            [void]$Script:PendingWebViewCompletions.Remove($Private:Item)
+            $Private:Item.IsCancelled = $true
+
+            try {
+                if ($null -ne $Private:Item.Shell) {
+                    [void]$Private:Item.Shell.BeginStop($null, $null)
+                    $Private:Item.Shell.Dispose()
+                }
+            }
+            catch {
+                # A worker that had already finished throws here. Nothing to recover: the item is
+                # off the queue, which is the part that matters.
+            }
+        }
+
+        if ($Private:Orphaned.Count -gt 0) {
+            "Abandoned {0} background request(s) belonging to closed tab '{1}'." -f $Private:Orphaned.Count, $TabSession.DisplayName | Write-LogOutput -LogType DEBUG
+        }
+    }
+    catch {
+        $_.Exception.Message | Write-LogOutput -LogType ERROR -ErrorObject $_
+    }
+}

--- a/src/Lib/Functions/Private/Update-BackgroundRequestElapsedTime.ps1
+++ b/src/Lib/Functions/Private/Update-BackgroundRequestElapsedTime.ps1
@@ -1,0 +1,46 @@
+function Update-BackgroundRequestElapsedTime {
+    <#
+    .SYNOPSIS
+    Write a live elapsed time into the status bar of every tab that has a background request in
+    flight.
+
+    .DESCRIPTION
+    Issue #40's elapsed-time indicator. Before this, $Script:RunTimeData.StopWatch was read exactly
+    once - at the very end of an execute - so the number only appeared after the wait was over, which
+    is the one moment it is of no use.
+
+    Deliberately NOT a second DispatcherTimer. It is driven from the existing 50 ms completion poll
+    timer, which is already the single place that knows about pending work, and is already correctly
+    suspended around modal dialogs. A second timer would have to learn both of those things again,
+    and would tick while a modal was open - the exact reentrancy problem
+    Suspend-WebViewCompletionPolling exists to prevent.
+
+    Writes to the OWNING tab's element rather than $Script:MainForm.Elements, and so needs no
+    Set-ActiveTabContext: repointing the whole application state twenty times a second, purely to
+    write a string, would be an absurd cost and a real risk. A tab executing in the background
+    therefore counts up while the user watches a different tab, which is the correct behaviour
+    anyway.
+
+    .PARAMETER Pending
+    The queue items to consider. Items without a StartedUtc (WebView2 editor tasks) are ignored.
+    #>
+    [CmdLetBinding()]
+    param(
+        $Pending
+    )
+
+    foreach ($Item in @($Pending)) {
+        if ($null -eq $Item -or $null -eq $Item.StartedUtc -or $Item.IsCancelled) {
+            continue
+        }
+
+        $Private:TimeBlock = $Item.TabSession.Elements.TextBlockStatusBarQueryTime
+        if ($null -eq $Private:TimeBlock) {
+            continue
+        }
+
+        # Formatted like the final value Reset-ExecuteQueryUiState writes from the stopwatch, so the
+        # indicator does not visibly change shape at the moment the request completes.
+        $Private:TimeBlock.Text = ([DateTime]::UtcNow - $Item.StartedUtc).ToString()
+    }
+}

--- a/tests/Invoke-ExecuteQuery.Tests.ps1
+++ b/tests/Invoke-ExecuteQuery.Tests.ps1
@@ -6,6 +6,13 @@
 # directly rather than only through the E2E suite, which does not run in CI.
 
 BeforeAll {
+    # Complete-ExecuteQueryResult builds a real System.Windows.Controls.ComboBoxItem when a renamed
+    # query has to be re-selected. That type lives in PresentationFramework, which a headless CI pwsh
+    # does not load on its own - without this the call throws inside the function's own catch and the
+    # selection is silently never set, so the test passes locally (where WPF is already loaded) and
+    # fails in CI. Mirrors the Add-Type in Update-QueryList.Tests.ps1, which carries the same note.
+    Add-Type -AssemblyName PresentationFramework
+
     $ParentPath = Split-Path -Path $PSScriptRoot -Parent
     $PrivatePath = Join-Path $ParentPath -ChildPath "src\Lib\Functions\Private"
 

--- a/tests/Invoke-ExecuteQuery.Tests.ps1
+++ b/tests/Invoke-ExecuteQuery.Tests.ps1
@@ -193,6 +193,26 @@ Describe "Complete-ExecuteQueryResult" {
         $Script:RunTimeData.StopWatch.IsRunning | Should -BeFalse
     }
 
+    It "selects the renamed query in the dropdown instead of clearing the selection" {
+        # Regression guard. This block used to test a variable that had never been assigned, so its
+        # body was unreachable and the line after it selected $null - executing a renamed query
+        # silently emptied the query dropdown. Find-or-create, then select, as Save-Query does.
+        Complete-ExecuteQueryResult -QueryResult (New-ResultResponse) -SaveResult ([pscustomobject]@{ Id = 100; DisplayName = "RenamedQuery" }) -TempQueryDoId $null
+
+        $Script:MainForm.Elements.ComboBoxSelectQuery.SelectedItem | Should -Not -BeNullOrEmpty
+        $Script:MainForm.Elements.ComboBoxSelectQuery.SelectedItem.Content | Should -Be "TestQuery - 100"
+    }
+
+    It "reuses an existing dropdown entry rather than adding a duplicate" {
+        $Existing = [pscustomobject]@{ Content = "TestQuery - 100" }
+        [void]$Script:MainForm.Elements.ComboBoxSelectQuery.Items.Add($Existing)
+
+        Complete-ExecuteQueryResult -QueryResult (New-ResultResponse) -SaveResult ([pscustomobject]@{ Id = 100; DisplayName = "RenamedQuery" }) -TempQueryDoId $null
+
+        $Script:MainForm.Elements.ComboBoxSelectQuery.Items.Count | Should -Be 1
+        [object]::ReferenceEquals($Script:MainForm.Elements.ComboBoxSelectQuery.SelectedItem, $Existing) | Should -BeTrue
+    }
+
     It "refreshes the query list only when the display name actually changed" {
         Complete-ExecuteQueryResult -QueryResult (New-ResultResponse) -SaveResult ([pscustomobject]@{ Id = 100; DisplayName = "TestQuery" }) -TempQueryDoId $null
         $script:QueryListRefreshes | Should -Be 0

--- a/tests/Invoke-ExecuteQuery.Tests.ps1
+++ b/tests/Invoke-ExecuteQuery.Tests.ps1
@@ -1,0 +1,223 @@
+#Requires -Version 7.0
+# Tests for the two halves issue #40 split out of Invoke-ExecuteQuery's completion block:
+# Reset-ExecuteQueryUiState (the teardown) and Complete-ExecuteQueryResult (everything that happens
+# once a result is in hand). Both are UI-thread-only and are now reached from three places - the
+# inline path, the background completion, and the failure paths - so they are worth asserting
+# directly rather than only through the E2E suite, which does not run in CI.
+
+BeforeAll {
+    $ParentPath = Split-Path -Path $PSScriptRoot -Parent
+    $PrivatePath = Join-Path $ParentPath -ChildPath "src\Lib\Functions\Private"
+
+    . (Join-Path $PrivatePath -ChildPath "ConvertTo-RedactedLogString.ps1")
+    . (Join-Path $PrivatePath -ChildPath "Get-LogResultShape.ps1")
+    . (Join-Path $PrivatePath -ChildPath "Set-TextBlockText.ps1")
+    . (Join-Path $PrivatePath -ChildPath "Invoke-ExecuteQuery.ps1")
+
+    $Script:Tracer = [System.Diagnostics.Trace]
+
+    function Write-LogOutput {
+        param(
+            [Parameter(ValueFromPipeline = $true)]$InputObject,
+            [string]$LogType,
+            $ErrorObject,
+            [switch]$SkipDialog
+        )
+        process { }
+    }
+
+    $script:RemovedQueryObjects = [System.Collections.Generic.List[object]]::new()
+    function Remove-SqlQueryObject {
+        param($DoId)
+        $script:RemovedQueryObjects.Add($DoId)
+    }
+
+    $script:ConfigWrites = [System.Collections.Generic.List[object]]::new()
+    function Set-ConfigProperty {
+        param(
+            [Parameter(ValueFromPipeline = $true)]$InputObject,
+            [string]$Property
+        )
+        process { $script:ConfigWrites.Add([pscustomobject]@{ Property = $Property; Value = $InputObject }) }
+    }
+
+    $script:QueryListRefreshes = 0
+    function Update-QueryList {
+        param([switch]$ForceRefresh)
+        $script:QueryListRefreshes++
+    }
+
+    function Invoke-SanitizeJsonKeys {
+        param([Parameter(ValueFromPipeline = $true)]$InputObject)
+        process { $InputObject }
+    }
+
+    function script:New-PopupStub {
+        $Popup = [pscustomobject]@{ Closed = $false }
+        $Popup | Add-Member -MemberType ScriptMethod -Name Close -Value { $this.Closed = $true }
+        return $Popup
+    }
+
+    function script:Initialize-ExecuteQueryTestState {
+        $script:RemovedQueryObjects.Clear()
+        $script:ConfigWrites.Clear()
+        $script:QueryListRefreshes = 0
+
+        $Script:RunTimeConfig = [PSCustomObject]@{ ApplicationName = "Test" }
+        $Script:PopupWindowExecuteQuery = New-PopupStub
+        $Script:AppConfig = [PSCustomObject]@{
+            CurrentSqlQuery = [PSCustomObject]@{ DoId = 100; FullName = "TestQuery - 100" }
+        }
+        $Script:RunTimeData = [PSCustomObject]@{
+            QueryResult     = $null
+            StopWatch       = [System.Diagnostics.Stopwatch]::StartNew()
+            CurrentSqlQuery = [PSCustomObject]@{ DisplayName = "TestQuery" }
+        }
+        $Script:MainForm = @{
+            Elements = @{
+                ButtonSaveQuery             = [PSCustomObject]@{ IsEnabled = $false }
+                ButtonExecuteQuery          = [PSCustomObject]@{ IsEnabled = $false }
+                ButtonShowOutput            = [PSCustomObject]@{ IsEnabled = $false }
+                ButtonSaveOutputFile        = [PSCustomObject]@{ IsEnabled = $false }
+                DataGridQueryResult         = [PSCustomObject]@{ ItemsSource = "previous"; AutoGenerateColumns = $false }
+                TextBlockStatusBarRows      = [PSCustomObject]@{ Name = "TextBlockStatusBarRows"; Text = "-" }
+                TextBlockStatusBarQueryTime = [PSCustomObject]@{ Name = "TextBlockStatusBarQueryTime"; Text = "-" }
+                ComboBoxSelectQuery         = [PSCustomObject]@{ Items = [System.Collections.ArrayList]::new(); SelectedItem = $null }
+            }
+        }
+    }
+
+    function script:New-ResultResponse {
+        param([int]$RowCount = 2)
+        $Rows = @(1..$RowCount | ForEach-Object { [pscustomobject]@{ Col1 = "v$_" } })
+        if ($RowCount -eq 0) { $Rows = @() }
+        return [pscustomobject]@{ d = [pscustomobject]@{ Records = $RowCount; Rows = $Rows } }
+    }
+}
+
+Describe "Reset-ExecuteQueryUiState" {
+    BeforeEach { Initialize-ExecuteQueryTestState }
+
+    It "re-enables the buttons the execute click disabled" {
+        Reset-ExecuteQueryUiState
+
+        $Script:MainForm.Elements.ButtonSaveQuery.IsEnabled | Should -BeTrue
+        $Script:MainForm.Elements.ButtonExecuteQuery.IsEnabled | Should -BeTrue
+    }
+
+    It "closes the 'Executing Query...' popup and forgets it" {
+        $Popup = $Script:PopupWindowExecuteQuery
+
+        Reset-ExecuteQueryUiState
+
+        $Popup.Closed | Should -BeTrue
+        # Nulled as well as closed: a stale reference would be Close()d a second time by the next
+        # execute's teardown.
+        $Script:PopupWindowExecuteQuery | Should -BeNullOrEmpty
+    }
+
+    It "stops the stopwatch and writes its value to the status bar" {
+        Reset-ExecuteQueryUiState
+
+        $Script:RunTimeData.StopWatch.IsRunning | Should -BeFalse
+        $Script:MainForm.Elements.TextBlockStatusBarQueryTime.Text | Should -Match '^\d{2}:\d{2}:\d{2}'
+    }
+
+    It "can stop the stopwatch without writing a time that would mean nothing" {
+        Reset-ExecuteQueryUiState -SkipStatusBarTime
+
+        $Script:RunTimeData.StopWatch.IsRunning | Should -BeFalse
+        $Script:MainForm.Elements.TextBlockStatusBarQueryTime.Text | Should -Be "-"
+    }
+
+    It "leaves the results grid untouched" {
+        # A failed or abandoned execute must not blank a perfectly good previous result.
+        Reset-ExecuteQueryUiState
+
+        $Script:MainForm.Elements.DataGridQueryResult.ItemsSource | Should -Be "previous"
+    }
+
+    It "does not throw when there is no popup and no stopwatch" {
+        $Script:PopupWindowExecuteQuery = $null
+        $Script:RunTimeData.StopWatch = $null
+
+        { Reset-ExecuteQueryUiState } | Should -Not -Throw
+    }
+}
+
+Describe "Complete-ExecuteQueryResult" {
+    BeforeEach { Initialize-ExecuteQueryTestState }
+
+    It "binds the rows and reports the record count" {
+        Complete-ExecuteQueryResult -QueryResult (New-ResultResponse -RowCount 2) -SaveResult ([pscustomobject]@{ Id = 100; DisplayName = "TestQuery" }) -TempQueryDoId $null
+
+        @($Script:MainForm.Elements.DataGridQueryResult.ItemsSource).Count | Should -Be 2
+        $Script:MainForm.Elements.TextBlockStatusBarRows.Text | Should -Be "2 rows"
+        $Script:MainForm.Elements.ButtonShowOutput.IsEnabled | Should -BeTrue
+        $Script:MainForm.Elements.ButtonSaveOutputFile.IsEnabled | Should -BeTrue
+    }
+
+    It "publishes the result so the export and grid-view features can read it" {
+        $Response = New-ResultResponse -RowCount 2
+
+        Complete-ExecuteQueryResult -QueryResult $Response -SaveResult ([pscustomobject]@{ Id = 100; DisplayName = "TestQuery" }) -TempQueryDoId $null
+
+        $Script:RunTimeData.QueryResult | Should -Be $Response
+    }
+
+    It "clears the grid and says '0 rows' for an empty result" {
+        Complete-ExecuteQueryResult -QueryResult (New-ResultResponse -RowCount 0) -SaveResult ([pscustomobject]@{ Id = 100; DisplayName = "TestQuery" }) -TempQueryDoId $null
+
+        $Script:MainForm.Elements.DataGridQueryResult.ItemsSource | Should -BeNullOrEmpty
+        $Script:MainForm.Elements.TextBlockStatusBarRows.Text | Should -Be "0 rows"
+    }
+
+    It "deletes the temporary selection object" {
+        Complete-ExecuteQueryResult -QueryResult (New-ResultResponse) -SaveResult ([pscustomobject]@{ Id = 100; DisplayName = "TestQuery" }) -TempQueryDoId "TMP-42"
+
+        $script:RemovedQueryObjects | Should -Contain "TMP-42"
+    }
+
+    It "deletes the temporary object even when the request failed" {
+        # A result that never arrived still leaves an object behind on the tenant.
+        Complete-ExecuteQueryResult -QueryResult $null -SaveResult ([pscustomobject]@{ Id = 100; DisplayName = "TestQuery" }) -TempQueryDoId "TMP-43"
+
+        $script:RemovedQueryObjects | Should -Contain "TMP-43"
+    }
+
+    It "returns the UI to a usable state on every path" {
+        Complete-ExecuteQueryResult -QueryResult $null -SaveResult ([pscustomobject]@{ Id = 100; DisplayName = "TestQuery" }) -TempQueryDoId $null
+
+        $Script:MainForm.Elements.ButtonExecuteQuery.IsEnabled | Should -BeTrue
+        $Script:MainForm.Elements.ButtonSaveQuery.IsEnabled | Should -BeTrue
+        $Script:RunTimeData.StopWatch.IsRunning | Should -BeFalse
+    }
+
+    It "refreshes the query list only when the display name actually changed" {
+        Complete-ExecuteQueryResult -QueryResult (New-ResultResponse) -SaveResult ([pscustomobject]@{ Id = 100; DisplayName = "TestQuery" }) -TempQueryDoId $null
+        $script:QueryListRefreshes | Should -Be 0
+
+        Complete-ExecuteQueryResult -QueryResult (New-ResultResponse) -SaveResult ([pscustomobject]@{ Id = 100; DisplayName = "RenamedQuery" }) -TempQueryDoId $null
+        $script:QueryListRefreshes | Should -Be 1
+    }
+
+    It "uses the SaveResult it was handed rather than re-reading module state" {
+        # The correctness argument for passing it on the pending item: by the time a background
+        # response lands, the frame that produced this value has long since returned, and the active
+        # tab may be a different one.
+        Complete-ExecuteQueryResult -QueryResult (New-ResultResponse) -SaveResult ([pscustomobject]@{ Id = 777; DisplayName = "FromTheRequest" }) -TempQueryDoId $null
+
+        $Written = @($script:ConfigWrites | Where-Object { $_.Property -eq "CurrentSqlQuery" })
+        $Written.Count | Should -BeGreaterThan 0
+        $Written.Value | Should -Contain 777
+    }
+
+    It "does not throw when the response is an ErrorRecord" {
+        $ErrorRecord = [System.Management.Automation.ErrorRecord]::new(
+            [System.Exception]::new("boom"), "OmadaFailure",
+            [System.Management.Automation.ErrorCategory]::ConnectionError, $null)
+
+        { Complete-ExecuteQueryResult -QueryResult $ErrorRecord -SaveResult ([pscustomobject]@{ Id = 100; DisplayName = "TestQuery" }) -TempQueryDoId $null } | Should -Not -Throw
+        $Script:MainForm.Elements.ButtonExecuteQuery.IsEnabled | Should -BeTrue
+    }
+}

--- a/tests/Remove-PendingBackgroundRequest.Tests.ps1
+++ b/tests/Remove-PendingBackgroundRequest.Tests.ps1
@@ -1,0 +1,115 @@
+#Requires -Version 7.0
+# Regression tests for a defect found while building issue #40's E2E coverage.
+#
+# Nothing ever removed a closing tab's entries from $Script:PendingWebViewCompletions. That was
+# survivable while the queue only held WebView2 editor tasks, but a background request's completion
+# calls Set-ActiveTabContext with its own TabSession - repointing $Script:MainForm.Elements,
+# $Script:RunTimeData, $Script:AppConfig and $Script:ConnectionStatus onto a tab that no longer
+# exists - and then writes results into disposed WPF elements. The restore in the poll timer's
+# finally cannot undo it either: Get-ActiveTabSession returns $null when the closing tab was the
+# active one, so the restore is skipped and the whole application is left pointing at a dead tab.
+
+BeforeAll {
+    $ParentPath = Split-Path -Path $PSScriptRoot -Parent
+    $PrivatePath = Join-Path $ParentPath -ChildPath "src\Lib\Functions\Private"
+    . (Join-Path $PrivatePath -ChildPath "Remove-PendingBackgroundRequest.ps1")
+
+    function Write-LogOutput {
+        param(
+            [Parameter(ValueFromPipeline = $true)]$InputObject,
+            [string]$LogType,
+            $ErrorObject,
+            [switch]$SkipDialog
+        )
+        process { }
+    }
+
+    function script:New-QueueItem {
+        param(
+            [string]$TabId,
+            [switch]$IsEditorTask,
+            [switch]$WithShell
+        )
+        $Shell = $null
+        if ($WithShell) {
+            $Shell = [powershell]::Create()
+            [void]$Shell.AddScript({ Start-Sleep -Seconds 30 })
+            [void]$Shell.BeginInvoke()
+        }
+        return [pscustomobject]@{
+            StartedUtc  = $(if ($IsEditorTask) { $null } else { [DateTime]::UtcNow })
+            TabSession  = [pscustomobject]@{ Id = $TabId; DisplayName = $TabId }
+            Shell       = $Shell
+            IsCancelled = $false
+        }
+    }
+}
+
+Describe "Remove-PendingBackgroundRequest" {
+    BeforeEach {
+        $Script:PendingWebViewCompletions = [System.Collections.Generic.List[object]]::new()
+    }
+
+    It "removes the closing tab's background requests from the queue" {
+        $Doomed = New-QueueItem -TabId "tab-A"
+        $Script:PendingWebViewCompletions.Add($Doomed)
+
+        Remove-PendingBackgroundRequest -TabSession ([pscustomobject]@{ Id = "tab-A"; DisplayName = "A" })
+
+        $Script:PendingWebViewCompletions.Count | Should -Be 0
+    }
+
+    It "leaves other tabs' requests alone" {
+        $Script:PendingWebViewCompletions.Add((New-QueueItem -TabId "tab-A"))
+        $Survivor = New-QueueItem -TabId "tab-B"
+        $Script:PendingWebViewCompletions.Add($Survivor)
+
+        Remove-PendingBackgroundRequest -TabSession ([pscustomobject]@{ Id = "tab-A"; DisplayName = "A" })
+
+        $Script:PendingWebViewCompletions.Count | Should -Be 1
+        $Script:PendingWebViewCompletions[0].TabSession.Id | Should -Be "tab-B"
+    }
+
+    It "leaves WebView2 editor tasks alone even for the closing tab" {
+        # They are not ours to stop, they carry no worker, and the existing behaviour around them is
+        # deliberately unchanged.
+        $Script:PendingWebViewCompletions.Add((New-QueueItem -TabId "tab-A" -IsEditorTask))
+
+        Remove-PendingBackgroundRequest -TabSession ([pscustomobject]@{ Id = "tab-A"; DisplayName = "A" })
+
+        $Script:PendingWebViewCompletions.Count | Should -Be 1
+    }
+
+    It "marks what it removes as cancelled" {
+        # So anything still holding a reference - a Cancel handler racing the tab close - can tell
+        # the request was abandoned rather than left running.
+        $Doomed = New-QueueItem -TabId "tab-A"
+        $Script:PendingWebViewCompletions.Add($Doomed)
+
+        Remove-PendingBackgroundRequest -TabSession ([pscustomobject]@{ Id = "tab-A"; DisplayName = "A" })
+
+        $Doomed.IsCancelled | Should -BeTrue
+    }
+
+    It "stops and disposes the worker so its runspace is not returned to the pool" {
+        # A pipeline killed mid-request leaves a half-read HTTP stream and a WebRequestSession in an
+        # unknown state. Disposing the shell is what releases the runspace, and a disposed
+        # [powershell] refuses further use - which is what this asserts.
+        $Doomed = New-QueueItem -TabId "tab-A" -WithShell
+        $Script:PendingWebViewCompletions.Add($Doomed)
+
+        Remove-PendingBackgroundRequest -TabSession ([pscustomobject]@{ Id = "tab-A"; DisplayName = "A" })
+
+        { $Doomed.Shell.AddScript({ 1 }) } | Should -Throw
+    }
+
+    It "does not throw when the queue does not exist yet" {
+        $Script:PendingWebViewCompletions = $null
+
+        { Remove-PendingBackgroundRequest -TabSession ([pscustomobject]@{ Id = "tab-A"; DisplayName = "A" }) } | Should -Not -Throw
+    }
+
+    It "does not throw for a tab with nothing in flight" {
+        { Remove-PendingBackgroundRequest -TabSession ([pscustomobject]@{ Id = "tab-Z"; DisplayName = "Z" }) } | Should -Not -Throw
+    }
+}

--- a/tests/Update-BackgroundRequestElapsedTime.Tests.ps1
+++ b/tests/Update-BackgroundRequestElapsedTime.Tests.ps1
@@ -1,0 +1,88 @@
+#Requires -Version 7.0
+# The elapsed-time indicator (issue #40). Before this, $Script:RunTimeData.StopWatch was read exactly
+# once - at the very end of an execute - so the number only appeared after the wait was over.
+#
+# The two properties worth protecting are both about NOT writing where it should not: it must write
+# to the OWNING tab's status bar rather than whatever tab is on screen (it is driven from a timer,
+# with no Set-ActiveTabContext), and it must leave WebView2 editor tasks and cancelled requests
+# alone.
+
+BeforeAll {
+    $ParentPath = Split-Path -Path $PSScriptRoot -Parent
+    $PrivatePath = Join-Path $ParentPath -ChildPath "src\Lib\Functions\Private"
+    . (Join-Path $PrivatePath -ChildPath "Update-BackgroundRequestElapsedTime.ps1")
+
+    function script:New-TimePending {
+        param(
+            $StartedUtc = ([DateTime]::UtcNow.AddSeconds(-5)),
+            [switch]$Cancelled,
+            [switch]$NoTimeBlock
+        )
+        $Elements = @{}
+        if (-not $NoTimeBlock) {
+            $Elements.TextBlockStatusBarQueryTime = [pscustomobject]@{ Text = "-" }
+        }
+        return [pscustomobject]@{
+            StartedUtc  = $StartedUtc
+            IsCancelled = [bool]$Cancelled
+            TabSession  = [pscustomobject]@{ Id = "tab-1"; Elements = $Elements }
+        }
+    }
+}
+
+Describe "Update-BackgroundRequestElapsedTime" {
+    It "writes an elapsed time into the owning tab's status bar" {
+        $Pending = New-TimePending
+
+        Update-BackgroundRequestElapsedTime -Pending @($Pending)
+
+        $Pending.TabSession.Elements.TextBlockStatusBarQueryTime.Text | Should -Not -Be "-"
+        # Same shape as the final value Reset-ExecuteQueryUiState writes from the stopwatch, so the
+        # indicator does not visibly change format when the request completes.
+        $Pending.TabSession.Elements.TextBlockStatusBarQueryTime.Text | Should -Match '^\d{2}:\d{2}:\d{2}'
+    }
+
+    It "writes to each pending request's own tab, not to one shared element" {
+        # This runs from a timer with no Set-ActiveTabContext, so two tabs executing at once must
+        # each count up in their own status bar.
+        $First = New-TimePending
+        $Second = New-TimePending
+        $Second.TabSession.Id = "tab-2"
+
+        Update-BackgroundRequestElapsedTime -Pending @($First, $Second)
+
+        $First.TabSession.Elements.TextBlockStatusBarQueryTime.Text | Should -Not -Be "-"
+        $Second.TabSession.Elements.TextBlockStatusBarQueryTime.Text | Should -Not -Be "-"
+        [object]::ReferenceEquals(
+            $First.TabSession.Elements.TextBlockStatusBarQueryTime,
+            $Second.TabSession.Elements.TextBlockStatusBarQueryTime) | Should -BeFalse
+    }
+
+    It "ignores WebView2 editor tasks, which have no StartedUtc" {
+        $EditorTask = New-TimePending -StartedUtc $null
+
+        Update-BackgroundRequestElapsedTime -Pending @($EditorTask)
+
+        $EditorTask.TabSession.Elements.TextBlockStatusBarQueryTime.Text | Should -Be "-"
+    }
+
+    It "ignores a cancelled request" {
+        # Its final state is written by the cancel path; continuing to count up over the top of that
+        # would be wrong and would look like the query was still running.
+        $Cancelled = New-TimePending -Cancelled
+
+        Update-BackgroundRequestElapsedTime -Pending @($Cancelled)
+
+        $Cancelled.TabSession.Elements.TextBlockStatusBarQueryTime.Text | Should -Be "-"
+    }
+
+    It "does not throw for a tab with no status bar element" {
+        # A tab torn down mid-request has no elements left to write into.
+        { Update-BackgroundRequestElapsedTime -Pending @(New-TimePending -NoTimeBlock) } | Should -Not -Throw
+    }
+
+    It "does not throw on a null or empty queue" {
+        { Update-BackgroundRequestElapsedTime -Pending $null } | Should -Not -Throw
+        { Update-BackgroundRequestElapsedTime -Pending @() } | Should -Not -Throw
+    }
+}

--- a/tests/e2e/Drivers.ps1
+++ b/tests/e2e/Drivers.ps1
@@ -34,6 +34,42 @@ function script:Invoke-E2EConnect {
     Invoke-E2EClick -ElementName "ButtonConnect"
 }
 
+function script:Wait-E2EAppSettled {
+    <#
+    Pump the dispatcher for a fixed period so work the APP started on its own - a WebView2
+    NavigationCompleted callback, a deferred editor push - has landed before a scenario acts.
+
+    Not the same thing as Wait-E2ENoPendingRequests, which waits on a condition. There is no
+    condition to wait on here: WebView2 posts its callbacks straight to the dispatcher rather than
+    onto the completion queue, and the harness leaves at least one editor task permanently pending,
+    so "the queue is empty" never becomes true. Only the first scenario of a run really needs this;
+    by the second, startup has long finished.
+    #>
+    param([int]$SettleMilliseconds = 500)
+    $Deadline = [DateTime]::UtcNow.AddMilliseconds($SettleMilliseconds)
+    while ([DateTime]::UtcNow -lt $Deadline) {
+        Invoke-E2EFlushDispatcher
+        Start-Sleep -Milliseconds 25
+    }
+}
+
+function script:Invoke-E2EGetSchemaAndWait {
+    # Retrieve the SQL schema and wait for it to land. Since issue #40 Get-SqlSchemaObject dispatches
+    # the fetch to a background worker and returns immediately, so anything asserting on the cache,
+    # the tree or the setSchema push has to wait for the completion.
+    param([double]$TimeoutSeconds = 15)
+    Get-SqlSchemaObject
+    Wait-E2ENoPendingRequests -TimeoutSeconds $TimeoutSeconds
+}
+
+function script:Invoke-E2EConnectAndWait {
+    # Connect and let the schema fetch land. Since issue #40 that fetch runs on a background worker,
+    # so a scenario asserting on the schema (or merely acting next) must wait for it.
+    param([double]$TimeoutSeconds = 15)
+    Invoke-E2EConnect
+    Wait-E2ENoPendingRequests -TimeoutSeconds $TimeoutSeconds
+}
+
 function script:Invoke-E2EExecute {
     Invoke-E2EClick -ElementName "ButtonExecuteQuery"
 }
@@ -60,6 +96,36 @@ function script:Reset-E2EScenario {
     $script:E2EFixtureOverride = $null
     $script:E2EChoiceReturn = $null
     $script:E2EChoices.Clear()
+    # Background requests complete immediately again unless a scenario asks for a slow one.
+    $script:E2ERequestDelayMs = 0
+}
+
+function script:Invoke-E2EExecuteAndWait {
+    <#
+    Click Execute and wait for the result to land. Since issue #40 the query round-trip runs on a
+    background worker, so the grid is NOT populated by the time the click returns - an assertion made
+    straight after Invoke-E2EExecute would be testing a race, not the feature. Every scenario that
+    cares about the outcome of an execute should go through here.
+    #>
+    param(
+        [double]$TimeoutSeconds = 15
+    )
+    Invoke-E2EExecute
+    Wait-E2EUntil -TimeoutSeconds $TimeoutSeconds -Message "execute to complete" -Condition {
+        # Re-enabled by Reset-ExecuteQueryUiState, which every terminal path goes through - success,
+        # failure and abandonment alike. Waiting on the grid instead would hang forever on the
+        # perfectly legitimate "query returned no rows" path.
+        $Script:MainForm.Elements.ButtonExecuteQuery.IsEnabled
+    }
+}
+
+function script:Wait-E2ENoPendingRequests {
+    # Drain any background request still in flight, so one scenario's slow query cannot complete in
+    # the middle of the next one and repoint the tab under it.
+    param([double]$TimeoutSeconds = 15)
+    Wait-E2EUntil -TimeoutSeconds $TimeoutSeconds -Message "pending background requests to drain" -Condition {
+        @($Script:PendingWebViewCompletions | Where-Object { $null -ne $_.StartedUtc }).Count -eq 0
+    }
 }
 
 function script:Reset-E2EConnection {
@@ -82,6 +148,9 @@ function script:New-E2EConnectedTab {
     New-EmptyTabSession | Out-Null   # creates and activates a new tab
     Set-E2EConnectionFields -Url $Url -Auth $Auth
     Invoke-E2EConnect
+    # Connecting fetches the SQL schema, which is a background request since issue #40. Let it land
+    # before the caller acts, so it does not complete in the middle of the caller's first step.
+    Wait-E2ENoPendingRequests
     return (Get-ActiveTabSession)
 }
 
@@ -201,6 +270,11 @@ function script:Reset-E2ETabsToOne {
     (Get-TabControlSessions).SelectedItem = $Script:Tabs[0].TabItem
     Reset-E2EConnection
     Reset-E2EScenario
+    # Settle before handing the scenario a clean tab. Since issue #40 a connect leaves a schema
+    # request in flight, and a scenario that starts while one is outstanding has it complete
+    # underneath its own first action - which repoints the tab context mid-step and makes the
+    # scenario's failures unrelated to what it is testing.
+    Wait-E2ENoPendingRequests
 }
 
 function script:Get-E2EActiveTabIndex {

--- a/tests/e2e/OmadaMocks.ps1
+++ b/tests/e2e/OmadaMocks.ps1
@@ -25,6 +25,78 @@ function script:Invoke-OmadaPSWebRequestWrapper {
     return $Response
 }
 
+# --- The background dispatch seam (issue #40) -----------------------------------------------------
+# Requests now also run on worker runspaces. The shim above cannot cover those: a worker has its own
+# OmadaWeb.PS and would call the REAL Invoke-OmadaRestMethod, so an unmocked background request would
+# reach out to whatever tenant URL the app built.
+#
+# The seam is placed at Start-OmadaBackgroundRequest rather than at
+# Invoke-OmadaPSWebRequestWrapperAsync deliberately. Everything ABOVE it stays real - the eligibility
+# gate, the parameter preparation, the completion queue, Complete-OmadaBackgroundRequest, the error
+# classification and the 50 ms poll timer - which is precisely the machinery issue #40 adds and the
+# part a scenario needs to be exercising. Only the worker's contents are replaced: the fixture is
+# resolved HERE, on the UI thread (Resolve-E2EFixture is a harness function and could not run in a
+# worker anyway), and the worker itself just waits and hands it back.
+#
+# The wait is real, on a real runspace, so a scenario can genuinely observe an in-flight request:
+# set $script:E2ERequestDelayMs to make a query take time.
+$script:E2ERequestDelayMs = 0
+
+function script:Start-OmadaBackgroundRequest {
+    param(
+        [hashtable]$Parameters,
+        $TabSession,
+        [scriptblock]$OnCompletedScriptBlock,
+        $Context,
+        [string]$Description
+    )
+
+    # Recorded in the same shape as the synchronous seam, so Get-E2ECallCount counts a background
+    # request exactly as it counts an inline one and existing assertions keep working.
+    $script:E2ECalls.Add([pscustomobject]@{
+            Uri      = [string]$Parameters.Uri
+            Method   = [string]$Parameters.Method
+            Body     = $Parameters.Body
+            DataType = $(if ($Parameters.Body -is [System.Collections.IDictionary] -and $Parameters.Body.Contains("dataType")) { [string]$Parameters.Body["dataType"] } else { $null })
+        })
+
+    $Payload = @{ Result = $null; ErrorRecord = $null }
+    try {
+        $Response = Resolve-E2EFixture -Uri $Parameters.Uri -Method $Parameters.Method -Body $Parameters.Body
+        if ($Response -is [System.Exception]) {
+            $Payload.ErrorRecord = [System.Management.Automation.ErrorRecord]::new(
+                $Response, "E2EFixtureFailure", [System.Management.Automation.ErrorCategory]::ConnectionError, $null)
+        }
+        else {
+            $Payload.Result = $Response
+        }
+    }
+    catch {
+        $Payload.ErrorRecord = $_
+    }
+
+    $Shell = [powershell]::Create()
+    [void]$Shell.AddScript({
+            param($DelayMs, $Payload)
+            if ($DelayMs -gt 0) { Start-Sleep -Milliseconds $DelayMs }
+            return $Payload
+        }).AddArgument($script:E2ERequestDelayMs).AddArgument($Payload)
+
+    $Pending = [PSCustomObject]@{
+        Task                   = $Shell.BeginInvoke()
+        Shell                  = $Shell
+        TabSession             = $TabSession
+        OnCompletedScriptBlock = $OnCompletedScriptBlock
+        StartedUtc             = [DateTime]::UtcNow
+        IsCancelled            = $false
+        IsBackgroundRequest    = $true
+        Description            = $Description
+        Context                = $Context
+    }
+    $Script:PendingWebViewCompletions.Add($Pending)
+    return $Pending
+}
+
 # --- Editor read seam: reproduce the poll-timer contract synchronously -----------------------------
 # The real poll timer sets $Script:Task then invokes the completion block. Invoke-ExecuteQuery reads
 # $Script:Task.Result as a JSON string. We invoke the block inline so execute is fully synchronous.

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -31,9 +31,31 @@ Exit code is `0` when every scenario passes, non-zero otherwise. A JUnit report 
   the real Connect/Execute/New buttons, and assert on real app state (connection status, the query and
   data-connection dropdowns, `DataGridQueryResult.ItemsSource`, the tab list, etc.).
 
-Because the single backend seam (`Invoke-OmadaPSWebRequestWrapper`) and the editor read/write seams are
-mocked to complete synchronously, each button click runs its whole handler chain inline — so the suite
-is deterministic and needs no dispatcher pumping or a rendered Monaco/WebView2 editor.
+The editor read/write seams and the synchronous backend seam (`Invoke-OmadaPSWebRequestWrapper`) are
+mocked to complete inline, so most button clicks still run their whole handler chain before
+`RaiseEvent` returns and need no rendered Monaco/WebView2 editor.
+
+**Execution is the exception, and deliberately so.** Since issue #40 the query round-trip and the
+schema fetch run on a background worker, so they do **not** finish inside the click that started
+them. The seam for those is `Start-OmadaBackgroundRequest` (see `OmadaMocks.ps1`), placed there on
+purpose: everything above it stays real — the eligibility gate, the parameter preparation, the shared
+completion queue, `Complete-OmadaBackgroundRequest`, the error classification and the 50 ms poll
+timer — and only the worker's contents are replaced. The fixture is resolved on the UI thread and the
+worker waits `$script:E2ERequestDelayMs` before handing it back, so a scenario can create a genuinely
+slow query and observe an in-flight one.
+
+That means a scenario must **wait** rather than assert straight after the click:
+
+| Helper | Use it for |
+|---|---|
+| `Invoke-E2EExecuteAndWait` | Click Execute and wait for the result to land |
+| `Invoke-E2EConnectAndWait` | Connect and let the schema fetch land |
+| `Invoke-E2EGetSchemaAndWait` | `Get-SqlSchemaObject` and wait |
+| `Wait-E2ENoPendingRequests` | Drain everything in flight (also run by `Reset-E2ETabsToOne`) |
+| `Wait-E2EUntil` | Any other condition; pumps the dispatcher and re-tests, throws on timeout |
+| `Wait-E2EAppSettled` | Let the app's own start-up callbacks land; only the first scenario of a run needs it |
+
+Asserting on the outcome of an execute without waiting tests a race, not the feature.
 
 ## Files
 

--- a/tests/e2e/scenarios/AsyncExecute.ps1
+++ b/tests/e2e/scenarios/AsyncExecute.ps1
@@ -1,0 +1,263 @@
+# Issue #40 (Roadmap C1): the query round-trip runs on a background worker and the window stays
+# responsive while it does.
+#
+# These scenarios exercise the REAL machinery. Only the contents of the worker are mocked
+# (tests/e2e/OmadaMocks.ps1 shadows Start-OmadaBackgroundRequest to resolve the fixture on the UI
+# thread and then wait in a real runspace); the eligibility gate, parameter preparation, the shared
+# completion queue, Complete-OmadaBackgroundRequest, the error classification and the 50 ms poll
+# timer are all the production code paths.
+#
+# $script:E2ERequestDelayMs is what makes an execute genuinely slow, so "the window stays responsive
+# during a long query" can be observed rather than asserted by assumption.
+
+E2ESuite -Name "AsyncExecute" -Body {
+
+    E2ECase -Name "the execute round-trip does not complete inside the click that started it" -Body {
+        # The whole point of the issue, stated as the one assertion that fails against the old
+        # synchronous code: after Invoke-E2EExecute returns, the result is NOT yet in hand.
+        Reset-E2ETabsToOne
+        Set-E2EConnectionFields
+        Invoke-E2EConnectAndWait
+        Select-E2EQuery | Out-Null
+        # This suite runs first, so it is the one scenario that can still race the app's own start-up
+        # work: WebView2 posts NavigationCompleted straight to the dispatcher, and the deferred
+        # editor/query work it triggers re-enables the very button this case asserts on. Settling
+        # first makes the case about the feature rather than about start-up timing.
+        Wait-E2EAppSettled
+
+        $script:E2ERequestDelayMs = 700
+        $Elements = Get-E2EElements
+        $Elements.DataGridQueryResult.ItemsSource = $null
+
+        Invoke-E2EExecute
+
+        E2EAssertTrue ($null -eq $Elements.DataGridQueryResult.ItemsSource) "the grid must not be populated by the time the click returns"
+        E2EAssertTrue (-not $Elements.ButtonExecuteQuery.IsEnabled) "Execute should still be disabled while the query is in flight"
+
+        Wait-E2EUntil -TimeoutSeconds 15 -Message "the query to complete" -Condition { $Elements.ButtonExecuteQuery.IsEnabled }
+        E2EAssertEqual 2 (@($Elements.DataGridQueryResult.ItemsSource).Count) "the grid should be populated once the result lands"
+    }
+
+    E2ECase -Name "the UI thread stays responsive while a long query is in flight" -Body {
+        # "Responsive" measured the only way it can be from inside the app: dispatcher work of a
+        # priority BELOW rendering still gets to run promptly while the request is outstanding. Under
+        # the old synchronous code the dispatcher was blocked inside Invoke-OmadaRestMethod and this
+        # could not have completed at all until the query finished.
+        Reset-E2ETabsToOne
+        Set-E2EConnectionFields
+        Invoke-E2EConnect
+        Select-E2EQuery | Out-Null
+
+        $script:E2ERequestDelayMs = 1500
+        $Elements = Get-E2EElements
+
+        Invoke-E2EExecute
+
+        $Stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+        Invoke-E2EFlushDispatcher
+        $Stopwatch.Stop()
+
+        E2EAssertTrue (-not $Elements.ButtonExecuteQuery.IsEnabled) "the query should still be in flight for this to mean anything"
+        E2EAssertTrue ($Stopwatch.ElapsedMilliseconds -lt 500) ("a dispatcher round-trip took {0} ms while a 1500 ms query was in flight; the UI thread is blocked" -f $Stopwatch.ElapsedMilliseconds)
+
+        Wait-E2ENoPendingRequests
+    }
+
+    E2ECase -Name "a tab switch mid-flight works and the result still lands on the originating tab" -Body {
+        # The completion queue repoints to the owning tab via Set-ActiveTabContext before invoking a
+        # completion block, and restores the previous tab afterwards. With execution off-thread that
+        # path is reachable for the first time in a way the user can trigger by hand.
+        Reset-E2ETabsToOne
+        Set-E2EConnectionFields
+        Invoke-E2EConnect
+        Select-E2EQuery | Out-Null
+
+        $ExecutingTab = Get-ActiveTabSession
+        $ExecutingTab.Elements.DataGridQueryResult.ItemsSource = $null
+
+        $script:E2ERequestDelayMs = 700
+        Invoke-E2EExecute
+
+        $OtherTab = New-EmptyTabSession
+        E2EAssertTrue ((Get-ActiveTabSession).Id -eq $OtherTab.Id) "the new tab should be active while the first tab's query is in flight"
+
+        Wait-E2EUntil -TimeoutSeconds 15 -Message "the backgrounded tab's query to complete" -Condition {
+            $ExecutingTab.Elements.ButtonExecuteQuery.IsEnabled
+        }
+
+        E2EAssertEqual 2 (@($ExecutingTab.Elements.DataGridQueryResult.ItemsSource).Count) "the result must land on the tab that issued it"
+        E2EAssertTrue ($null -eq $OtherTab.Elements.DataGridQueryResult.ItemsSource) "the result must NOT land on the tab that happened to be active"
+        E2EAssertTrue ((Get-ActiveTabSession).Id -eq $OtherTab.Id) "the active tab must be restored after the completion ran"
+    }
+
+    E2ECase -Name "two tabs executing at once both get their own result" -Body {
+        Reset-E2ETabsToOne
+        Set-E2EConnectionFields
+        Invoke-E2EConnect
+        Select-E2EQuery | Out-Null
+        $FirstTab = Get-ActiveTabSession
+        $FirstTab.Elements.DataGridQueryResult.ItemsSource = $null
+
+        $script:E2ERequestDelayMs = 900
+        Invoke-E2EExecute
+
+        $SecondTab = New-E2EConnectedTab
+        Select-E2EQuery | Out-Null
+        $SecondTab.Elements.DataGridQueryResult.ItemsSource = $null
+        Invoke-E2EExecute
+
+        Wait-E2EUntil -TimeoutSeconds 20 -Message "both tabs' queries to complete" -Condition {
+            $FirstTab.Elements.ButtonExecuteQuery.IsEnabled -and $SecondTab.Elements.ButtonExecuteQuery.IsEnabled
+        }
+
+        E2EAssertEqual 2 (@($FirstTab.Elements.DataGridQueryResult.ItemsSource).Count) "the first tab should have its own result"
+        E2EAssertEqual 2 (@($SecondTab.Elements.DataGridQueryResult.ItemsSource).Count) "the second tab should have its own result"
+    }
+
+    E2ECase -Name "an error mid-flight returns the UI to a clean state" -Body {
+        # The failure has to arrive from the WORKER, travel back through
+        # Complete-OmadaBackgroundRequest and Resolve-OmadaRequestFailure, and still leave the tab
+        # usable. Before issue #40 a failing request threw on the UI thread inside the click; now it
+        # is a value that crosses a runspace boundary, which is a genuinely different path.
+        Reset-E2ETabsToOne
+        Set-E2EConnectionFields
+        Invoke-E2EConnect
+        Select-E2EQuery | Out-Null
+
+        $Elements = Get-E2EElements
+
+        $script:E2ERequestDelayMs = 300
+        $script:E2EFixtureOverride = {
+            param($Path, $Method, $DataType, $Body)
+            if ($DataType -eq "SqlDataProducer") {
+                return @{ Value = ([System.Exception]::new("Internal Server Error")) }
+            }
+            return $null
+        }
+
+        try {
+            Invoke-E2EExecuteAndWait
+
+            E2EAssertTrue $Elements.ButtonExecuteQuery.IsEnabled "Execute must be re-enabled after a failure"
+            E2EAssertTrue $Elements.ButtonSaveQuery.IsEnabled "Save must be re-enabled after a failure"
+            E2EAssertTrue ($null -eq $Script:PopupWindowExecuteQuery) "the 'Executing Query...' popup must be closed after a failure"
+            # Note, deliberately not asserted as desirable: a failed execute still reports "0 rows"
+            # and clears the grid, exactly as it did before this change. That is the "empty result vs
+            # failed query" ambiguity of issue #44, and fixing it here would be scope drift. What
+            # matters for #40 is that the failure gets back from the worker and the tab is usable.
+            E2EAssertTrue ((Get-E2ECallCount -MethodLike "POST" -DataType "SqlDataProducer") -ge 1) "the failing execute should still have been issued"
+        }
+        finally {
+            $script:E2EFixtureOverride = $null
+        }
+    }
+
+    E2ECase -Name "the elapsed-time indicator counts up while a query is in flight" -Body {
+        # Before issue #40 the stopwatch was read exactly once, at the very end - so the number only
+        # appeared after the wait was over, which is the one moment it is of no use.
+        Reset-E2ETabsToOne
+        Set-E2EConnectionFields
+        Invoke-E2EConnect
+        Select-E2EQuery | Out-Null
+
+        $Elements = Get-E2EElements
+        $Elements.TextBlockStatusBarQueryTime.Text = "-"
+
+        $script:E2ERequestDelayMs = 1600
+        Invoke-E2EExecute
+
+        Wait-E2EUntil -TimeoutSeconds 10 -Message "the elapsed-time indicator to update mid-flight" -Condition {
+            $Elements.TextBlockStatusBarQueryTime.Text -ne "-"
+        }
+        E2EAssertTrue (-not $Elements.ButtonExecuteQuery.IsEnabled) "the indicator must have updated while the query was still running"
+
+        Wait-E2ENoPendingRequests
+    }
+
+    E2ECase -Name "an unrelated completion landing mid-execute does not re-enable Execute" -Body {
+        # Regression guard for a class of bug that only exists now that several requests can be in
+        # flight at once: the completion poll timer repoints the tab context around EVERY completion
+        # it drains, so a schema fetch landing in the middle of an execute runs Set-ActiveTabContext
+        # (and everything downstream of it) while the execute is still outstanding. If any of that
+        # re-enables the Execute button, the user can start a second query on a tab that is already
+        # running one.
+        Reset-E2ETabsToOne
+        Set-E2EConnectionFields
+        Invoke-E2EConnectAndWait
+        Select-E2EQuery | Out-Null
+
+        $Elements = Get-E2EElements
+
+        $script:E2ERequestDelayMs = 900
+        Invoke-E2EExecute
+        E2EAssertTrue (-not $Elements.ButtonExecuteQuery.IsEnabled) "arrange: Execute should be disabled while the query is in flight"
+
+        # Force a second, unrelated background request onto the queue and let it complete first.
+        $Script:SqlSchemaCache = @{}
+        $script:E2ERequestDelayMs = 0
+        Get-SqlSchemaObject
+        Wait-E2EUntil -TimeoutSeconds 10 -Message "the schema request to land" -Condition {
+            @($Script:PendingWebViewCompletions | Where-Object { $_.Description -eq "SQL schema" }).Count -eq 0
+        }
+
+        E2EAssertTrue (-not $Elements.ButtonExecuteQuery.IsEnabled) "Execute must still be disabled: the query it belongs to is still running"
+
+        Wait-E2ENoPendingRequests
+        E2EAssertTrue $Elements.ButtonExecuteQuery.IsEnabled "Execute should be re-enabled once the query itself completes"
+    }
+
+    E2ECase -Name "closing a tab abandons its in-flight request instead of letting it repoint the app" -Body {
+        # Found while building this suite, and a real defect rather than a tidiness measure. Nothing
+        # used to remove a closing tab's entries from the completion queue. A background request's
+        # completion calls Set-ActiveTabContext with its own TabSession, which repoints
+        # $Script:MainForm.Elements, $Script:RunTimeData, $Script:AppConfig and
+        # $Script:ConnectionStatus - onto a tab that no longer exists - and the restore in the poll
+        # timer's finally cannot undo it, because Get-ActiveTabSession returns $null when the closed
+        # tab was the active one.
+        Reset-E2ETabsToOne
+        Set-E2EConnectionFields
+        Invoke-E2EConnectAndWait
+        $KeepTab = Get-ActiveTabSession
+
+        $DoomedTab = New-E2EConnectedTab
+        Select-E2EQuery | Out-Null
+
+        $script:E2ERequestDelayMs = 1200
+        Invoke-E2EExecute
+        E2EAssertEqual 1 (@($Script:PendingWebViewCompletions | Where-Object { $_.Description -eq "Execute query" }).Count) "arrange: the doomed tab should have a query in flight"
+
+        Close-TabSession -TabId $DoomedTab.Id
+
+        E2EAssertEqual 0 (@($Script:PendingWebViewCompletions | Where-Object { $_.Description -eq "Execute query" }).Count) "closing the tab must drop its in-flight request from the completion queue"
+
+        # Pump past the point the abandoned request would have completed, so a completion that
+        # somehow survived has every chance to do damage before the assertions below.
+        $Deadline = [DateTime]::UtcNow.AddMilliseconds(1800)
+        while ([DateTime]::UtcNow -lt $Deadline) {
+            Invoke-E2EFlushDispatcher
+            Start-Sleep -Milliseconds 50
+        }
+
+        E2EAssertTrue ((Get-ActiveTabSession).Id -eq $KeepTab.Id) "the surviving tab must still be the active one"
+        E2EAssertTrue ([object]::ReferenceEquals($Script:MainForm.Elements, $KeepTab.Elements)) "the app's element bag must still point at the surviving tab, not the closed one"
+    }
+
+    E2ECase -Name "the background path is not taken for a tab that is not connected" -Body {
+        # The authentication policy, observed from the outside: off-thread execution is only offered
+        # to a session that already authenticated on the UI thread, because OmadaWeb.PS would
+        # otherwise open an ownerless login window from a worker.
+        Reset-E2ETabsToOne
+        Set-E2EConnectionFields
+        Invoke-E2EConnect
+        Select-E2EQuery | Out-Null
+
+        $Parameters = @{ ForceAuthentication = $false }
+        E2EAssertTrue (Test-OmadaBackgroundRequestEligible -Parameters $Parameters) "a connected tab should be eligible"
+
+        $Script:ConnectionStatus = $false
+        E2EAssertTrue (-not (Test-OmadaBackgroundRequestEligible -Parameters $Parameters)) "a disconnected tab must not be eligible"
+
+        $Script:ConnectionStatus = $true
+        E2EAssertTrue (-not (Test-OmadaBackgroundRequestEligible -Parameters @{ ForceAuthentication = $true })) "a re-authenticating request must not be eligible"
+    }
+}

--- a/tests/e2e/scenarios/Core.ps1
+++ b/tests/e2e/scenarios/Core.ps1
@@ -27,7 +27,7 @@ E2ESuite -Name "Execute" -Body {
         $Item = Select-E2EQuery
         E2EAssertTrue ($null -ne $Item) "Query item 'TestQuery - 100' should exist in the dropdown"
 
-        Invoke-E2EExecute
+        Invoke-E2EExecuteAndWait
 
         $Elements = Get-E2EElements
         E2EAssertEqual 2 ([int]$Script:RunTimeData.QueryResult.d.Records) "Records count should match the fixture"
@@ -42,7 +42,7 @@ E2ESuite -Name "Execute" -Body {
         Set-E2EConnectionFields
         Invoke-E2EConnect
         Select-E2EQuery | Out-Null
-        Invoke-E2EExecute
+        Invoke-E2EExecuteAndWait
 
         $Elements = Get-E2EElements
         E2EAssertEqual 0 ([int]$Script:RunTimeData.QueryResult.d.Records) "Records should be 0 for an empty result"

--- a/tests/e2e/scenarios/NoReconnect.ps1
+++ b/tests/e2e/scenarios/NoReconnect.ps1
@@ -133,8 +133,17 @@ E2ESuite -Name "NoReconnectStartup" -Body {
         New-E2EPersistedTabStore -TabCount 1 | Out-Null
         Initialize-E2ERestoreRun -NoReconnect $false
         $script:E2EChoiceReturn = 2
+        # "Retrieves its schema" is only observable from a COLD cache. The schema cache is keyed by
+        # pool SessionKey + data connection and lives for the whole session, and every scenario in
+        # this run connects to the same tenant with the same identity - so by the time this one runs
+        # the key is warm and a correct connect issues no request at all. Emptying it here is what
+        # makes the assertion about the connect path rather than about which scenarios ran first.
+        $Script:SqlSchemaCache = @{}
 
         Restore-TabSessions
+        # The schema fetch a successful reconnect triggers is a background request since issue #40,
+        # so the call it makes is not on the record until the request has actually been issued.
+        Wait-E2ENoPendingRequests
 
         E2EAssertEqual 1 (Get-E2EChoices -TitleLike "Reconnect?").Count "the reconnect prompt should be shown"
         E2EAssertTrue ($Script:ConnectionStatus) "accepting the prompt must connect the restored tab"

--- a/tests/e2e/scenarios/Regression.ps1
+++ b/tests/e2e/scenarios/Regression.ps1
@@ -6,7 +6,11 @@ E2ESuite -Name "SchemaCache" -Body {
     E2ECase -Name "the SQL schema is fetched once per pool + data connection and reused from cache" -Body {
         Reset-E2ETabsToOne
         Set-E2EConnectionFields
-        Invoke-E2EConnect
+        # Waited for, so the connect's own schema request has drained before the cache is emptied
+        # below. Left outstanding it would suppress BOTH calls, since a request for that key really
+        # would already be in flight - and the case would pass for the wrong reason, measuring the
+        # in-flight guard instead of the cache.
+        Invoke-E2EConnectAndWait
 
         # Provide the schema window objects Get-SqlSchemaObject writes into (it is normally driven by
         # the schema window). Created on the UI/dispatcher thread so WPF is happy.

--- a/tests/e2e/scenarios/Regression.ps1
+++ b/tests/e2e/scenarios/Regression.ps1
@@ -20,8 +20,12 @@ E2ESuite -Name "SchemaCache" -Body {
         $Script:SqlSchemaCache = @{}
 
         $script:E2ECalls.Clear()
+        # Both calls are issued before the first response lands, which is exactly the case the
+        # in-flight guard exists for: the cache alone cannot suppress the second one, because the
+        # cache is only populated when a response arrives.
         Get-SqlSchemaObject
         Get-SqlSchemaObject
+        Wait-E2ENoPendingRequests
 
         E2EAssertEqual 1 (Get-E2ECallCount -MethodLike "POST" -UriLike "*getsqlschema*") "the schema POST should fire once; the second call is served from the pool cache"
     }
@@ -35,7 +39,7 @@ E2ESuite -Name "SchemaCache" -Body {
         $Script:SqlSchemaForm = [pscustomobject]@{ Definition = (New-Object System.Windows.Window) }
 
         $script:E2EEditorScripts.Clear()
-        Get-SqlSchemaObject
+        Invoke-E2EGetSchemaAndWait
 
         $SetSchema = $script:E2EEditorScripts | Where-Object { $_ -like "setSchema(*" } | Select-Object -Last 1
         E2EAssertTrue ($null -ne $SetSchema) "a setSchema(...) script should be pushed to the editor"
@@ -59,7 +63,7 @@ E2ESuite -Name "SchemaCache" -Body {
 
         $script:E2EEditorScripts.Clear()
         $script:E2ELogMessages.Clear()
-        Get-SqlSchemaObject
+        Invoke-E2EGetSchemaAndWait
 
         $SetSchema = $script:E2EEditorScripts | Where-Object { $_ -like "setSchema(*" } | Select-Object -Last 1
         E2EAssertTrue ($null -ne $SetSchema) "setSchema(...) must still be pushed with the schema window closed"
@@ -88,6 +92,7 @@ E2ESuite -Name "SchemaCache" -Body {
 
         $script:E2EEditorScripts.Clear()
         $ComboBoxDataConnection.SelectedItem = $TargetItem
+        Wait-E2ENoPendingRequests
 
         $SetSchema = $script:E2EEditorScripts | Where-Object { $_ -like "setSchema(*" } | Select-Object -Last 1
         E2EAssertTrue ($null -ne $SetSchema) "selecting a data connection should push that database's schema to the editor"
@@ -130,17 +135,19 @@ E2ESuite -Name "SchemaWindowTabSwitch" -Body {
 
         try {
             E2EAssertTrue (Test-SqlSchemaFormIsVisible) "the mock schema window should be visible for the test"
-            Get-SqlSchemaObject
+            Invoke-E2EGetSchemaAndWait
             E2EAssertTrue ($Script:SqlSchemaForm.Definition.Title -like "*OtherDB*") "the schema window should first show tab B's database (OtherDB)"
 
             # Switch to tab A: the schema window must follow it to OISES. This is the discriminating
             # assertion - without the fix the window stays on tab B's OtherDB.
             (Get-TabControlSessions).SelectedItem = $TabA.TabItem
+            Wait-E2ENoPendingRequests
             $TitleAfterA = $Script:SqlSchemaForm.Definition.Title
             E2EAssertTrue ($TitleAfterA -like "*OISES*") ("switching to tab A must refresh the schema window to tab A's database (OISES); actual='{0}', visible='{1}'" -f $TitleAfterA, (Test-SqlSchemaFormIsVisible))
 
             # And switching back to tab B follows it to OtherDB.
             (Get-TabControlSessions).SelectedItem = $TabB.TabItem
+            Wait-E2ENoPendingRequests
             E2EAssertTrue ($Script:SqlSchemaForm.Definition.Title -like "*OtherDB*") "switching to tab B must refresh the schema window to tab B's database (OtherDB)"
         }
         finally {


### PR DESCRIPTION
Slice **C1-3** of **#40** (Roadmap C1). Targets the working baseline branch `feature/async-query-execution`, not `main`.

**The headline.** The `GetPagingData` round-trip — the call that actually freezes the window for the length of a query — now runs on a background worker, and its completion binds the grid from the poll timer with the owning tab made active.

## Scope, stated plainly

Everything **before** the round-trip stays synchronous: reading the editor, the syntax gate, `Save-Query`, and creating the temporary selection object. They are short calls, and two of them can open a modal dialog, which belongs on the UI thread. Moving those off-thread is **C1-5**, with a far larger blast radius.

| Piece | What it does |
|---|---|
| `Complete-ExecuteQueryResult` | Everything once a result is in hand — identical for the inline and background paths |
| `Reset-ExecuteQueryUiState` | The teardown, in one place |
| `Update-BackgroundRequestElapsedTime` | The live elapsed-time indicator |
| `Remove-PendingBackgroundRequest` | Abandons a closing tab's in-flight requests |

## Decisions worth reviewing

- **The completion gets everything on the pending item; it re-reads no `$Script:` state.** `$Private:Result` (the `Save-Query` outcome) and the temporary object id exist nowhere else by the time a response lands, and the active tab may have changed. This is the discipline #40's analysis calls for, applied from the first async caller rather than retrofitted in C1-5.
- **Ownership of the temporary object passes to the completion on dispatch**, so the dispatching frame nulls its own copy. Otherwise its `catch` would delete an object the in-flight query is still executing against. (`Stop-ExecuteQueryRequest` reads it back off the pending item in C1-4.)
- **`Reset-ExecuteQueryUiState` exists because the teardown was written out five times** in slightly different forms — one copy forgot the stopwatch, another the status bar — and this change would have added a sixth. It deliberately does **not** touch the grid: a failed or abandoned execute must not blank a good previous result.
- **Elapsed time is driven from the existing 50 ms poll timer, every 20th tick — not a second `DispatcherTimer`.** That timer already knows about pending work and is already suspended around modal dialogs; a second one would have to learn both again, and would tick while a modal was open — the exact reentrancy `Suspend-WebViewCompletionPolling` exists to prevent.
- **It writes to the owning tab's status bar**, not through `$Script:MainForm.Elements`, so no `Set-ActiveTabContext` twenty times a second. A backgrounded tab counts up while the user watches another, which is the correct behaviour anyway.

## Two real defects found while building the E2E coverage

Both are only reachable now that several requests can be in flight at once, and both are worth reading closely.

### 1. Closing a tab left its in-flight requests on the completion queue

A background request's completion calls `Set-ActiveTabContext` with its own `TabSession` — repointing `$Script:MainForm.Elements`, `$Script:RunTimeData`, `$Script:AppConfig` and `$Script:ConnectionStatus` **onto a tab that no longer exists** — then writes results into disposed WPF elements.

The restore in the timer's `finally` cannot undo it: `Get-ActiveTabSession` returns `$null` when the closed tab was the active one, so the restore is **skipped** and the whole application is left pointing at a dead tab.

Fixed in `Remove-PendingBackgroundRequest` (called from `Complete-TabClose`, which also stops and disposes the worker so its runspace is not returned to the pool), with a second guard in the poll timer itself.

### 2. C1-0's dispatcher pump opened a reentrancy window in the Execute click

Pumping the dispatcher is exactly what lets the poll timer fire. A completion drained there ran `Set-ActiveTabContext` **in the middle of the click handler**, after it had already disabled the buttons on the tab it started with.

Observed, not theorised: the buttons stayed disabled on the *old* element bag while the execute ran against a different one. The pump is now wrapped in `Suspend`/`Resume-WebViewCompletionPolling`, which keeps the render pass (all it needs) and denies the timer.

This is a hazard C1-0 introduced and this slice made visible. Worth noting for the record: `Start-Sleep` could not cause it, because it never pumped.

### And one design correction

The schema cache alone stopped being enough once that fetch went off-thread, because **the cache is only populated when a response lands** — two calls close together both missed it and both hit the tenant. The "already in flight" check reads the completion queue directly rather than a side table of keys: a side table must be cleared on every path a request can leave by, and a key left behind on the abandonment path would block that pool and database from **ever** fetching its schema again for the session. `-not IsCompleted` matters too — an item whose worker finished but which the timer has not drained is *not* in flight, and treating it as such would refuse the fetch and leave the caller with no schema at all.

## E2E

Seven new scenarios: a long query stays responsive, a tab switch mid-flight, two tabs at once, an error mid-flight, the elapsed-time indicator, the eligibility policy, and the two defects above.

The seam is `Start-OmadaBackgroundRequest`, chosen so the eligibility gate, the completion queue, `Complete-OmadaBackgroundRequest`, the error classification and the poll timer are all **real**; only the worker's contents are replaced, and it waits `$script:E2ERequestDelayMs` so a slow query can genuinely be observed rather than assumed.

`tests/e2e/README.md` now documents that execution is asynchronous and which wait helper to use — asserting on the outcome of an execute without waiting tests a race, not the feature.

## Verification

```
Invoke-Pester -Path tests          →  667 passed, 0 failed  (28 new)
build/build.ps1 -Task E2E          →  47 tests, 0 failures  (run twice for flakiness)
PSScriptAnalyzer, build's profile  →  clean
```

## Not covered

Everything in #40's authentication analysis, unchanged from C1-2: the mock replaces `Invoke-OmadaRestMethod`, so no authentication ever happens under test. Live-tenant verification of a genuinely slow query and an expired cookie mid-request is still needed.

The error path still reports "0 rows" and clears the grid, exactly as before this change. That is issue #44's "empty result vs failed query" ambiguity; fixing it here would be scope drift, and the scenario says so rather than quietly asserting the current behaviour is desirable.
