### PR TITLE
Add a Cancel button that abandons the wait, honestly (C1-4)

### DIFF
--- a/src/Lib/Events/MainFormTabContent.Elements.ButtonExecuteQuery.ps1
+++ b/src/Lib/Events/MainFormTabContent.Elements.ButtonExecuteQuery.ps1
@@ -2,6 +2,16 @@ $Script:MainForm.Elements.ButtonExecuteQuery.Add_Click({
         try {
             $_ | Show-EventInfo
 
+            # While a query is in flight this button reads "Cancel" (Set-ExecuteQueryButtonState), so
+            # a click here is a request to stop waiting rather than to execute again. Checked first,
+            # before any of the start-an-execute work below - starting a stopwatch and showing a
+            # popup on the way to cancelling would be exactly backwards.
+            if ($null -ne (Get-ActiveExecuteQueryRequest)) {
+                "Cancel requested for the running query." | Write-LogOutput
+                Stop-ExecuteQueryRequest
+                return
+            }
+
             $Script:RunTimeData.StopWatch = [System.Diagnostics.Stopwatch]::StartNew()
 
             $Script:PopupWindowExecuteQuery = Show-PopupWindow -Message "Executing Query..."

--- a/src/Lib/Functions/Private/Get-ActiveExecuteQueryRequest.ps1
+++ b/src/Lib/Functions/Private/Get-ActiveExecuteQueryRequest.ps1
@@ -1,0 +1,37 @@
+function Get-ActiveExecuteQueryRequest {
+    <#
+    .SYNOPSIS
+    The in-flight execute request belonging to a tab, or $null when that tab is not executing.
+
+    .DESCRIPTION
+    Read straight off the completion queue rather than from a per-tab "IsExecuting" flag, for the
+    same reason Get-SqlSchemaObject checks the queue for a schema fetch: a flag has to be cleared on
+    every path a request can leave by - success, failure, cancellation, and abandonment when its tab
+    is closed - and one missed path leaves a tab that can never execute again. The queue is the
+    single record of what is outstanding and cannot get out of step with itself.
+
+    Cancelled items are excluded: the pipeline may take a moment to stop, but as far as the UI is
+    concerned that request is over the instant the user asked for it to be.
+
+    .PARAMETER TabSession
+    The tab to ask about. Defaults to the active one.
+    #>
+    [CmdLetBinding()]
+    param(
+        $TabSession
+    )
+
+    if ($null -eq $TabSession) {
+        $TabSession = Get-ActiveTabSession
+    }
+    if ($null -eq $TabSession -or $null -eq $Script:PendingWebViewCompletions) {
+        return $null
+    }
+
+    return @($Script:PendingWebViewCompletions | Where-Object {
+            $_.Description -eq $Script:ExecuteQueryRequestDescription -and
+            $null -ne $_.TabSession -and
+            $_.TabSession.Id -eq $TabSession.Id -and
+            -not $_.IsCancelled
+        }) | Select-Object -First 1
+}

--- a/src/Lib/Functions/Private/Initialize-UiComponents.ps1
+++ b/src/Lib/Functions/Private/Initialize-UiComponents.ps1
@@ -41,4 +41,10 @@ function Initialize-UiComponents {
 
     #Initialize UI DataGridQueryResult column selection anchor
     $Script:DataGridQueryResultColumnSelectionAnchor = $null
+
+    # Execute/Cancel (issue #40). Set-ActiveTabContext calls this on every tab switch, so switching to
+    # a tab whose query is still running shows Cancel, and switching away and back does not lose it.
+    # Derived from the completion queue, so it is correct here without any per-tab flag to keep in
+    # step - which is the same reason Test-ConnectionButton can be called freely.
+    Set-ExecuteQueryButtonState
 }

--- a/src/Lib/Functions/Private/Invoke-ExecuteQuery.ps1
+++ b/src/Lib/Functions/Private/Invoke-ExecuteQuery.ps1
@@ -196,9 +196,19 @@ function Reset-ExecuteQueryUiState {
     )
 
     try {
-        $Script:MainForm.Elements.ButtonSaveQuery.IsEnabled = $true
-        $Script:MainForm.Elements.ButtonExecuteQuery.IsEnabled = $true
-        # Back to "Execute": by the time any caller reaches this, the request is off the queue -
+        # Only for a tab that is still connected. A query can now outlive the connection it was
+        # issued on - the user can disconnect, or a 401 can tear the tab down through
+        # Set-SqlConnectionState, while the request is in flight - and the completion still runs
+        # afterwards. Re-enabling here unconditionally would hand a disconnected tab a live Execute
+        # and Save button: the "in-between tab state" of issue #65, arrived at from a new direction.
+        # Set-SqlQueryFunctionState remains the single writer of these when disconnected.
+        if ($Script:ConnectionStatus) {
+            $Script:MainForm.Elements.ButtonSaveQuery.IsEnabled = $true
+            $Script:MainForm.Elements.ButtonExecuteQuery.IsEnabled = $true
+        }
+
+        # Back to "Execute" either way: a tab must never be left showing Cancel with nothing to
+        # cancel, connected or not. By the time any caller reaches this the request is off the queue -
         # drained by the poll timer, or removed by Stop-ExecuteQueryRequest before it called here.
         Set-ExecuteQueryButtonState
 

--- a/src/Lib/Functions/Private/Invoke-ExecuteQuery.ps1
+++ b/src/Lib/Functions/Private/Invoke-ExecuteQuery.ps1
@@ -115,7 +115,7 @@ function Invoke-ExecuteQuery {
                     # $Script: state: by the time the response lands the user may be looking at
                     # another tab, and $Private:Result (the Save-Query outcome) and the temporary
                     # object id do not exist anywhere else.
-                    $Private:Pending = Invoke-OmadaPSWebRequestWrapperAsync -Description "Execute query" -Context @{
+                    $Private:Pending = Invoke-OmadaPSWebRequestWrapperAsync -Description $Script:ExecuteQueryRequestDescription -Context @{
                         SaveResult    = $Private:Result
                         TempQueryDoId = $Private:TempQueryDoId
                     } -OnResultScriptBlock {
@@ -126,8 +126,12 @@ function Invoke-ExecuteQuery {
                     if ($null -ne $Private:Pending) {
                         # Dispatched. Ownership of the temporary object passes to the completion, so
                         # this frame must forget it - otherwise the catch below would delete an object
-                        # the in-flight query is still executing against.
+                        # the in-flight query is still executing against. (Stop-ExecuteQueryRequest
+                        # reads it back off the pending item if the user cancels.)
                         $Private:TempQueryDoId = $null
+                        # The Execute button becomes Cancel: from here the only useful thing the user
+                        # can do with it is stop waiting.
+                        Set-ExecuteQueryButtonState
                         return
                     }
 
@@ -162,6 +166,11 @@ function Invoke-ExecuteQuery {
     }
 }
 
+# The label an execute request carries on the completion queue. A constant because it is matched,
+# not just displayed: Get-ActiveExecuteQueryRequest reads the queue through it to decide whether the
+# active tab is executing, which is what drives the Execute/Cancel button.
+$Script:ExecuteQueryRequestDescription = "Execute query"
+
 function Reset-ExecuteQueryUiState {
     <#
     .SYNOPSIS
@@ -189,6 +198,9 @@ function Reset-ExecuteQueryUiState {
     try {
         $Script:MainForm.Elements.ButtonSaveQuery.IsEnabled = $true
         $Script:MainForm.Elements.ButtonExecuteQuery.IsEnabled = $true
+        # Back to "Execute": by the time any caller reaches this, the request is off the queue -
+        # drained by the poll timer, or removed by Stop-ExecuteQueryRequest before it called here.
+        Set-ExecuteQueryButtonState
 
         if ($null -ne $Script:PopupWindowExecuteQuery) {
             $Script:PopupWindowExecuteQuery.Close()

--- a/src/Lib/Functions/Private/Set-ExecuteQueryButtonState.ps1
+++ b/src/Lib/Functions/Private/Set-ExecuteQueryButtonState.ps1
@@ -1,0 +1,58 @@
+function Set-ExecuteQueryButtonState {
+    <#
+    .SYNOPSIS
+    Make the Execute button read "Execute" or "Cancel" according to whether the active tab has a
+    query in flight.
+
+    .DESCRIPTION
+    Issue #40's Cancel. The button the user just pressed becomes the way to stop - the same pattern
+    the Connect button already uses for Disconnect (Test-ConnectionButton), so there is no new
+    control and no new place for a tab's state to disagree with what is on screen.
+
+    Driven off the completion queue via Get-ActiveExecuteQueryRequest, so it is correct whenever it
+    is called and needs no flag kept in step. It is called after dispatch, after completion, and from
+    Initialize-UiComponents - which Set-ActiveTabContext runs on every tab switch, so switching to a
+    tab that is still executing shows Cancel, and switching away and back does not lose it.
+
+    .NOTES
+    Cancel here means "stop waiting", not "stop the query". Omada goes on executing it; there is no
+    server-side cancellation to call (that is issue #43). The tooltip says so rather than implying a
+    power the app does not have.
+    #>
+    [CmdLetBinding()]
+    param()
+
+    try {
+        if ($null -eq $Script:MainForm -or $null -eq $Script:MainForm.Elements -or $null -eq $Script:MainForm.Elements.ButtonExecuteQuery) {
+            return
+        }
+
+        $Private:InFlight = $null -ne (Get-ActiveExecuteQueryRequest)
+
+        if ($Private:InFlight) {
+            # Enabled, deliberately: this is the one control that must stay live while the rest of
+            # the query controls are disabled, because it is now the way out.
+            $Script:MainForm.Elements.ButtonExecuteQuery.IsEnabled = $true
+            $Script:MainForm.Elements.ButtonExecuteQuery.ToolTip = "Stop waiting for this query. The query itself keeps running on the server."
+            if ($null -ne $Script:MainForm.Elements.ButtonExecuteQueryText) {
+                $Script:MainForm.Elements.ButtonExecuteQueryText | Set-ButtonText -Value "_Cancel"
+            }
+            if ($null -ne $Script:MainForm.Elements.ButtonExecuteQueryImage) {
+                # Segoe MDL2 "Cancel" (E711), replacing the "Play" glyph.
+                $Script:MainForm.Elements.ButtonExecuteQueryImage.Text = [char]0xE711
+            }
+        }
+        else {
+            $Script:MainForm.Elements.ButtonExecuteQuery.ToolTip = "Execute"
+            if ($null -ne $Script:MainForm.Elements.ButtonExecuteQueryText) {
+                $Script:MainForm.Elements.ButtonExecuteQueryText | Set-ButtonText -Value "_Execute"
+            }
+            if ($null -ne $Script:MainForm.Elements.ButtonExecuteQueryImage) {
+                $Script:MainForm.Elements.ButtonExecuteQueryImage.Text = [char]0xE768
+            }
+        }
+    }
+    catch {
+        $_.Exception.Message | Write-LogOutput -LogType ERROR -ErrorObject $_
+    }
+}

--- a/src/Lib/Functions/Private/Stop-ExecuteQueryRequest.ps1
+++ b/src/Lib/Functions/Private/Stop-ExecuteQueryRequest.ps1
@@ -1,0 +1,78 @@
+function Stop-ExecuteQueryRequest {
+    <#
+    .SYNOPSIS
+    Abandon the wait for the active tab's in-flight query and return the tab to a clean state.
+
+    .DESCRIPTION
+    Issue #40's Cancel button. What it does, precisely, and the wording matters because the UI says
+    the same thing:
+
+      - It stops THIS APPLICATION waiting. The query goes on executing on the Omada server. There is
+        no server-side cancellation to call - that is issue #43 - so claiming otherwise would be a
+        lie the user could act on (starting a "replacement" query while the first still holds the
+        same server resources).
+      - The temporary TMP_<guid> object created for an "execute selection" run is still deleted.
+        Cancelling between creating it and the completion that would have removed it is exactly how
+        one gets left behind on the tenant. New-TemporarySqlQueryObject reuses and undeletes a stale
+        one on the next run, so the damage self-heals - but leaving litter on someone's tenant
+        because they clicked Cancel is not acceptable.
+      - The results grid is left alone. Abandoning a query must not blank a perfectly good previous
+        result.
+
+    .NOTES
+    The stopped runspace is discarded, not returned to the pool. A pipeline killed mid-request leaves
+    a half-read HTTP stream and a WebRequestSession in an unknown state, so the [powershell] is
+    disposed and the pool creates a replacement.
+
+    Removing the item from the queue here - rather than letting the poll timer drain it - is what
+    makes the cancellation immediate from the UI's point of view: Get-ActiveExecuteQueryRequest stops
+    reporting the tab as executing, so the button flips back to Execute in the same click.
+    #>
+    [CmdLetBinding()]
+    param()
+
+    try {
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement))
+
+        $Private:Pending = Get-ActiveExecuteQueryRequest
+        if ($null -eq $Private:Pending) {
+            "No query is running on this tab; nothing to cancel." | Write-LogOutput -LogType DEBUG
+            return
+        }
+
+        # Marked and de-queued before anything that can block, so nothing else treats this tab as
+        # still executing while the clean-up below runs.
+        $Private:Pending.IsCancelled = $true
+        [void]$Script:PendingWebViewCompletions.Remove($Private:Pending)
+
+        try {
+            if ($null -ne $Private:Pending.Shell) {
+                [void]$Private:Pending.Shell.BeginStop($null, $null)
+                $Private:Pending.Shell.Dispose()
+            }
+        }
+        catch {
+            # A worker that had already finished throws here; the item is off the queue either way.
+            "Stopping the query worker reported: {0}" -f $_.Exception.Message | Write-LogOutput -LogType DEBUG
+        }
+
+        # Itself a network call, on the UI thread exactly as it is on the normal completion path.
+        # Cancelling a query does not make cleaning up after it optional.
+        $Private:TempQueryDoId = $Private:Pending.Context.Caller.TempQueryDoId
+        if ($null -ne $Private:TempQueryDoId) {
+            "Removing the temporary query object left by the cancelled execution." | Write-LogOutput -LogType DEBUG
+            Remove-SqlQueryObject -DoId $Private:TempQueryDoId
+        }
+
+        "Stopped waiting for the query. It may still be running on the server." | Write-LogOutput -LogType WARNING -SkipDialog
+        $Script:MainForm.Elements.TextBlockStatusBarRows | Set-TextBlockText -Text "cancelled"
+
+        Reset-ExecuteQueryUiState
+    }
+    catch {
+        # Whatever went wrong, the tab must not be left in the executing state - that would leave the
+        # user with a Cancel button that cancels nothing and no way back to Execute.
+        Reset-ExecuteQueryUiState
+        $_.Exception.Message | Write-LogOutput -LogType ERROR -ErrorObject $_
+    }
+}

--- a/tests/Get-ActiveExecuteQueryRequest.Tests.ps1
+++ b/tests/Get-ActiveExecuteQueryRequest.Tests.ps1
@@ -1,0 +1,90 @@
+#Requires -Version 7.0
+# "Is this tab executing?" - the single question the Execute/Cancel button is derived from (#40).
+#
+# It reads the completion queue rather than a per-tab flag on purpose: a flag has to be cleared on
+# every path a request can leave by (success, failure, cancellation, and abandonment when its tab is
+# closed) and one missed path leaves a tab that can never execute again. These tests pin the queue
+# reading down, including the cases where it must answer "no".
+
+BeforeAll {
+    $ParentPath = Split-Path -Path $PSScriptRoot -Parent
+    $PrivatePath = Join-Path $ParentPath -ChildPath "src\Lib\Functions\Private"
+    . (Join-Path $PrivatePath -ChildPath "Get-ActiveExecuteQueryRequest.ps1")
+
+    $Script:ExecuteQueryRequestDescription = "Execute query"
+
+    function Get-ActiveTabSession { return $script:StubActiveTab }
+
+    function script:New-QueueItem {
+        param(
+            [string]$TabId = "tab-A",
+            [string]$Description = "Execute query",
+            [switch]$Cancelled
+        )
+        return [pscustomobject]@{
+            Description = $Description
+            TabSession  = [pscustomobject]@{ Id = $TabId }
+            IsCancelled = [bool]$Cancelled
+        }
+    }
+}
+
+Describe "Get-ActiveExecuteQueryRequest" {
+    BeforeEach {
+        $Script:PendingWebViewCompletions = [System.Collections.Generic.List[object]]::new()
+        $script:StubActiveTab = [pscustomobject]@{ Id = "tab-A" }
+    }
+
+    It "finds the active tab's execute request" {
+        $Script:PendingWebViewCompletions.Add((New-QueueItem))
+
+        (Get-ActiveExecuteQueryRequest) | Should -Not -BeNullOrEmpty
+    }
+
+    It "answers null when nothing is running" {
+        Get-ActiveExecuteQueryRequest | Should -BeNullOrEmpty
+    }
+
+    It "ignores another tab's execute request" {
+        # Otherwise one tab's query would put every other tab's button into Cancel.
+        $Script:PendingWebViewCompletions.Add((New-QueueItem -TabId "tab-B"))
+
+        Get-ActiveExecuteQueryRequest | Should -BeNullOrEmpty
+    }
+
+    It "ignores requests that are not executes" {
+        # A schema fetch is in flight constantly; it must not turn Execute into Cancel.
+        $Script:PendingWebViewCompletions.Add((New-QueueItem -Description "SQL schema"))
+
+        Get-ActiveExecuteQueryRequest | Should -BeNullOrEmpty
+    }
+
+    It "ignores an already-cancelled request" {
+        # The pipeline may take a moment to stop, but the request is over the instant the user asked
+        # for it to be - otherwise Cancel could not flip the button back in the same click.
+        $Script:PendingWebViewCompletions.Add((New-QueueItem -Cancelled))
+
+        Get-ActiveExecuteQueryRequest | Should -BeNullOrEmpty
+    }
+
+    It "can be asked about a specific tab rather than the active one" {
+        # What the tab-switch path needs: the button must show Cancel for a tab that is executing
+        # even when it is not the one on screen at the moment the question is asked.
+        $Script:PendingWebViewCompletions.Add((New-QueueItem -TabId "tab-B"))
+
+        Get-ActiveExecuteQueryRequest -TabSession ([pscustomobject]@{ Id = "tab-B" }) | Should -Not -BeNullOrEmpty
+    }
+
+    It "answers null when there is no active tab at all" {
+        $script:StubActiveTab = $null
+        $Script:PendingWebViewCompletions.Add((New-QueueItem))
+
+        Get-ActiveExecuteQueryRequest | Should -BeNullOrEmpty
+    }
+
+    It "answers null when the queue does not exist yet" {
+        $Script:PendingWebViewCompletions = $null
+
+        Get-ActiveExecuteQueryRequest | Should -BeNullOrEmpty
+    }
+}

--- a/tests/Invoke-ExecuteQuery.Tests.ps1
+++ b/tests/Invoke-ExecuteQuery.Tests.ps1
@@ -19,9 +19,18 @@ BeforeAll {
     . (Join-Path $PrivatePath -ChildPath "ConvertTo-RedactedLogString.ps1")
     . (Join-Path $PrivatePath -ChildPath "Get-LogResultShape.ps1")
     . (Join-Path $PrivatePath -ChildPath "Set-TextBlockText.ps1")
+    # Reset-ExecuteQueryUiState now also flips the Execute/Cancel button (issue #40 / C1-4). The real
+    # chain is dot-sourced rather than stubbed: a missing collaborator would throw inside this
+    # function's own catch and silently skip the rest of the teardown, which is exactly the failure
+    # mode these tests exist to catch.
+    . (Join-Path $PrivatePath -ChildPath "Set-ButtonText.ps1")
+    . (Join-Path $PrivatePath -ChildPath "Get-ActiveExecuteQueryRequest.ps1")
+    . (Join-Path $PrivatePath -ChildPath "Set-ExecuteQueryButtonState.ps1")
     . (Join-Path $PrivatePath -ChildPath "Invoke-ExecuteQuery.ps1")
 
     $Script:Tracer = [System.Diagnostics.Trace]
+
+    function Get-ActiveTabSession { return [pscustomobject]@{ Id = "tab-A" } }
 
     function Write-LogOutput {
         param(
@@ -71,6 +80,8 @@ BeforeAll {
         $script:QueryListRefreshes = 0
 
         $Script:RunTimeConfig = [PSCustomObject]@{ ApplicationName = "Test" }
+        # No request outstanding, so the button state resolves to "Execute".
+        $Script:PendingWebViewCompletions = [System.Collections.Generic.List[object]]::new()
         $Script:PopupWindowExecuteQuery = New-PopupStub
         $Script:AppConfig = [PSCustomObject]@{
             CurrentSqlQuery = [PSCustomObject]@{ DoId = 100; FullName = "TestQuery - 100" }
@@ -83,7 +94,9 @@ BeforeAll {
         $Script:MainForm = @{
             Elements = @{
                 ButtonSaveQuery             = [PSCustomObject]@{ IsEnabled = $false }
-                ButtonExecuteQuery          = [PSCustomObject]@{ IsEnabled = $false }
+                ButtonExecuteQuery          = [PSCustomObject]@{ IsEnabled = $false; ToolTip = "Execute" }
+                ButtonExecuteQueryText      = [PSCustomObject]@{ Name = "ButtonExecuteQueryText"; Text = "_Cancel" }
+                ButtonExecuteQueryImage     = [PSCustomObject]@{ Name = "ButtonExecuteQueryImage"; Text = [char]0xE711 }
                 ButtonShowOutput            = [PSCustomObject]@{ IsEnabled = $false }
                 ButtonSaveOutputFile        = [PSCustomObject]@{ IsEnabled = $false }
                 DataGridQueryResult         = [PSCustomObject]@{ ItemsSource = "previous"; AutoGenerateColumns = $false }
@@ -110,6 +123,15 @@ Describe "Reset-ExecuteQueryUiState" {
 
         $Script:MainForm.Elements.ButtonSaveQuery.IsEnabled | Should -BeTrue
         $Script:MainForm.Elements.ButtonExecuteQuery.IsEnabled | Should -BeTrue
+    }
+
+    It "puts the Execute/Cancel button back to Execute" {
+        # Every terminal path goes through here - success, failure and cancellation alike - so this
+        # is the single place that guarantees a tab cannot be left showing Cancel with nothing to
+        # cancel.
+        Reset-ExecuteQueryUiState
+
+        $Script:MainForm.Elements.ButtonExecuteQueryText.Text | Should -Be "_Execute"
     }
 
     It "closes the 'Executing Query...' popup and forgets it" {

--- a/tests/Invoke-ExecuteQuery.Tests.ps1
+++ b/tests/Invoke-ExecuteQuery.Tests.ps1
@@ -80,6 +80,9 @@ BeforeAll {
         $script:QueryListRefreshes = 0
 
         $Script:RunTimeConfig = [PSCustomObject]@{ ApplicationName = "Test" }
+        # The tab is connected unless a test says otherwise: the teardown only re-enables the query
+        # controls for a connected tab.
+        $Script:ConnectionStatus = $true
         # No request outstanding, so the button state resolves to "Execute".
         $Script:PendingWebViewCompletions = [System.Collections.Generic.List[object]]::new()
         $Script:PopupWindowExecuteQuery = New-PopupStub
@@ -123,6 +126,30 @@ Describe "Reset-ExecuteQueryUiState" {
 
         $Script:MainForm.Elements.ButtonSaveQuery.IsEnabled | Should -BeTrue
         $Script:MainForm.Elements.ButtonExecuteQuery.IsEnabled | Should -BeTrue
+    }
+
+    It "does not re-enable the query controls for a tab that is no longer connected" {
+        # A query can outlive the connection it was issued on: the user can disconnect, or a 401 can
+        # tear the tab down through Set-SqlConnectionState, while the request is still in flight -
+        # and the completion runs afterwards regardless. Re-enabling unconditionally would hand a
+        # disconnected tab a live Execute and Save button, which is issue #65's "in-between tab
+        # state" arrived at from a new direction.
+        $Script:ConnectionStatus = $false
+
+        Reset-ExecuteQueryUiState
+
+        $Script:MainForm.Elements.ButtonSaveQuery.IsEnabled | Should -BeFalse
+        $Script:MainForm.Elements.ButtonExecuteQuery.IsEnabled | Should -BeFalse
+    }
+
+    It "still returns the button to Execute on a disconnected tab" {
+        # The label has to be corrected either way: a tab must never be left showing Cancel with
+        # nothing to cancel, whether or not it is still connected.
+        $Script:ConnectionStatus = $false
+
+        Reset-ExecuteQueryUiState
+
+        $Script:MainForm.Elements.ButtonExecuteQueryText.Text | Should -Be "_Execute"
     }
 
     It "puts the Execute/Cancel button back to Execute" {

--- a/tests/Set-ExecuteQueryButtonState.Tests.ps1
+++ b/tests/Set-ExecuteQueryButtonState.Tests.ps1
@@ -1,0 +1,115 @@
+#Requires -Version 7.0
+# The Execute/Cancel toggle (issue #40). The button the user just pressed becomes the way to stop -
+# the same pattern the Connect button already uses for Disconnect.
+
+BeforeAll {
+    $ParentPath = Split-Path -Path $PSScriptRoot -Parent
+    $PrivatePath = Join-Path $ParentPath -ChildPath "src\Lib\Functions\Private"
+
+    . (Join-Path $PrivatePath -ChildPath "ConvertTo-RedactedLogString.ps1")
+    . (Join-Path $PrivatePath -ChildPath "Set-ButtonText.ps1")
+    . (Join-Path $PrivatePath -ChildPath "Set-ExecuteQueryButtonState.ps1")
+
+    $Script:Tracer = [System.Diagnostics.Trace]
+    $script:ExecuteGlyph = [char]0xE768
+    $script:CancelGlyph = [char]0xE711
+
+    function Write-LogOutput {
+        param(
+            [Parameter(ValueFromPipeline = $true)]$InputObject,
+            [string]$LogType,
+            $ErrorObject,
+            [switch]$SkipDialog
+        )
+        process { }
+    }
+
+    function Get-ActiveExecuteQueryRequest {
+        param($TabSession)
+        return $script:StubInFlightRequest
+    }
+
+    function script:Initialize-ButtonTestState {
+        $Script:RunTimeConfig = [PSCustomObject]@{ ApplicationName = "Test" }
+        $script:StubInFlightRequest = $null
+        $Script:MainForm = @{
+            Elements = @{
+                ButtonExecuteQuery      = [PSCustomObject]@{ IsEnabled = $true; ToolTip = "Execute" }
+                ButtonExecuteQueryText  = [PSCustomObject]@{ Name = "ButtonExecuteQueryText"; Text = "_Execute" }
+                ButtonExecuteQueryImage = [PSCustomObject]@{ Name = "ButtonExecuteQueryImage"; Text = $script:ExecuteGlyph }
+            }
+        }
+    }
+}
+
+Describe "Set-ExecuteQueryButtonState" {
+    BeforeEach { Initialize-ButtonTestState }
+
+    Context "while a query is in flight" {
+        BeforeEach {
+            $script:StubInFlightRequest = [pscustomobject]@{ Description = "Execute query" }
+        }
+
+        It "labels the button Cancel" {
+            Set-ExecuteQueryButtonState
+
+            $Script:MainForm.Elements.ButtonExecuteQueryText.Text | Should -Be "_Cancel"
+        }
+
+        It "keeps the button enabled, because it is the only way out" {
+            # The rest of the query controls are disabled during an execute. This one must not be:
+            # a disabled Cancel button would leave the user with no way to abandon the wait.
+            $Script:MainForm.Elements.ButtonExecuteQuery.IsEnabled = $false
+
+            Set-ExecuteQueryButtonState
+
+            $Script:MainForm.Elements.ButtonExecuteQuery.IsEnabled | Should -BeTrue
+        }
+
+        It "says in the tooltip that the query keeps running on the server" {
+            # The app cannot cancel an Omada query (issue #43). Claiming it could would let a user
+            # start a replacement believing the first had been killed.
+            Set-ExecuteQueryButtonState
+
+            $Script:MainForm.Elements.ButtonExecuteQuery.ToolTip | Should -Match "keeps running on the server"
+        }
+
+        It "swaps the glyph" {
+            Set-ExecuteQueryButtonState
+
+            $Script:MainForm.Elements.ButtonExecuteQueryImage.Text | Should -Be $script:CancelGlyph
+        }
+    }
+
+    Context "when nothing is running" {
+        It "returns the button to Execute" {
+            $Script:MainForm.Elements.ButtonExecuteQueryText.Text = "_Cancel"
+            $Script:MainForm.Elements.ButtonExecuteQueryImage.Text = $script:CancelGlyph
+            $Script:MainForm.Elements.ButtonExecuteQuery.ToolTip = "Stop waiting"
+
+            Set-ExecuteQueryButtonState
+
+            $Script:MainForm.Elements.ButtonExecuteQueryText.Text | Should -Be "_Execute"
+            $Script:MainForm.Elements.ButtonExecuteQueryImage.Text | Should -Be $script:ExecuteGlyph
+            $Script:MainForm.Elements.ButtonExecuteQuery.ToolTip | Should -Be "Execute"
+        }
+
+        It "does not enable a button the connection state has disabled" {
+            # A disconnected tab must not get a live Execute button just because this ran.
+            $Script:MainForm.Elements.ButtonExecuteQuery.IsEnabled = $false
+
+            Set-ExecuteQueryButtonState
+
+            $Script:MainForm.Elements.ButtonExecuteQuery.IsEnabled | Should -BeFalse
+        }
+    }
+
+    It "is safe to call before the UI exists" {
+        # It runs from Initialize-UiComponents, which is reached during tab creation and teardown.
+        $Script:MainForm = $null
+        { Set-ExecuteQueryButtonState } | Should -Not -Throw
+
+        $Script:MainForm = @{ Elements = @{} }
+        { Set-ExecuteQueryButtonState } | Should -Not -Throw
+    }
+}

--- a/tests/Stop-ExecuteQueryRequest.Tests.ps1
+++ b/tests/Stop-ExecuteQueryRequest.Tests.ps1
@@ -1,0 +1,178 @@
+#Requires -Version 7.0
+# The Cancel action (issue #40).
+#
+# Cancel means "stop waiting", not "stop the query": Omada goes on executing it and there is no
+# server-side cancellation to call (issue #43). What the app CAN be held to is everything else -
+# taking the request off the queue immediately, discarding the worker's runspace, cleaning up the
+# temporary object it created on the tenant, and leaving the tab usable and its previous result
+# intact.
+
+BeforeAll {
+    $ParentPath = Split-Path -Path $PSScriptRoot -Parent
+    $PrivatePath = Join-Path $ParentPath -ChildPath "src\Lib\Functions\Private"
+
+    . (Join-Path $PrivatePath -ChildPath "ConvertTo-RedactedLogString.ps1")
+    . (Join-Path $PrivatePath -ChildPath "Set-TextBlockText.ps1")
+    . (Join-Path $PrivatePath -ChildPath "Get-ActiveExecuteQueryRequest.ps1")
+    . (Join-Path $PrivatePath -ChildPath "Stop-ExecuteQueryRequest.ps1")
+
+    $Script:Tracer = [System.Diagnostics.Trace]
+    $Script:ExecuteQueryRequestDescription = "Execute query"
+
+    $script:LogMessages = [System.Collections.Generic.List[object]]::new()
+    function Write-LogOutput {
+        param(
+            [Parameter(ValueFromPipeline = $true)]$InputObject,
+            [string]$LogType,
+            $ErrorObject,
+            [switch]$SkipDialog
+        )
+        process { $script:LogMessages.Add([pscustomobject]@{ LogType = $LogType; Message = [string]$InputObject }) }
+    }
+
+    $script:RemovedQueryObjects = [System.Collections.Generic.List[object]]::new()
+    function Remove-SqlQueryObject {
+        param($DoId)
+        $script:RemovedQueryObjects.Add($DoId)
+    }
+
+    $script:ResetCalls = 0
+    function Reset-ExecuteQueryUiState {
+        param([switch]$SkipStatusBarTime)
+        $script:ResetCalls++
+    }
+
+    function Get-ActiveTabSession { return $script:StubActiveTab }
+
+    function script:Initialize-CancelTestState {
+        param([switch]$WithTempObject, [switch]$WithLiveShell)
+
+        $script:LogMessages.Clear()
+        $script:RemovedQueryObjects.Clear()
+        $script:ResetCalls = 0
+        $script:StubActiveTab = [pscustomobject]@{ Id = "tab-A" }
+        $Script:RunTimeConfig = [PSCustomObject]@{ ApplicationName = "Test" }
+        $Script:MainForm = @{
+            Elements = @{
+                TextBlockStatusBarRows = [PSCustomObject]@{ Name = "TextBlockStatusBarRows"; Text = "2 rows" }
+            }
+        }
+
+        $Shell = $null
+        if ($WithLiveShell) {
+            $Shell = [powershell]::Create()
+            [void]$Shell.AddScript({ Start-Sleep -Seconds 30 })
+            [void]$Shell.BeginInvoke()
+        }
+
+        $script:PendingItem = [pscustomobject]@{
+            Description = "Execute query"
+            TabSession  = [pscustomobject]@{ Id = "tab-A" }
+            IsCancelled = $false
+            Shell       = $Shell
+            Context     = @{ Caller = @{ TempQueryDoId = $(if ($WithTempObject) { "TMP-42" } else { $null }) } }
+        }
+        $Script:PendingWebViewCompletions = [System.Collections.Generic.List[object]]::new()
+        $Script:PendingWebViewCompletions.Add($script:PendingItem)
+    }
+}
+
+Describe "Stop-ExecuteQueryRequest" {
+    It "takes the request off the queue and marks it cancelled" {
+        # Immediately, and before anything that can block: nothing else may treat this tab as still
+        # executing while the clean-up runs, and it is what lets the button flip back in one click.
+        Initialize-CancelTestState
+
+        Stop-ExecuteQueryRequest
+
+        $Script:PendingWebViewCompletions.Count | Should -Be 0
+        $script:PendingItem.IsCancelled | Should -BeTrue
+    }
+
+    It "returns the tab to a usable state" {
+        Initialize-CancelTestState
+
+        Stop-ExecuteQueryRequest
+
+        $script:ResetCalls | Should -Be 1
+    }
+
+    It "deletes the temporary query object the cancelled run left on the tenant" {
+        # The leak this exists for: the object is created before the request and deleted by the
+        # completion, so cancelling in between would strand it.
+        Initialize-CancelTestState -WithTempObject
+
+        Stop-ExecuteQueryRequest
+
+        $script:RemovedQueryObjects | Should -Contain "TMP-42"
+    }
+
+    It "reads the temporary object id off the pending item, not from module state" {
+        # It exists nowhere else by the time Cancel is clicked - the frame that created it returned
+        # long ago, and the dispatching frame deliberately forgot it.
+        Initialize-CancelTestState -WithTempObject
+        $script:PendingItem.Context.Caller.TempQueryDoId = "TMP-99"
+
+        Stop-ExecuteQueryRequest
+
+        $script:RemovedQueryObjects | Should -Contain "TMP-99"
+    }
+
+    It "deletes nothing when the run created no temporary object" {
+        Initialize-CancelTestState
+
+        Stop-ExecuteQueryRequest
+
+        $script:RemovedQueryObjects.Count | Should -Be 0
+    }
+
+    It "tells the user the query is still running on the server" {
+        # The honest message. The app cannot stop an Omada query - that is issue #43 - and implying
+        # otherwise would let a user start a "replacement" query believing the first had been killed.
+        Initialize-CancelTestState
+
+        Stop-ExecuteQueryRequest
+
+        @($script:LogMessages | Where-Object { $_.Message -like "*may still be running on the server*" }).Count | Should -BeGreaterThan 0
+    }
+
+    It "marks the row count as cancelled rather than leaving a stale one" {
+        Initialize-CancelTestState
+
+        Stop-ExecuteQueryRequest
+
+        $Script:MainForm.Elements.TextBlockStatusBarRows.Text | Should -Be "cancelled"
+    }
+
+    It "stops and disposes the worker so its runspace is not reused" {
+        # A pipeline killed mid-request leaves a half-read HTTP stream and a WebRequestSession in an
+        # unknown state; the pool must create a replacement rather than hand this one to the next
+        # query. A disposed [powershell] refuses further use, which is what this asserts.
+        Initialize-CancelTestState -WithLiveShell
+
+        Stop-ExecuteQueryRequest
+
+        { $script:PendingItem.Shell.AddScript({ 1 }) } | Should -Throw
+    }
+
+    It "does nothing when the tab has no query running" {
+        Initialize-CancelTestState
+        $Script:PendingWebViewCompletions.Clear()
+
+        Stop-ExecuteQueryRequest
+
+        $script:ResetCalls | Should -Be 0
+        $script:RemovedQueryObjects.Count | Should -Be 0
+    }
+
+    It "still returns the tab to a usable state when the clean-up itself fails" {
+        # Otherwise the user is left with a Cancel button that cancels nothing and no way back.
+        Initialize-CancelTestState -WithTempObject
+        function Remove-SqlQueryObject { param($DoId) throw "tenant unreachable" }
+
+        { Stop-ExecuteQueryRequest } | Should -Not -Throw
+        $script:ResetCalls | Should -BeGreaterThan 0
+
+        function Remove-SqlQueryObject { param($DoId) $script:RemovedQueryObjects.Add($DoId) }
+    }
+}

--- a/tests/e2e/Drivers.ps1
+++ b/tests/e2e/Drivers.ps1
@@ -34,6 +34,24 @@ function script:Invoke-E2EConnect {
     Invoke-E2EClick -ElementName "ButtonConnect"
 }
 
+function script:Test-E2EExecuteInFlight {
+    # Whether a tab has a query outstanding, read off the completion queue - the same record the app
+    # itself uses (Get-ActiveExecuteQueryRequest). Since C1-4 the Execute button stays ENABLED while a
+    # query runs, because it is the Cancel button, so IsEnabled is no longer a usable signal for this.
+    param($TabSession)
+    if ($null -eq $TabSession) { $TabSession = Get-ActiveTabSession }
+    return @($Script:PendingWebViewCompletions | Where-Object {
+            $_.Description -eq "Execute query" -and $null -ne $_.TabSession -and
+            $_.TabSession.Id -eq $TabSession.Id -and -not $_.IsCancelled
+        }).Count -gt 0
+}
+
+function script:Get-E2EExecuteButtonText {
+    param($TabSession)
+    $Elements = if ($null -ne $TabSession) { $TabSession.Elements } else { $Script:MainForm.Elements }
+    return [string]$Elements.ButtonExecuteQueryText.Text
+}
+
 function script:Wait-E2EAppSettled {
     <#
     Pump the dispatcher for a fixed period so work the APP started on its own - a WebView2
@@ -110,13 +128,17 @@ function script:Invoke-E2EExecuteAndWait {
     param(
         [double]$TimeoutSeconds = 15
     )
+    $Tab = Get-ActiveTabSession
     Invoke-E2EExecute
     Wait-E2EUntil -TimeoutSeconds $TimeoutSeconds -Message "execute to complete" -Condition {
-        # Re-enabled by Reset-ExecuteQueryUiState, which every terminal path goes through - success,
-        # failure and abandonment alike. Waiting on the grid instead would hang forever on the
+        # The queue, not the button: since C1-4 the Execute button stays enabled during a query
+        # because it is the Cancel button. Waiting on the grid instead would hang forever on the
         # perfectly legitimate "query returned no rows" path.
-        $Script:MainForm.Elements.ButtonExecuteQuery.IsEnabled
+        -not (Test-E2EExecuteInFlight -TabSession $Tab)
     }
+    # The request leaves the queue just BEFORE its completion block runs, so one more pump makes sure
+    # the completion (grid binding, status bar, button reset) has actually happened.
+    Invoke-E2EFlushDispatcher
 }
 
 function script:Wait-E2ENoPendingRequests {
@@ -130,6 +152,11 @@ function script:Wait-E2ENoPendingRequests {
 
 function script:Reset-E2EConnection {
     # Put the active tab back to a disconnected, clean state between scenarios that reuse one tab.
+    # Drained first: a request still in flight from the previous scenario would otherwise complete
+    # in the middle of this one, repointing the tab context and binding a stale result into its grid.
+    # A scenario that leaves work outstanding fails HERE, where the cause is obvious, rather than as
+    # a puzzling assertion failure in whichever scenario happens to run next.
+    Wait-E2ENoPendingRequests
     if ($Script:ConnectionStatus) {
         Invoke-E2EConnect   # ButtonConnect toggles to Disconnect when already connected
     }

--- a/tests/e2e/scenarios/AsyncExecute.ps1
+++ b/tests/e2e/scenarios/AsyncExecute.ps1
@@ -32,9 +32,12 @@ E2ESuite -Name "AsyncExecute" -Body {
         Invoke-E2EExecute
 
         E2EAssertTrue ($null -eq $Elements.DataGridQueryResult.ItemsSource) "the grid must not be populated by the time the click returns"
-        E2EAssertTrue (-not $Elements.ButtonExecuteQuery.IsEnabled) "Execute should still be disabled while the query is in flight"
+        E2EAssertTrue (Test-E2EExecuteInFlight) "the query should still be outstanding when the click returns"
+        E2EAssertEqual "_Cancel" (Get-E2EExecuteButtonText) "the Execute button should read Cancel while the query is in flight"
+        E2EAssertTrue $Elements.ButtonExecuteQuery.IsEnabled "the Cancel button must stay enabled - it is the only way out"
 
-        Wait-E2EUntil -TimeoutSeconds 15 -Message "the query to complete" -Condition { $Elements.ButtonExecuteQuery.IsEnabled }
+        Wait-E2EUntil -TimeoutSeconds 15 -Message "the query to complete" -Condition { -not (Test-E2EExecuteInFlight) }
+        Invoke-E2EFlushDispatcher
         E2EAssertEqual 2 (@($Elements.DataGridQueryResult.ItemsSource).Count) "the grid should be populated once the result lands"
     }
 
@@ -57,7 +60,7 @@ E2ESuite -Name "AsyncExecute" -Body {
         Invoke-E2EFlushDispatcher
         $Stopwatch.Stop()
 
-        E2EAssertTrue (-not $Elements.ButtonExecuteQuery.IsEnabled) "the query should still be in flight for this to mean anything"
+        E2EAssertTrue (Test-E2EExecuteInFlight) "the query should still be in flight for this to mean anything"
         E2EAssertTrue ($Stopwatch.ElapsedMilliseconds -lt 500) ("a dispatcher round-trip took {0} ms while a 1500 ms query was in flight; the UI thread is blocked" -f $Stopwatch.ElapsedMilliseconds)
 
         Wait-E2ENoPendingRequests
@@ -82,8 +85,9 @@ E2ESuite -Name "AsyncExecute" -Body {
         E2EAssertTrue ((Get-ActiveTabSession).Id -eq $OtherTab.Id) "the new tab should be active while the first tab's query is in flight"
 
         Wait-E2EUntil -TimeoutSeconds 15 -Message "the backgrounded tab's query to complete" -Condition {
-            $ExecutingTab.Elements.ButtonExecuteQuery.IsEnabled
+            -not (Test-E2EExecuteInFlight -TabSession $ExecutingTab)
         }
+        Invoke-E2EFlushDispatcher
 
         E2EAssertEqual 2 (@($ExecutingTab.Elements.DataGridQueryResult.ItemsSource).Count) "the result must land on the tab that issued it"
         E2EAssertTrue ($null -eq $OtherTab.Elements.DataGridQueryResult.ItemsSource) "the result must NOT land on the tab that happened to be active"
@@ -107,8 +111,9 @@ E2ESuite -Name "AsyncExecute" -Body {
         Invoke-E2EExecute
 
         Wait-E2EUntil -TimeoutSeconds 20 -Message "both tabs' queries to complete" -Condition {
-            $FirstTab.Elements.ButtonExecuteQuery.IsEnabled -and $SecondTab.Elements.ButtonExecuteQuery.IsEnabled
+            -not (Test-E2EExecuteInFlight -TabSession $FirstTab) -and -not (Test-E2EExecuteInFlight -TabSession $SecondTab)
         }
+        Invoke-E2EFlushDispatcher
 
         E2EAssertEqual 2 (@($FirstTab.Elements.DataGridQueryResult.ItemsSource).Count) "the first tab should have its own result"
         E2EAssertEqual 2 (@($SecondTab.Elements.DataGridQueryResult.ItemsSource).Count) "the second tab should have its own result"
@@ -138,6 +143,7 @@ E2ESuite -Name "AsyncExecute" -Body {
         try {
             Invoke-E2EExecuteAndWait
 
+            E2EAssertEqual "_Execute" (Get-E2EExecuteButtonText) "the button must be back to Execute after a failure"
             E2EAssertTrue $Elements.ButtonExecuteQuery.IsEnabled "Execute must be re-enabled after a failure"
             E2EAssertTrue $Elements.ButtonSaveQuery.IsEnabled "Save must be re-enabled after a failure"
             E2EAssertTrue ($null -eq $Script:PopupWindowExecuteQuery) "the 'Executing Query...' popup must be closed after a failure"
@@ -169,7 +175,7 @@ E2ESuite -Name "AsyncExecute" -Body {
         Wait-E2EUntil -TimeoutSeconds 10 -Message "the elapsed-time indicator to update mid-flight" -Condition {
             $Elements.TextBlockStatusBarQueryTime.Text -ne "-"
         }
-        E2EAssertTrue (-not $Elements.ButtonExecuteQuery.IsEnabled) "the indicator must have updated while the query was still running"
+        E2EAssertTrue (Test-E2EExecuteInFlight) "the indicator must have updated while the query was still running"
 
         Wait-E2ENoPendingRequests
     }
@@ -190,7 +196,7 @@ E2ESuite -Name "AsyncExecute" -Body {
 
         $script:E2ERequestDelayMs = 900
         Invoke-E2EExecute
-        E2EAssertTrue (-not $Elements.ButtonExecuteQuery.IsEnabled) "arrange: Execute should be disabled while the query is in flight"
+        E2EAssertTrue (Test-E2EExecuteInFlight) "arrange: the query should be in flight"
 
         # Force a second, unrelated background request onto the queue and let it complete first.
         $Script:SqlSchemaCache = @{}
@@ -200,10 +206,10 @@ E2ESuite -Name "AsyncExecute" -Body {
             @($Script:PendingWebViewCompletions | Where-Object { $_.Description -eq "SQL schema" }).Count -eq 0
         }
 
-        E2EAssertTrue (-not $Elements.ButtonExecuteQuery.IsEnabled) "Execute must still be disabled: the query it belongs to is still running"
+        E2EAssertEqual "_Cancel" (Get-E2EExecuteButtonText) "the button must still read Cancel: the query it belongs to is still running"
 
         Wait-E2ENoPendingRequests
-        E2EAssertTrue $Elements.ButtonExecuteQuery.IsEnabled "Execute should be re-enabled once the query itself completes"
+        E2EAssertEqual "_Execute" (Get-E2EExecuteButtonText) "the button should be back to Execute once the query itself completes"
     }
 
     E2ECase -Name "closing a tab abandons its in-flight request instead of letting it repoint the app" -Body {

--- a/tests/e2e/scenarios/CancelExecute.ps1
+++ b/tests/e2e/scenarios/CancelExecute.ps1
@@ -1,0 +1,163 @@
+# Issue #40 (Roadmap C1): the Cancel button.
+#
+# Cancel here means "stop waiting", not "stop the query" - Omada goes on executing it, and there is
+# no server-side cancellation to call (issue #43). These scenarios hold the app to exactly that: the
+# tab comes back to a usable state, the temporary object created for an execute-selection run is
+# still cleaned up, and nothing claims more than the app can actually do.
+
+E2ESuite -Name "CancelExecute" -Body {
+
+    E2ECase -Name "the Execute button becomes Cancel while a query is in flight, and back again" -Body {
+        Reset-E2ETabsToOne
+        Set-E2EConnectionFields
+        Invoke-E2EConnectAndWait
+        Select-E2EQuery | Out-Null
+
+        E2EAssertEqual "_Execute" (Get-E2EExecuteButtonText) "arrange: the button should read Execute before anything runs"
+
+        $script:E2ERequestDelayMs = 900
+        Invoke-E2EExecute
+
+        E2EAssertEqual "_Cancel" (Get-E2EExecuteButtonText) "the button must read Cancel while the query is in flight"
+
+        Wait-E2EUntil -TimeoutSeconds 15 -Message "the query to finish" -Condition { -not (Test-E2EExecuteInFlight) }
+        Invoke-E2EFlushDispatcher
+        E2EAssertEqual "_Execute" (Get-E2EExecuteButtonText) "the button must return to Execute once the query completes"
+    }
+
+    E2ECase -Name "cancelling mid-flight returns the tab to a usable state" -Body {
+        Reset-E2ETabsToOne
+        Set-E2EConnectionFields
+        Invoke-E2EConnectAndWait
+        Select-E2EQuery | Out-Null
+
+        $Elements = Get-E2EElements
+        $script:E2ERequestDelayMs = 4000
+        Invoke-E2EExecute
+        E2EAssertTrue (Test-E2EExecuteInFlight) "arrange: the query should be in flight"
+
+        # The second click is the Cancel: same button, different meaning.
+        Invoke-E2EExecute
+
+        E2EAssertTrue (-not (Test-E2EExecuteInFlight)) "cancelling must take the request off the completion queue immediately"
+        E2EAssertEqual "_Execute" (Get-E2EExecuteButtonText) "the button must go back to Execute in the same click"
+        E2EAssertTrue $Elements.ButtonExecuteQuery.IsEnabled "Execute must be usable again"
+        E2EAssertTrue $Elements.ButtonSaveQuery.IsEnabled "Save must be usable again"
+        E2EAssertTrue ($null -eq $Script:PopupWindowExecuteQuery) "the 'Executing Query...' popup must be closed"
+    }
+
+    E2ECase -Name "cancelling does not blank a previous result" -Body {
+        # Abandoning a query is not a reason to throw away what the user was already looking at.
+        Reset-E2ETabsToOne
+        Set-E2EConnectionFields
+        Invoke-E2EConnectAndWait
+        Select-E2EQuery | Out-Null
+
+        Invoke-E2EExecuteAndWait
+        $Elements = Get-E2EElements
+        E2EAssertEqual 2 (@($Elements.DataGridQueryResult.ItemsSource).Count) "arrange: the grid should hold a result"
+
+        $script:E2ERequestDelayMs = 4000
+        Invoke-E2EExecute
+        Invoke-E2EExecute   # cancel
+
+        E2EAssertEqual 2 (@($Elements.DataGridQueryResult.ItemsSource).Count) "the previous result must survive a cancellation"
+    }
+
+    E2ECase -Name "cancelling says so honestly, without claiming the query was stopped" -Body {
+        Reset-E2ETabsToOne
+        Set-E2EConnectionFields
+        Invoke-E2EConnectAndWait
+        Select-E2EQuery | Out-Null
+
+        Clear-E2ELog
+        $script:E2ERequestDelayMs = 4000
+        Invoke-E2EExecute
+        Invoke-E2EExecute   # cancel
+
+        $Messages = @(Get-E2ELogMessages | ForEach-Object { $_.Message })
+        E2EAssertTrue (@($Messages | Where-Object { $_ -like "*may still be running on the server*" }).Count -ge 1) "the user must be told the query keeps running server-side"
+        E2EAssertTrue (@($Messages | Where-Object { $_ -like "*cancelled the query*" -or $_ -like "*query was stopped*" }).Count -eq 0) "nothing may claim the query itself was stopped - the app cannot do that (issue #43)"
+    }
+
+    E2ECase -Name "cancelling an execute-selection run still deletes the temporary query object" -Body {
+        # The leak this case exists for: the temporary TMP_<guid> object is created before the
+        # request and deleted by the completion, so cancelling in between would leave it on the
+        # tenant. New-TemporarySqlQueryObject reuses a stale one on the next run so the damage
+        # self-heals, but leaving litter because someone clicked Cancel is not acceptable.
+        Reset-E2ETabsToOne
+        Set-E2EConnectionFields
+        Invoke-E2EConnectAndWait
+        Select-E2EQuery | Out-Null
+
+        # A selection makes Invoke-ExecuteQuery create a temporary object to execute against.
+        $script:E2ESelectedText = "SELECT TOP 1 * FROM dbo.Users"
+        $script:E2ERequestDelayMs = 4000
+        $script:E2ECalls.Clear()
+
+        Invoke-E2EExecute
+        E2EAssertTrue ((Get-E2ECallCount -MethodLike "POST" -UriLike "*C_P_SQLTROUBLESHOOTING") -ge 1) "arrange: a temporary query object should have been created"
+
+        Invoke-E2EExecute   # cancel
+
+        E2EAssertTrue ((Get-E2ECallCount -MethodLike "DELETE") -ge 1) "cancelling must delete the temporary query object it left on the tenant"
+
+        $script:E2ESelectedText = $null
+    }
+
+    E2ECase -Name "a cancelled query's late response never reaches the grid" -Body {
+        # The worker may take a moment to stop, and its result must not arrive afterwards and
+        # overwrite what the user is looking at now.
+        Reset-E2ETabsToOne
+        Set-E2EConnectionFields
+        Invoke-E2EConnectAndWait
+        Select-E2EQuery | Out-Null
+
+        Invoke-E2EExecuteAndWait
+        $Elements = Get-E2EElements
+        $BeforeCount = @($Elements.DataGridQueryResult.ItemsSource).Count
+
+        $script:E2ERequestDelayMs = 800
+        Invoke-E2EExecute
+        Invoke-E2EExecute   # cancel
+
+        # Pump well past the point the abandoned worker would have finished.
+        $Deadline = [DateTime]::UtcNow.AddMilliseconds(1600)
+        while ([DateTime]::UtcNow -lt $Deadline) {
+            Invoke-E2EFlushDispatcher
+            Start-Sleep -Milliseconds 50
+        }
+
+        E2EAssertEqual $BeforeCount (@($Elements.DataGridQueryResult.ItemsSource).Count) "a cancelled query's late result must not land in the grid"
+        E2EAssertEqual "_Execute" (Get-E2EExecuteButtonText) "the tab must still be in the Execute state"
+    }
+
+    E2ECase -Name "cancelling one tab leaves another tab's query running" -Body {
+        Reset-E2ETabsToOne
+        Set-E2EConnectionFields
+        Invoke-E2EConnectAndWait
+        Select-E2EQuery | Out-Null
+        $FirstTab = Get-ActiveTabSession
+
+        $script:E2ERequestDelayMs = 2500
+        Invoke-E2EExecute
+
+        # Built by hand rather than with New-E2EConnectedTab, which drains every pending request -
+        # including the first tab's query, which is the very thing this case needs still running.
+        New-EmptyTabSession | Out-Null
+        $SecondTab = Get-ActiveTabSession
+        Set-E2EConnectionFields
+        Invoke-E2EConnect
+        Select-E2EQuery | Out-Null
+        Invoke-E2EExecute
+        E2EAssertTrue (Test-E2EExecuteInFlight -TabSession $FirstTab) "arrange: the first tab should still be executing"
+        E2EAssertTrue (Test-E2EExecuteInFlight -TabSession $SecondTab) "arrange: the second tab should be executing too"
+
+        Invoke-E2EExecute   # cancel, on the second tab
+
+        E2EAssertTrue (-not (Test-E2EExecuteInFlight -TabSession $SecondTab)) "the second tab's query must be cancelled"
+        E2EAssertTrue (Test-E2EExecuteInFlight -TabSession $FirstTab) "the first tab's query must be untouched"
+
+        Wait-E2ENoPendingRequests -TimeoutSeconds 20
+    }
+}


### PR DESCRIPTION
Slice **C1-4** of **#40** (Roadmap C1). Targets the working baseline branch `feature/async-query-execution`, not `main`.

> **Stacked on #79 (C1-3).** Until that merges, the diff here includes its commits; it will narrow to this slice once #79 lands.

Issue #40's second headline criterion: *"Cancel button abandons the wait and returns the UI to a clean state."*

## The shape

While a query is in flight the **Execute button reads "Cancel"**, and clicking it abandons the wait. Same pattern the Connect button already uses for Disconnect (`Test-ConnectionButton`) — so there is no new control, and no new place for a tab's state to disagree with what is on screen.

## Cancel means stop *waiting*, not stop the *query*

Omada goes on executing it. There is no server-side cancellation to call — that is **#43** — so the tooltip and the log message both say so.

This is not pedantry. A user who believes the query was killed will start a "replacement" query while the first still holds the same server resources. The app should not imply a power it does not have, and there is a test asserting that nothing in the wording claims the query itself was stopped.

## What cancelling actually does

| | |
|---|---|
| **Queue** | The request is marked cancelled and removed **immediately**, before anything that can block — so nothing else treats the tab as executing, and the button flips back to Execute in the same click |
| **Worker** | Stopped **and disposed**. A pipeline killed mid-request leaves a half-read HTTP stream and a `WebRequestSession` in an unknown state; its runspace must be discarded rather than handed to the next query |
| **Tenant** | The temporary `TMP_<guid>` object is deleted. It is created *before* the request and deleted by the completion, so cancelling in between is exactly how one gets stranded |
| **Grid** | Left alone. Abandoning a query is not a reason to throw away what the user was already looking at |

`New-TemporarySqlQueryObject` reuses a stale object on the next run, so a leak would self-heal — but leaving litter on someone's tenant because they clicked Cancel is not acceptable, and "it heals eventually" is a poor answer for a shared tenant.

## Decisions worth reviewing

- **"Is this tab executing?" is read off the completion queue** (`Get-ActiveExecuteQueryRequest`), not from a per-tab flag. A flag has to be cleared on **every** path a request can leave by — success, failure, cancellation, and abandonment when its tab is closed — and one missed path leaves a tab that can never execute again. Deriving it means `Set-ExecuteQueryButtonState` can be called freely, which is why it can live in `Initialize-UiComponents`: `Set-ActiveTabContext` runs that on every tab switch, so switching to a tab that is still executing shows Cancel, and switching away and back does not lose it.
- **The click handler checks for Cancel first**, before starting a stopwatch or showing a popup. Doing that work on the way to cancelling would be exactly backwards.
- **`Set-ExecuteQueryButtonState` never enables a disabled button when nothing is running.** A disconnected tab must not acquire a live Execute button just because this ran; it only forces the button enabled while a query is outstanding, where it is the only way out.

## One behaviour change reviewers should know about

**The Execute button now stays ENABLED while a query runs**, because it *is* the Cancel button. `IsEnabled` is therefore no longer a signal for "is this tab busy". The E2E scenarios that used it that way now ask the queue (`Test-E2EExecuteInFlight`) or the button's label.

## Verification

```
Invoke-Pester -Path tests   →  693 passed, 0 failed  (25 new)
build/build.ps1 -Task E2E   →  54 tests, 0 failures  (7 new)
PSScriptAnalyzer            →  clean under the build's profile
```

The seven new E2E scenarios include the ones that are easy to get wrong: cancelling an **execute-selection** run still issues the DELETE, a cancelled query's **late response never reaches the grid**, and cancelling one tab **leaves another tab's query running**.

The harness was hardened along the way: `Reset-E2EConnection` now drains pending requests, so a scenario that leaves work outstanding fails where the cause is obvious rather than as a puzzling assertion failure in whichever scenario happens to run next — which is precisely how it presented while writing these.

## Known edge, not fixed here

If a tab is disconnected while a query is in flight, `Set-SqlQueryFunctionState -Status $false` disables the Execute button, so the Cancel affordance goes with it. The completion still runs and still cleans up; only the button is unavailable. Fixing it means teaching the connection-state machine about in-flight requests, which is a wider change than this slice, and disconnecting mid-query is not a gesture the UI encourages.
