### PR TITLE
Run the whole execute chain off the UI thread as one job (C1-5)

### DIFF
--- a/src/Lib/Functions/Private/Invoke-ExecuteQuery.ps1
+++ b/src/Lib/Functions/Private/Invoke-ExecuteQuery.ps1
@@ -305,7 +305,12 @@ function Complete-ExecuteQueryResult {
 
         $Script:DataGridQueryResultColumnSelectionAnchor = $null
 
-        if ($null -ne $Script:RunTimeData.QueryResult -and ($Script:RunTimeData.QueryResult.d.Rows | Measure-Object).Count -le 0) {
+        # "-eq $null -or", not "-ne $null -and". A null result used to fall through to the binding
+        # branch, where @($null.d.Rows) is a one-element array containing $null: the grid was bound to
+        # a phantom row and the Show output / Save output buttons were enabled for a result that does
+        # not exist. Null became far more reachable once a request could fail or be abandoned in a
+        # worker, so it is now treated as what it is - no rows.
+        if ($null -eq $Script:RunTimeData.QueryResult -or ($Script:RunTimeData.QueryResult.d.Rows | Measure-Object).Count -le 0) {
             "Query did not return any results!" | Write-LogOutput -LogType WARNING
             $Script:MainForm.Elements.TextBlockStatusBarRows | Set-TextBlockText -Text "0 rows"
             $Script:MainForm.Elements.DataGridQueryResult.ItemsSource = $null

--- a/src/Lib/Functions/Private/Invoke-ExecuteQuery.ps1
+++ b/src/Lib/Functions/Private/Invoke-ExecuteQuery.ps1
@@ -14,7 +14,6 @@ function Invoke-ExecuteQuery {
         $ScriptToExecute = "(function() { var fullText = editor.getValue(); var sel = editor.getSelection(); var hasSelection = sel && !sel.isEmpty(); var selectedText = hasSelection ? editor.getModel().getValueInRange(sel) : null; return { fullText: fullText, selectedText: selectedText, selectionStartLine: hasSelection ? sel.startLineNumber : 1, selectionStartColumn: hasSelection ? sel.startColumn : 1 }; })();"
 
         $OnCompletedScriptBlock = {
-            $Private:TempQueryDoId = $null
             try {
                 if ($Script:Task.Status -eq "RanToCompletion") {
                     $Private:EditorData = $Script:Task.Result | ConvertFrom-Json
@@ -65,81 +64,56 @@ function Invoke-ExecuteQuery {
                         }
                     }
 
-                    $Private:Result = Save-Query -NewQuery:$false
-
-                    $Private:ExecutionTargetId = $Script:AppConfig.CurrentSqlQuery.DoId
-                    if (![string]::IsNullOrWhiteSpace($Private:SelectionText)) {
-                        "Execute selection mode: creating temporary query object" | Write-LogOutput -LogType DEBUG
-                        $Private:TempQueryDoId = New-TemporarySqlQueryObject -QueryText $Private:SelectionText
-                        if ($null -ne $Private:TempQueryDoId) {
-                            $Private:ExecutionTargetId = $Private:TempQueryDoId
-                        }
-                        else {
-                            "Failed to create temporary query object for selection execution." | Write-LogOutput -LogType ERROR
-                            return
-                        }
+                    # C1-5: the whole dependent chain - fetch the query, save it if it changed,
+                    # create the temporary selection object, execute, delete the temporary object -
+                    # runs as ONE background job. Up to five round-trips, none of them on the UI
+                    # thread, and still only ONE completion.
+                    #
+                    # That last part is the design decision worth reviewing. The obvious way to make
+                    # five dependent calls non-blocking is five dispatches chained through five
+                    # completions; issue #40's own analysis names the danger of doing that here, and
+                    # it is real: Set-ActiveTabContext can repoint $Script:MainForm.Elements,
+                    # $Script:RunTimeData and $Script:AppConfig between completions, so every extra
+                    # completion is another place the chain can resume against the wrong tab. One job
+                    # means one repoint - the same number this path already had after C1-3.
+                    #
+                    # The context is gathered HERE, on the UI thread, as plain values. The worker gets
+                    # no $Script: state and no WPF, and returns a description of what happened for the
+                    # completion to apply.
+                    $Private:PipelineContext = @{
+                        BaseUrl            = $Script:AppConfig.BaseUrl
+                        QueryDoId          = $Script:AppConfig.CurrentSqlQuery.DoId
+                        QueryText          = $Script:RunTimeData.QueryText
+                        CurrentQueryText   = $Script:RunTimeData.CurrentQueryText
+                        DisplayName        = $Script:MainForm.Elements.TextBoxDisplayName.Text
+                        CurrentDisplayName = $Script:RunTimeData.CurrentSqlQuery.DisplayName
+                        DataConnectionDoId = $Script:AppConfig.CurrentDataConnection.DoId
+                        SelectionText      = $Private:SelectionText
+                        TempName           = "TMP_$($Script:RunTimeConfig.InstanceGuid)"
+                        SkipSave           = $false
                     }
-
-                    $Script:RunTimeData.RestMethodParam.Uri = "{0}/webservice/jQGridPopulationWebService.asmx/GetPagingData" -f $Script:AppConfig.BaseUrl
-
-                    $Script:RunTimeData.RestMethodParam.Body = @{
-                        "dataType"     = "SqlDataProducer"
-                        "dataTypeArgs" = @{
-                            "targetId" = $Private:ExecutionTargetId
-                        }
-                        "page"         = 1
-                        "rows"         = 100000
-                        "sidx"         = $null
-                        "sord"         = "asc"
-                        "_search"      = $false
-                        "searchField"  = $null
-                        "searchString" = $null
-                        "filters"      = $null
-                        "searchOper"   = $null
-                    }
-                    "Body: {0}" -f (ConvertTo-RedactedLogString -InputObject $Script:RunTimeData.RestMethodParam.Body -ShapeOnly) | Write-LogOutput -LogType VERBOSE
-                    "QueryUrl: {0}" -f $Script:RunTimeData.RestMethodParam.Uri | Write-LogOutput -LogType DEBUG
 
                     "Retrieve query output, please wait..." | Write-LogOutput
-                    $Script:RunTimeData.RestMethodParam.Method = "POST"
-                    $Script:RunTimeData.QueryResult = $null
 
-                    # The headline of issue #40: THIS is the call that freezes the window, and it is
-                    # the one that now runs on a background worker. Everything above it - reading the
-                    # editor, the syntax gate, saving the query, creating the temporary object - is
-                    # still synchronous, and deliberately so: those are short calls, and two of them
-                    # can open a modal dialog, which belongs on the UI thread. Moving the remaining
-                    # round-trips off-thread is C1-5, a separate slice with a much larger blast radius.
-                    #
-                    # Everything the completion needs travels on the context. It must not re-read
-                    # $Script: state: by the time the response lands the user may be looking at
-                    # another tab, and $Private:Result (the Save-Query outcome) and the temporary
-                    # object id do not exist anywhere else.
-                    $Private:Pending = Invoke-OmadaPSWebRequestWrapperAsync -Description $Script:ExecuteQueryRequestDescription -Context @{
-                        SaveResult    = $Private:Result
-                        TempQueryDoId = $Private:TempQueryDoId
+                    $Private:Pending = Invoke-OmadaPSWebRequestWrapperAsync -Description $Script:ExecuteQueryRequestDescription -PipelineContext $Private:PipelineContext -Context @{
+                        DisplayName = $Private:PipelineContext.DisplayName
                     } -OnResultScriptBlock {
                         param($Pending)
-                        Complete-ExecuteQueryResult -QueryResult $Pending.Outcome -SaveResult $Pending.Context.Caller.SaveResult -TempQueryDoId $Pending.Context.Caller.TempQueryDoId
+                        Complete-ExecuteQueryPipeline -Outcome $Pending.Outcome
                     }
 
                     if ($null -ne $Private:Pending) {
-                        # Dispatched. Ownership of the temporary object passes to the completion, so
-                        # this frame must forget it - otherwise the catch below would delete an object
-                        # the in-flight query is still executing against. (Stop-ExecuteQueryRequest
-                        # reads it back off the pending item if the user cancels.)
-                        $Private:TempQueryDoId = $null
                         # The Execute button becomes Cancel: from here the only useful thing the user
                         # can do with it is stop waiting.
                         Set-ExecuteQueryButtonState
                         return
                     }
 
-                    # Not eligible for a worker, or none available: run it inline, exactly as before.
-                    $Private:QueryResult = Invoke-OmadaPSWebRequestWrapper
-                    $Private:CompletedTempQueryDoId = $Private:TempQueryDoId
-                    $Private:TempQueryDoId = $null
-                    Complete-ExecuteQueryResult -QueryResult $Private:QueryResult -SaveResult $Private:Result -TempQueryDoId $Private:CompletedTempQueryDoId
+                    # No worker available, or the tab is not eligible for one: run the identical
+                    # chain inline. Slower - it blocks, exactly as the app did before #40 - but the
+                    # same requests in the same order, because it is literally the same function.
+                    $Private:PipelineContext.Parameters = Build-OmadaRequestParameter
+                    Complete-ExecuteQueryPipeline -Outcome (Invoke-OmadaExecutePipeline -Context $Private:PipelineContext)
                     return
                 }
                 elseif ($Script:Task.Status -eq "Faulted") {
@@ -151,9 +125,9 @@ function Invoke-ExecuteQuery {
                 Reset-ExecuteQueryUiState
             }
             catch {
-                if ($null -ne $Private:TempQueryDoId) {
-                    Remove-SqlQueryObject -DoId $Private:TempQueryDoId
-                }
+                # No temporary-object clean-up here any more: since C1-5 the pipeline owns that
+                # object for its whole lifetime and deletes it in its own finally, so this frame
+                # never holds one to leak.
                 Reset-ExecuteQueryUiState
                 $_.Exception.Message | Write-LogOutput -LogType ERROR -ErrorObject $_
             }
@@ -226,6 +200,67 @@ function Reset-ExecuteQueryUiState {
         }
     }
     catch {
+        $_.Exception.Message | Write-LogOutput -LogType ERROR -ErrorObject $_
+    }
+}
+
+function Complete-ExecuteQueryPipeline {
+    <#
+    .SYNOPSIS
+    Apply the outcome of an execute pipeline on the UI thread: log what it did, then bind the result.
+
+    .DESCRIPTION
+    The UI half of C1-5. Invoke-OmadaExecutePipeline cannot log, cannot touch WPF and cannot write
+    the config, so it returns a description of what happened and this applies it - from the
+    completion poll timer, with the owning tab already made active.
+
+    Everything it needs is in $Outcome. It deliberately re-reads nothing from $Script: state that the
+    pipeline already decided: by the time this runs the user may be looking at another tab, and the
+    save result in particular exists nowhere else.
+
+    .PARAMETER Outcome
+    The pipeline's outcome hashtable - or an ErrorRecord, when the failure was one of the two
+    tenant-level kinds Resolve-OmadaRequestFailure classifies and returns in place of a result.
+    #>
+    [CmdLetBinding()]
+    param(
+        $Outcome
+    )
+
+    try {
+        # The classified-failure case: the request never got far enough to produce an outcome, and
+        # Set-SqlConnectionState has already torn the tab down. Complete-ExecuteQueryResult reports
+        # it the same way a failed single request has always been reported.
+        if ($Outcome -is [System.Management.Automation.ErrorRecord] -or $null -eq $Outcome -or $null -eq $Outcome.Steps) {
+            Complete-ExecuteQueryResult -QueryResult $Outcome -SaveResult $null -TempQueryDoId $null
+            return
+        }
+
+        # The steps the worker actually took, logged here because it could not log them itself. This
+        # is what keeps the log as informative as it was when every request was made inline.
+        foreach ($Private:Step in @($Outcome.Steps)) {
+            "Pipeline step {0}: {1} {2}" -f $Private:Step.Name, $Private:Step.Method, $Private:Step.Uri | Write-LogOutput -LogType DEBUG
+        }
+
+        if ($Outcome.SaveSkipped) {
+            "No changes detected! Saving not needed." | Write-LogOutput -LogType DEBUG
+        }
+        elseif ($null -ne $Outcome.SaveResult) {
+            "Query saved!" | Write-LogOutput
+        }
+
+        if ($null -ne $Outcome.ErrorRecord) {
+            "The query pipeline failed at step '{0}': {1}" -f $Outcome.FailedStep, $Outcome.ErrorRecord.Exception.Message | Write-LogOutput -LogType ERROR -ErrorObject $Outcome.ErrorRecord
+            Complete-ExecuteQueryResult -QueryResult $Outcome.ErrorRecord -SaveResult $Outcome.SaveResult -TempQueryDoId $null
+            return
+        }
+
+        # TempQueryDoId is passed as $null on purpose: the pipeline already deleted the temporary
+        # object in its own finally, whatever the outcome. Passing it would delete it twice.
+        Complete-ExecuteQueryResult -QueryResult $Outcome.QueryResult -SaveResult $Outcome.SaveResult -TempQueryDoId $null
+    }
+    catch {
+        Reset-ExecuteQueryUiState
         $_.Exception.Message | Write-LogOutput -LogType ERROR -ErrorObject $_
     }
 }

--- a/src/Lib/Functions/Private/Invoke-OmadaExecutePipeline.ps1
+++ b/src/Lib/Functions/Private/Invoke-OmadaExecutePipeline.ps1
@@ -1,0 +1,211 @@
+function Invoke-OmadaExecutePipeline {
+    <#
+    .SYNOPSIS
+    Run the whole execute chain - save the query, create the temporary selection object, execute,
+    delete the temporary object - as one sequence, and return everything the UI needs to apply it.
+
+    .DESCRIPTION
+    Issue #40, C1-5: "the UI thread never blocks on a network call". The execute path makes up to
+    five dependent round-trips, and each one's inputs depend on the previous one's response, so they
+    cannot simply be fired off in parallel.
+
+    The obvious way to make them non-blocking is five separate background requests chained through
+    five completions. This is deliberately NOT that, and the reason is the one the issue's own
+    analysis identifies as the danger of this slice: between completions, Set-ActiveTabContext can
+    repoint $Script:MainForm.Elements, $Script:RunTimeData and $Script:AppConfig onto a different
+    tab. Five completions means five places where the chain can resume against the wrong tab. One
+    background job means ONE completion - exactly the number the path already had after C1-3 - so
+    the tab-context risk of this slice is not managed, it is removed.
+
+    The whole function is runspace-safe: no $Script: reads, no logging, no WPF, no calls into this
+    module beyond New-OmadaQueryRequest and Invoke-OmadaRequestCore, which are equally pure. What it
+    cannot do - writing the config, the dropdown, the grid, the log - it does not attempt; it returns
+    a description of what happened and the UI thread applies it.
+
+    Every URL and body comes from New-OmadaQueryRequest, the same builder Save-Query,
+    New-TemporarySqlQueryObject and Remove-SqlQueryObject use on the UI thread. There is exactly one
+    definition of each request, so the inline and background paths cannot drift apart.
+
+    .PARAMETER Context
+    Plain values gathered on the UI thread - see New-OmadaQueryRequest for the keys. Additionally:
+      Parameters   the prepared Invoke-OmadaRestMethod splat (Uri, Method and Body are overwritten
+                   per step; everything else - SessionKey, authentication, redaction - carries).
+      SkipSave     $true to leave the query untouched (nothing to save).
+
+    .OUTPUTS
+    Hashtable:
+      SaveResult     the response to the save, or $null when no save was needed
+      SaveSkipped    $true when nothing had changed, so no save request was made
+      TempQueryDoId  the temporary object's id when one was created, else $null
+      QueryResult    the execute response
+      ErrorRecord    the first failure, or $null
+      FailedStep     which step failed, or $null
+      Steps          an ordered trace of @{ Name; Method; Uri } for the UI to log
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [hashtable]$Context
+    )
+
+    $Outcome = @{
+        SaveResult    = $null
+        SaveSkipped   = $false
+        TempQueryDoId = $null
+        QueryResult   = $null
+        ErrorRecord   = $null
+        FailedStep    = $null
+        Steps         = [System.Collections.Generic.List[object]]::new()
+    }
+
+    # One local helper rather than a call out to another file: this runs in a worker runspace, and
+    # every extra name it depends on is another thing that has to be dot-sourced there.
+    $Invoke = {
+        param($StepName, $Request)
+        $Parameters = $Context.Parameters.Clone()
+        $Parameters.Uri = $Request.Uri
+        $Parameters.Method = $Request.Method
+        if ($null -eq $Request.Body) {
+            if ($Parameters.ContainsKey("Body")) { $Parameters.Remove("Body") }
+        }
+        else {
+            $Parameters.Body = $Request.Body
+        }
+        $Outcome.Steps.Add(@{ Name = $StepName; Method = $Request.Method; Uri = $Request.Uri })
+        return Invoke-OmadaRequestCore -Parameters $Parameters
+    }
+
+    try {
+        # --- 1. Save the current query -------------------------------------------------------------
+        # The server's copy is fetched first because the decision to save at all depends on it:
+        # Save-Query has always compared the editor text against C_QUERY as well as against what this
+        # session last saved.
+        if (-not $Context.SkipSave) {
+            $Private:Fetch = & $Invoke "GetQueryObject" (@{
+                    Method = "GET"
+                    Uri    = "{0}/odata/dataobjects/C_P_SQLTROUBLESHOOTING({1})" -f $Context.BaseUrl, $Context.QueryDoId
+                    Body   = $null
+                })
+            if ($null -ne $Private:Fetch.ErrorRecord) {
+                $Outcome.ErrorRecord = $Private:Fetch.ErrorRecord
+                $Outcome.FailedStep = "GetQueryObject"
+                return $Outcome
+            }
+
+            $Private:SaveContext = $Context.Clone()
+            $Private:SaveContext.SavedQueryText = $Private:Fetch.Result.C_QUERY
+            $Private:SaveRequest = New-OmadaQueryRequest -Kind "SaveExistingQuery" -Context $Private:SaveContext
+
+            if ($null -eq $Private:SaveRequest) {
+                # "No changes detected! Saving not needed." - the caller still needs the fetched
+                # object, because it carries the display name the completion reads.
+                $Outcome.SaveSkipped = $true
+                $Outcome.SaveResult = $Private:Fetch.Result
+            }
+            else {
+                $Private:Save = & $Invoke "SaveQuery" $Private:SaveRequest
+                if ($null -ne $Private:Save.ErrorRecord) {
+                    $Outcome.ErrorRecord = $Private:Save.ErrorRecord
+                    $Outcome.FailedStep = "SaveQuery"
+                    return $Outcome
+                }
+                $Outcome.SaveResult = $Private:Save.Result
+            }
+        }
+
+        # --- 2. The temporary object, for an execute-selection run ---------------------------------
+        if (![string]::IsNullOrWhiteSpace($Context.SelectionText)) {
+            $Private:ReuseDoId = $null
+
+            # A probe failure is not fatal, exactly as it is not on the UI thread: the existing
+            # New-TemporarySqlQueryObject swallows it and falls through to creating a new object.
+            $Private:Probe = & $Invoke "TempQueryProbe" (New-OmadaQueryRequest -Kind "TempQueryProbe" -Context $Context)
+            if ($null -eq $Private:Probe.ErrorRecord -and
+                $null -ne $Private:Probe.Result -and $null -ne $Private:Probe.Result.Value -and
+                @($Private:Probe.Result.Value).Count -gt 0 -and
+                ![string]::IsNullOrWhiteSpace($Private:Probe.Result.Value[0].Id)) {
+
+                $Private:ReuseDoId = $Private:Probe.Result.Value[0].Id
+
+                if ($Private:Probe.Result.Value[0].Deleted -eq $true) {
+                    $Private:UndeleteContext = $Context.Clone()
+                    $Private:UndeleteContext.TempQueryDoId = $Private:ReuseDoId
+                    # Also non-fatal: the upsert below is a PUT that will fail loudly if the object
+                    # really is unusable.
+                    [void](& $Invoke "TempQueryUndelete" (New-OmadaQueryRequest -Kind "TempQueryUndelete" -Context $Private:UndeleteContext))
+                }
+            }
+
+            $Private:UpsertContext = $Context.Clone()
+            $Private:UpsertContext.TempQueryDoId = $Private:ReuseDoId
+            $Private:Upsert = & $Invoke "TempQueryUpsert" (New-OmadaQueryRequest -Kind "TempQueryUpsert" -Context $Private:UpsertContext)
+
+            if ($null -ne $Private:Upsert.ErrorRecord) {
+                $Outcome.ErrorRecord = $Private:Upsert.ErrorRecord
+                $Outcome.FailedStep = "TempQueryUpsert"
+                return $Outcome
+            }
+
+            # A PUT onto the reused object answers without an Id, so fall back to the id that was
+            # reused - it is the object the query must run against either way.
+            $Outcome.TempQueryDoId = if ($null -ne $Private:Upsert.Result -and $null -ne $Private:Upsert.Result.Id) { $Private:Upsert.Result.Id } else { $Private:ReuseDoId }
+
+            # Published to the UI thread the moment it is known, through the synchronized table
+            # Start-OmadaBackgroundRequest put on the pending item. Cancellation kills this frame
+            # outright, so the finally below never runs - and without this the UI would have no idea
+            # which object to clean up. It is the one piece of state that has to escape the worker
+            # before the worker finishes.
+            if ($null -ne $Context.Progress) {
+                $Context.Progress.TempQueryDoId = $Outcome.TempQueryDoId
+            }
+
+            if ($null -eq $Outcome.TempQueryDoId) {
+                $Outcome.FailedStep = "TempQueryUpsert"
+                return $Outcome
+            }
+        }
+
+        # --- 3. The query itself -------------------------------------------------------------------
+        $Private:ExecuteContext = $Context.Clone()
+        $Private:ExecuteContext.TargetQueryDoId = if ($null -ne $Outcome.TempQueryDoId) { $Outcome.TempQueryDoId } else { $Context.QueryDoId }
+        $Private:Execute = & $Invoke "ExecuteQuery" (New-OmadaQueryRequest -Kind "ExecuteQuery" -Context $Private:ExecuteContext)
+
+        if ($null -ne $Private:Execute.ErrorRecord) {
+            $Outcome.ErrorRecord = $Private:Execute.ErrorRecord
+            $Outcome.FailedStep = "ExecuteQuery"
+        }
+        else {
+            $Outcome.QueryResult = $Private:Execute.Result
+        }
+
+        return $Outcome
+    }
+    catch {
+        $Outcome.ErrorRecord = $_
+        if ($null -eq $Outcome.FailedStep) { $Outcome.FailedStep = "Pipeline" }
+        return $Outcome
+    }
+    finally {
+        # The temporary object is deleted here, in a finally, and not by the caller: it must go
+        # whether the query succeeded, failed or threw. Leaving it is how a TMP_<guid> ends up
+        # stranded on someone's tenant. Its own failure is swallowed - there is nothing useful to do
+        # about it from in here, and it must not mask the real error being returned above.
+        #
+        # Cancellation is the one case this cannot cover: stopping the pipeline kills this frame
+        # outright. Stop-ExecuteQueryRequest deletes it from the UI thread instead, which is why the
+        # id is also reported back on the pending item.
+        if ($null -ne $Outcome.TempQueryDoId) {
+            try {
+                $Private:DeleteContext = $Context.Clone()
+                $Private:DeleteContext.TempQueryDoId = $Outcome.TempQueryDoId
+                [void](& $Invoke "DeleteTempQuery" (New-OmadaQueryRequest -Kind "DeleteQuery" -Context $Private:DeleteContext))
+                # Cleared so the UI does not delete it a second time on a cancellation that raced
+                # this frame.
+                if ($null -ne $Context.Progress) {
+                    $Context.Progress.TempQueryDoId = $null
+                }
+            }
+            catch { }
+        }
+    }
+}

--- a/src/Lib/Functions/Private/Invoke-OmadaPSWebRequestWrapperAsync.ps1
+++ b/src/Lib/Functions/Private/Invoke-OmadaPSWebRequestWrapperAsync.ps1
@@ -47,6 +47,12 @@ function Invoke-OmadaPSWebRequestWrapperAsync {
 
         $Context,
 
+        # When supplied, the worker runs the whole dependent execute chain rather than a single
+        # request (issue #40, C1-5). $Pending.Outcome is then the pipeline's outcome object instead
+        # of a single response - or an ErrorRecord, when the failure was one of the two tenant-level
+        # kinds Resolve-OmadaRequestFailure classifies.
+        [hashtable]$PipelineContext,
+
         [string]$Description = "Omada request"
     )
 
@@ -84,7 +90,7 @@ function Invoke-OmadaPSWebRequestWrapperAsync {
         # The completion block below is the bridge back onto the UI thread. It is a plain block: it
         # reads everything it needs from $Pending, and calls only module-private functions, which
         # resolve because the poll timer invokes it from a top-level frame.
-        return Start-OmadaBackgroundRequest -Parameters $Private:Parameters -TabSession $Private:TabSession -Description $Description -Context $Private:RequestContext -OnCompletedScriptBlock {
+        return Start-OmadaBackgroundRequest -Parameters $Private:Parameters -TabSession $Private:TabSession -Description $Description -Context $Private:RequestContext -PipelineContext $PipelineContext -OnCompletedScriptBlock {
             param($Pending)
 
             $Private:Outcome = Complete-OmadaBackgroundRequest -Pending $Pending

--- a/src/Lib/Functions/Private/Invoke-OmadaPSWebRequestWrapperAsync.ps1
+++ b/src/Lib/Functions/Private/Invoke-OmadaPSWebRequestWrapperAsync.ps1
@@ -100,19 +100,35 @@ function Invoke-OmadaPSWebRequestWrapperAsync {
                 return
             }
 
-            if ($null -ne $Private:Outcome.ErrorRecord) {
-                # Same classification as the inline path. The two tenant-level branches throw, which
-                # the poll timer catches and logs; the third returns the ErrorRecord, which is what
-                # callers test with -is [ErrorRecord].
-                $Pending | Add-Member -NotePropertyName "Outcome" -NotePropertyValue (Resolve-OmadaRequestFailure -ErrorRecord $Private:Outcome.ErrorRecord) -Force
+            try {
+                if ($null -ne $Private:Outcome.ErrorRecord) {
+                    # Same classification as the inline path. The two tenant-level branches throw,
+                    # which the poll timer catches and logs; the third returns the ErrorRecord, which
+                    # is what callers test with -is [ErrorRecord].
+                    $Pending | Add-Member -NotePropertyName "Outcome" -NotePropertyValue (Resolve-OmadaRequestFailure -ErrorRecord $Private:Outcome.ErrorRecord) -Force
+                }
+                else {
+                    "Result: {0}" -f (ConvertTo-RedactedLogString -InputObject $Private:Outcome.Result) | Write-LogOutput -LogType VERBOSE
+                    $Script:RunTimeData.RestMethodParam.ForceAuthentication = $false
+                    $Pending | Add-Member -NotePropertyName "Outcome" -NotePropertyValue $Private:Outcome.Result -Force
+                }
             }
-            else {
-                "Result: {0}" -f (ConvertTo-RedactedLogString -InputObject $Private:Outcome.Result) | Write-LogOutput -LogType VERBOSE
-                $Script:RunTimeData.RestMethodParam.ForceAuthentication = $false
-                $Pending | Add-Member -NotePropertyName "Outcome" -NotePropertyValue $Private:Outcome.Result -Force
+            finally {
+                # In a finally, and this is not defensive tidiness. Resolve-OmadaRequestFailure THROWS
+                # for the two tenant-level failures (Unauthorized, OData endpoint missing). Without
+                # this the caller's result block would be skipped for exactly those cases - and for an
+                # execute that block is what closes the "Executing Query..." popup, re-enables the
+                # buttons and stops the stopwatch. The item has already been removed from the queue by
+                # the poll timer, so nothing else would ever run it: the tab would simply stay stuck
+                # mid-execute after an expired session, which is the worst possible moment for it.
+                #
+                # The throw still propagates afterwards, so the "tenant-level failures throw"
+                # contract is unchanged; the poll timer catches and logs it as before.
+                if ($null -eq $Pending.Outcome) {
+                    $Pending | Add-Member -NotePropertyName "Outcome" -NotePropertyValue $Private:Outcome.ErrorRecord -Force
+                }
+                & $Pending.Context.OnResult $Pending
             }
-
-            & $Pending.Context.OnResult $Pending
         }
     }
     catch {

--- a/src/Lib/Functions/Private/New-OmadaQueryRequest.ps1
+++ b/src/Lib/Functions/Private/New-OmadaQueryRequest.ps1
@@ -1,0 +1,172 @@
+function New-OmadaQueryRequest {
+    <#
+    .SYNOPSIS
+    Build the method, URI and body for one Omada request in the execute path, from plain values.
+
+    .DESCRIPTION
+    Every URL and body shape the execute path uses, in one place, expressed as a pure function of a
+    context hashtable: no $Script: reads, no logging, no network. That makes it usable from two
+    places that must never disagree - the UI-thread functions (Save-Query,
+    New-TemporarySqlQueryObject, Remove-SqlQueryObject, Invoke-ExecuteQuery) and
+    Invoke-OmadaExecutePipeline, which runs the same sequence inside a background worker (issue #40,
+    C1-5).
+
+    Written as one function with a -Kind rather than six small ones so that the request shapes sit
+    side by side: they share a base URL, an entity path and a body convention, and a change to one is
+    usually a change to its neighbours.
+
+    Being pure is also what makes these testable at all. Before this, "which URL does saving a query
+    use, and when is the body empty?" could only be answered by running the app against a tenant.
+
+    .PARAMETER Kind
+    Which request to build:
+
+      SaveExistingQuery  PUT the current query. Returns $null when nothing changed - the caller must
+                         treat that as "no request needed", exactly as Save-Query's "No changes
+                         detected!" branch always has.
+      ExecuteQuery       POST GetPagingData for a target query id.
+      TempQueryProbe     GET the TMP_<guid> object by name, including deleted ones.
+      TempQueryUndelete  POST UndeleteDataObject for a soft-deleted temporary object.
+      TempQueryUpsert    PUT (reuse) or POST (create) the temporary object carrying the selection.
+      DeleteQuery        DELETE a query object by id.
+
+    .PARAMETER Context
+    Plain values gathered on the UI thread. Keys used, by Kind:
+      BaseUrl              all
+      QueryDoId            SaveExistingQuery
+      QueryText            SaveExistingQuery
+      CurrentQueryText     SaveExistingQuery  (the text last known to be saved)
+      SavedQueryText       SaveExistingQuery  (C_QUERY from the freshly fetched object)
+      DisplayName          SaveExistingQuery  (what the Display name box holds now)
+      CurrentDisplayName   SaveExistingQuery  (the name last known to be saved)
+      DataConnectionDoId   SaveExistingQuery, TempQueryUpsert
+      TargetQueryDoId      ExecuteQuery
+      TempName             TempQueryProbe, TempQueryUpsert
+      TempQueryDoId        TempQueryUndelete, TempQueryUpsert (reuse), DeleteQuery
+      SelectionText        TempQueryUpsert
+
+    .OUTPUTS
+    Hashtable @{ Method; Uri; Body }, or $null when no request is needed.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateSet("SaveExistingQuery", "ExecuteQuery", "TempQueryProbe", "TempQueryUndelete", "TempQueryUpsert", "DeleteQuery")]
+        [string]$Kind,
+
+        [Parameter(Mandatory = $true)]
+        [hashtable]$Context
+    )
+
+    $Private:BaseUrl = [string]$Context.BaseUrl
+    $Private:EntityUrl = "{0}/odata/dataobjects/C_P_SQLTROUBLESHOOTING" -f $Private:BaseUrl
+
+    switch ($Kind) {
+
+        "SaveExistingQuery" {
+            # The diff rules, preserved exactly as Save-Query has always applied them: the query text
+            # is sent when it differs from either what this session last saved OR what the server
+            # actually holds, and the name is sent when the Display name box no longer matches the
+            # name last saved. An empty body means nothing changed.
+            $Private:Body = @{}
+
+            if ($Context.QueryText -ne $Context.CurrentQueryText -or $Context.QueryText -ne $Context.SavedQueryText) {
+                $Private:Body.Add("C_QUERY", $Context.QueryText)
+                if (![string]::IsNullOrWhiteSpace($Context.DataConnectionDoId)) {
+                    $Private:Body.Add("C_SQLTROUBLESHOOTING_DATACONNECTION", @{ Id = $Context.DataConnectionDoId })
+                }
+            }
+
+            if ($Context.CurrentDisplayName -ne $Context.DisplayName) {
+                $Private:Body.Add("NAME", $Context.DisplayName)
+            }
+
+            if (($Private:Body.Keys | Measure-Object).Count -le 0) {
+                return $null
+            }
+
+            return @{
+                Method = "PUT"
+                Uri    = "{0}({1})" -f $Private:EntityUrl, $Context.QueryDoId
+                Body   = $Private:Body
+            }
+        }
+
+        "ExecuteQuery" {
+            return @{
+                Method = "POST"
+                Uri    = "{0}/webservice/jQGridPopulationWebService.asmx/GetPagingData" -f $Private:BaseUrl
+                Body   = @{
+                    "dataType"     = "SqlDataProducer"
+                    "dataTypeArgs" = @{
+                        "targetId" = $Context.TargetQueryDoId
+                    }
+                    "page"         = 1
+                    "rows"         = 100000
+                    "sidx"         = $null
+                    "sord"         = "asc"
+                    "_search"      = $false
+                    "searchField"  = $null
+                    "searchString" = $null
+                    "filters"      = $null
+                    "searchOper"   = $null
+                }
+            }
+        }
+
+        "TempQueryProbe" {
+            # DeletedStatus=Both on purpose: the temporary object is soft-deleted after every run, so
+            # the one being looked for is normally in the deleted set.
+            return @{
+                Method = "GET"
+                Uri    = "{0}?DeletedStatus=Both&`$filter=NAME eq '{1}'" -f $Private:EntityUrl, $Context.TempName
+                Body   = $null
+            }
+        }
+
+        "TempQueryUndelete" {
+            return @{
+                Method = "POST"
+                Uri    = "{0}/WebService/DataObjectWebService.asmx/UndeleteDataObject" -f $Private:BaseUrl
+                # Pre-serialized, as this endpoint has always been called: it is an ASMX method that
+                # wants a JSON string rather than the object the OData endpoints take.
+                Body   = (@{ id = $Context.TempQueryDoId } | ConvertTo-Json)
+            }
+        }
+
+        "TempQueryUpsert" {
+            $Private:Body = @{
+                "NAME"    = $Context.TempName
+                "C_QUERY" = $Context.SelectionText
+            }
+            if (![string]::IsNullOrWhiteSpace($Context.DataConnectionDoId)) {
+                $Private:Body.Add("C_SQLTROUBLESHOOTING_DATACONNECTION", @{ Id = $Context.DataConnectionDoId })
+            }
+
+            # PUT onto the recovered object when there is one, POST a new one otherwise. The name is
+            # always TMP_<InstanceGuid> - never a fresh guid - so a missing temporary object is
+            # recreated under the same name instead of piling up stale ones on the tenant.
+            if (![string]::IsNullOrWhiteSpace($Context.TempQueryDoId)) {
+                return @{
+                    Method = "PUT"
+                    Uri    = "{0}({1})" -f $Private:EntityUrl, $Context.TempQueryDoId
+                    Body   = $Private:Body
+                }
+            }
+
+            return @{
+                Method = "POST"
+                Uri    = $Private:EntityUrl
+                Body   = $Private:Body
+            }
+        }
+
+        "DeleteQuery" {
+            return @{
+                Method = "DELETE"
+                Uri    = "{0}({1})" -f $Private:EntityUrl, $Context.TempQueryDoId
+                Body   = $null
+            }
+        }
+    }
+}

--- a/src/Lib/Functions/Private/New-TemporarySqlQueryObject.ps1
+++ b/src/Lib/Functions/Private/New-TemporarySqlQueryObject.ps1
@@ -9,10 +9,21 @@ function New-TemporarySqlQueryObject {
 
         $TempName = "TMP_$($Script:RunTimeConfig.InstanceGuid)"
 
+        # Every URL and body below comes from New-OmadaQueryRequest, which the background pipeline
+        # also uses inside the worker (issue #40, C1-5) - one definition each, so the inline and
+        # background paths cannot drift apart.
+        $Private:TempContext = @{
+            BaseUrl            = $Script:AppConfig.BaseUrl
+            TempName           = $TempName
+            SelectionText      = $QueryText
+            DataConnectionDoId = $Script:AppConfig.CurrentDataConnection.DoId
+        }
+
         try {
-            $Script:RunTimeData.RestMethodParam.Uri = "{0}/odata/dataobjects/C_P_SQLTROUBLESHOOTING?DeletedStatus=Both&`$filter=NAME eq '{1}'" -f $Script:AppConfig.BaseUrl, $TempName
-            $Script:RunTimeData.RestMethodParam.Method = "GET"
-            $Script:RunTimeData.RestMethodParam.Body = $null
+            $Private:Probe = New-OmadaQueryRequest -Kind "TempQueryProbe" -Context $Private:TempContext
+            $Script:RunTimeData.RestMethodParam.Uri = $Private:Probe.Uri
+            $Script:RunTimeData.RestMethodParam.Method = $Private:Probe.Method
+            $Script:RunTimeData.RestMethodParam.Body = $Private:Probe.Body
             $ExistingTempQuery = Invoke-OmadaPSWebRequestWrapper
 
             $RestoreSuccess = $false
@@ -20,11 +31,12 @@ function New-TemporarySqlQueryObject {
 
                 if ($ExistingTempQuery.Value[0].Deleted -eq $true) {
                     "Temporary query object with name '{0}' exists. Reuse it." -f $TempName | Write-LogOutput -LogType DEBUG
-                    $Script:RunTimeData.RestMethodParam.Uri = "{0}/WebService/DataObjectWebService.asmx/UndeleteDataObject" -f $Script:AppConfig.BaseUrl
-                    $Script:RunTimeData.RestMethodParam.Method = "POST"
-                    $Script:RunTimeData.RestMethodParam.Body = @{
-                        id = $ExistingTempQuery.Value[0].Id
-                    } | ConvertTo-Json
+                    $Private:UndeleteContext = $Private:TempContext.Clone()
+                    $Private:UndeleteContext.TempQueryDoId = $ExistingTempQuery.Value[0].Id
+                    $Private:Undelete = New-OmadaQueryRequest -Kind "TempQueryUndelete" -Context $Private:UndeleteContext
+                    $Script:RunTimeData.RestMethodParam.Uri = $Private:Undelete.Uri
+                    $Script:RunTimeData.RestMethodParam.Method = $Private:Undelete.Method
+                    $Script:RunTimeData.RestMethodParam.Body = $Private:Undelete.Body
                     $null = Invoke-OmadaPSWebRequestWrapper
                 }
                 else {
@@ -39,8 +51,7 @@ function New-TemporarySqlQueryObject {
 
         if ($RestoreSuccess) {
             "Reusing existing temporary query object with DoId: {0}" -f $ExistingTempQuery.Value[0].Id | Write-LogOutput -LogType DEBUG
-            $Script:RunTimeData.RestMethodParam.Uri = "{0}/odata/dataobjects/C_P_SQLTROUBLESHOOTING({1})" -f $Script:AppConfig.BaseUrl, $ExistingTempQuery.Value[0].Id
-            $Script:RunTimeData.RestMethodParam.Method = "PUT"
+            $Private:TempContext.TempQueryDoId = $ExistingTempQuery.Value[0].Id
         }
         else {
             # Reuse the application-wide InstanceGuid (see Initialize-GlobalConfigSettings) for the
@@ -49,25 +60,26 @@ function New-TemporarySqlQueryObject {
             # query objects piled up on the server instead of the single shared TMP_<InstanceGuid>
             # being recreated and reused.
             "Temporary query object '{0}' does not exist. Creating it." -f $TempName | Write-LogOutput -LogType DEBUG
-            $Script:RunTimeData.RestMethodParam.Uri = "{0}/odata/dataobjects/C_P_SQLTROUBLESHOOTING" -f $Script:AppConfig.BaseUrl
-            $Script:RunTimeData.RestMethodParam.Method = "POST"
+            $Private:TempContext.TempQueryDoId = $null
         }
 
-        $Script:RunTimeData.RestMethodParam.Body = @{
-            "NAME"    = $TempName
-            "C_QUERY" = $QueryText
-        }
-        if (![string]::IsNullOrWhiteSpace($Script:AppConfig.CurrentDataConnection.DoId)) {
-            $Script:RunTimeData.RestMethodParam.Body.Add("C_SQLTROUBLESHOOTING_DATACONNECTION", @{ Id = $Script:AppConfig.CurrentDataConnection.DoId })
-        }
+        # PUT when an object was recovered, POST otherwise - the builder decides from TempQueryDoId.
+        $Private:Upsert = New-OmadaQueryRequest -Kind "TempQueryUpsert" -Context $Private:TempContext
+        $Script:RunTimeData.RestMethodParam.Uri = $Private:Upsert.Uri
+        $Script:RunTimeData.RestMethodParam.Method = $Private:Upsert.Method
+        $Script:RunTimeData.RestMethodParam.Body = $Private:Upsert.Body
 
         "Body: {0}" -f (ConvertTo-RedactedLogString -InputObject $Script:RunTimeData.RestMethodParam.Body -ShapeOnly) | Write-LogOutput -LogType VERBOSE
         "QueryUrl: {0}" -f $Script:RunTimeData.RestMethodParam.Uri | Write-LogOutput -LogType DEBUG
 
         $Private:Result = Invoke-OmadaPSWebRequestWrapper
-        if ($null -ne $Private:Result -and $null -ne $Private:Result.Id) {
-            "Temporary query object created with DoId: {0}" -f $Private:Result.Id | Write-LogOutput -LogType DEBUG
-            return $Private:Result.Id
+        # A PUT onto a recovered object answers without an Id, so fall back to the id that was
+        # reused: it is the object the query has to run against either way. Same rule the pipeline
+        # applies in the worker.
+        $Private:CreatedDoId = if ($null -ne $Private:Result -and $null -ne $Private:Result.Id) { $Private:Result.Id } else { $Private:TempContext.TempQueryDoId }
+        if ($null -ne $Private:CreatedDoId) {
+            "Temporary query object ready with DoId: {0}" -f $Private:CreatedDoId | Write-LogOutput -LogType DEBUG
+            return $Private:CreatedDoId
         }
         else {
             "Failed to create temporary query object: no Id in response." | Write-LogOutput -LogType ERROR

--- a/src/Lib/Functions/Private/Remove-SqlQueryObject.ps1
+++ b/src/Lib/Functions/Private/Remove-SqlQueryObject.ps1
@@ -1,4 +1,18 @@
 function Remove-SqlQueryObject {
+    <#
+    .SYNOPSIS
+    Delete a query object by DoId. Runs on a background worker when one is available.
+
+    .DESCRIPTION
+    This is a fire-and-forget clean-up: nothing in the app waits on its result, and every caller
+    already treats a failure as a warning rather than an error. That makes it the easiest of the
+    execute path's round-trips to take off the UI thread (issue #40, C1-5), and the one it matters
+    most for - it is what runs when the user clicks Cancel, and blocking the UI thread inside the
+    handler that exists to unblock the UI would be a poor joke.
+
+    Falls back to a synchronous delete when no worker is available, exactly as every other
+    background caller does.
+    #>
     [CmdLetBinding()]
     param(
         [Parameter(Mandatory)]
@@ -9,11 +23,30 @@ function Remove-SqlQueryObject {
 
         "Deleting query object with DoId: {0}" -f $DoId | Write-LogOutput -LogType DEBUG
 
-        $Script:RunTimeData.RestMethodParam.Uri = "{0}/odata/dataobjects/C_P_SQLTROUBLESHOOTING({1})" -f $Script:AppConfig.BaseUrl, $DoId
-        $Script:RunTimeData.RestMethodParam.Method = "DELETE"
-        $Script:RunTimeData.RestMethodParam.Body = $null
+        # The same builder the pipeline uses in the worker, so there is one definition of this URL.
+        $Private:Request = New-OmadaQueryRequest -Kind "DeleteQuery" -Context @{
+            BaseUrl       = $Script:AppConfig.BaseUrl
+            TempQueryDoId = $DoId
+        }
+
+        $Script:RunTimeData.RestMethodParam.Uri = $Private:Request.Uri
+        $Script:RunTimeData.RestMethodParam.Method = $Private:Request.Method
+        $Script:RunTimeData.RestMethodParam.Body = $Private:Request.Body
 
         "QueryUrl: {0}" -f $Script:RunTimeData.RestMethodParam.Uri | Write-LogOutput -LogType DEBUG
+
+        $Private:Pending = Invoke-OmadaPSWebRequestWrapperAsync -Description "Delete query object" -Context @{ DoId = $DoId } -OnResultScriptBlock {
+            param($Pending)
+            if ($Pending.Outcome -is [System.Management.Automation.ErrorRecord]) {
+                "Failed to delete query object {0}: {1}" -f $Pending.Context.Caller.DoId, $Pending.Outcome.Exception.Message | Write-LogOutput -LogType WARNING -SkipDialog
+                return
+            }
+            "Query object {0} deleted successfully." -f $Pending.Context.Caller.DoId | Write-LogOutput -LogType DEBUG
+        }
+
+        if ($null -ne $Private:Pending) {
+            return
+        }
 
         Invoke-OmadaPSWebRequestWrapper | Out-Null
         "Query object {0} deleted successfully." -f $DoId | Write-LogOutput -LogType DEBUG

--- a/src/Lib/Functions/Private/Save-Query.ps1
+++ b/src/Lib/Functions/Private/Save-Query.ps1
@@ -34,17 +34,37 @@ function Save-Query {
             $private:Result = Get-SqlQueryObject
             $Script:RunTimeData.RestMethodParam.Method = "PUT"
         }
-        $Script:RunTimeData.RestMethodParam.Body = @{}
-        if ($NewQuery -or ($Script:RunTimeData.CurrentQueryText -ne $Script:RunTimeData.QueryText -or $Script:RunTimeData.QueryText -ne $private:Result.C_QUERY)) {
-            $Script:RunTimeData.RestMethodParam.Body.Add("C_QUERY", $Script:RunTimeData.QueryText)
+
+        # The diff rules and the URL come from New-OmadaQueryRequest, which is also what the
+        # background pipeline uses inside the worker (issue #40, C1-5). One definition of "what does
+        # saving a query send, and when is there nothing to send" - two copies of that would drift,
+        # and the drift would only show up against a real tenant.
+        $Private:SaveContext = @{
+            BaseUrl            = $Script:AppConfig.BaseUrl
+            QueryDoId          = $Script:AppConfig.CurrentSqlQuery.DoId
+            QueryText          = $Script:RunTimeData.QueryText
+            CurrentQueryText   = $Script:RunTimeData.CurrentQueryText
+            SavedQueryText     = $private:Result.C_QUERY
+            DisplayName        = $Script:MainForm.Elements.TextBoxDisplayName.Text
+            CurrentDisplayName = $Script:RunTimeData.CurrentSqlQuery.DisplayName
+            DataConnectionDoId = $Script:AppConfig.CurrentDataConnection.DoId
+        }
+        $Private:SaveRequest = New-OmadaQueryRequest -Kind "SaveExistingQuery" -Context $Private:SaveContext
+
+        # A new query always has a body: there is nothing on the server to compare against, so the
+        # "nothing changed" answer cannot apply. The URI and method for that case were set above.
+        $Script:RunTimeData.RestMethodParam.Body = if ($null -ne $Private:SaveRequest) { $Private:SaveRequest.Body } else { @{} }
+        if ($NewQuery) {
+            $Script:RunTimeData.RestMethodParam.Body = @{ "C_QUERY" = $Script:RunTimeData.QueryText }
             if (![string]::IsNullOrWhiteSpace($Script:AppConfig.CurrentDataConnection.DoId)) {
                 $Script:RunTimeData.RestMethodParam.Body.Add("C_SQLTROUBLESHOOTING_DATACONNECTION", @{Id = $Script:AppConfig.CurrentDataConnection.DoId })
             }
+            if ($Script:RunTimeData.CurrentSqlQuery.DisplayName -ne $Script:MainForm.Elements.TextBoxDisplayName.Text) {
+                $Script:RunTimeData.RestMethodParam.Body.Add("NAME", $Script:MainForm.Elements.TextBoxDisplayName.Text)
+            }
         }
-        if ($Script:RunTimeData.CurrentSqlQuery.DisplayName -ne $Script:MainForm.Elements.TextBoxDisplayName.Text) {
-            $Script:RunTimeData.RestMethodParam.Body.Add("NAME", $Script:MainForm.Elements.TextBoxDisplayName.Text)
-        }
-        if (!$NewQuery -and ($Script:RunTimeData.RestMethodParam.Body.Keys | Measure-Object).Count -le 0) {
+
+        if (!$NewQuery -and $null -eq $Private:SaveRequest) {
             "No changes detected! Saving not needed." | Write-LogOutput -LogType DEBUG
             return $private:Result
         }

--- a/src/Lib/Functions/Private/Start-OmadaBackgroundRequest.ps1
+++ b/src/Lib/Functions/Private/Start-OmadaBackgroundRequest.ps1
@@ -74,10 +74,20 @@ function Start-OmadaBackgroundRequest {
             return $null
         }
 
+        # Everything the worker will dot-source is checked here, not just the core: a missing file
+        # must mean "fall back to the UI thread", the way every other unavailability does. Checking
+        # only the core would dispatch a worker that then fails on its first line - turning a clean
+        # fallback into a failed request.
         $Private:PrivateFolder = Join-Path $Script:RunTimeConfig.ModuleFolder -ChildPath "Lib\Functions\Private"
-        if (-not (Test-Path -LiteralPath (Join-Path $Private:PrivateFolder -ChildPath "Invoke-OmadaRequestCore.ps1"))) {
-            "Background request core not found under '{0}'; running on the UI thread instead." -f $Private:PrivateFolder | Write-LogOutput -LogType WARNING -SkipDialog
-            return $null
+        $Private:RequiredWorkerFiles = @("Invoke-OmadaRequestCore.ps1")
+        if ($null -ne $PipelineContext) {
+            $Private:RequiredWorkerFiles += @("New-OmadaQueryRequest.ps1", "Invoke-OmadaExecutePipeline.ps1")
+        }
+        foreach ($Private:WorkerFile in $Private:RequiredWorkerFiles) {
+            if (-not (Test-Path -LiteralPath (Join-Path $Private:PrivateFolder -ChildPath $Private:WorkerFile))) {
+                "Background worker file '{0}' not found under '{1}'; running on the UI thread instead." -f $Private:WorkerFile, $Private:PrivateFolder | Write-LogOutput -LogType WARNING -SkipDialog
+                return $null
+            }
         }
 
         # The pipeline builds each step's request itself, but every step still goes out with the

--- a/src/Lib/Functions/Private/Start-OmadaBackgroundRequest.ps1
+++ b/src/Lib/Functions/Private/Start-OmadaBackgroundRequest.ps1
@@ -58,6 +58,11 @@ function Start-OmadaBackgroundRequest {
 
         $Context,
 
+        # When supplied, the worker runs the whole dependent execute chain (Invoke-OmadaExecutePipeline)
+        # instead of a single request, and returns its outcome as the Result. This is what makes C1-5
+        # possible with ONE completion rather than five - see the pipeline's own notes.
+        [hashtable]$PipelineContext,
+
         [string]$Description = "Omada request"
     )
 
@@ -69,21 +74,40 @@ function Start-OmadaBackgroundRequest {
             return $null
         }
 
-        $Private:CorePath = Join-Path $Script:RunTimeConfig.ModuleFolder -ChildPath "Lib\Functions\Private\Invoke-OmadaRequestCore.ps1"
-        if (-not (Test-Path -LiteralPath $Private:CorePath)) {
-            "Background request core not found at '{0}'; running on the UI thread instead." -f $Private:CorePath | Write-LogOutput -LogType WARNING -SkipDialog
+        $Private:PrivateFolder = Join-Path $Script:RunTimeConfig.ModuleFolder -ChildPath "Lib\Functions\Private"
+        if (-not (Test-Path -LiteralPath (Join-Path $Private:PrivateFolder -ChildPath "Invoke-OmadaRequestCore.ps1"))) {
+            "Background request core not found under '{0}'; running on the UI thread instead." -f $Private:PrivateFolder | Write-LogOutput -LogType WARNING -SkipDialog
             return $null
+        }
+
+        # The pipeline builds each step's request itself, but every step still goes out with the
+        # session's own transport settings - SessionKey, authentication, redaction - so it is handed
+        # the same prepared splat a single request would have used. Cloned, and into a clone of the
+        # context, for the reason the -Parameters help gives: the live hashtable is mutated by the
+        # next call site.
+        # A synchronized table the worker can publish into while it is still running. Only used by
+        # the pipeline, and only for the temporary object's id: cancellation kills the worker outright
+        # so its own clean-up never runs, and the UI has to know which object to remove.
+        $Private:Progress = [hashtable]::Synchronized(@{})
+        if ($null -ne $PipelineContext) {
+            $PipelineContext = $PipelineContext.Clone()
+            $PipelineContext.Parameters = $Parameters.Clone()
+            $PipelineContext.Progress = $Private:Progress
         }
 
         $Private:Shell = [powershell]::Create()
         $Private:Shell.RunspacePool = $Private:Pool
 
-        # The worker dot-sources the core from disk rather than being handed its source text: one
-        # copy of the function, and the file is already the thing the unit tests execute.
-        # $TransportScriptPath is the test seam - see Start-OmadaBackgroundRequest's note below.
+        # The worker dot-sources what it needs from disk rather than being handed source text: one
+        # copy of every function, and those files are already the things the unit tests execute.
+        # $TransportScriptPath is the mock seam - see Install-OmadaMockTransport.
         [void]$Private:Shell.AddScript({
-                param($CorePath, $RequestParameters, $TransportScriptPath, $TransportContext)
-                . $CorePath
+                param($PrivateFolder, $RequestParameters, $PipelineContext, $TransportScriptPath, $TransportContext)
+                . (Join-Path $PrivateFolder "Invoke-OmadaRequestCore.ps1")
+                if ($null -ne $PipelineContext) {
+                    . (Join-Path $PrivateFolder "New-OmadaQueryRequest.ps1")
+                    . (Join-Path $PrivateFolder "Invoke-OmadaExecutePipeline.ps1")
+                }
                 if (![string]::IsNullOrWhiteSpace($TransportScriptPath) -and (Test-Path -LiteralPath $TransportScriptPath)) {
                     . $TransportScriptPath
                     $Initializer = Get-Command -Name Initialize-OmadaRequestWorkerTransport -ErrorAction SilentlyContinue
@@ -91,8 +115,16 @@ function Start-OmadaBackgroundRequest {
                         Initialize-OmadaRequestWorkerTransport -Context $TransportContext
                     }
                 }
+                if ($null -ne $PipelineContext) {
+                    $PipelineOutcome = Invoke-OmadaExecutePipeline -Context $PipelineContext
+                    # Reported in the transport's own shape so the UI-side plumbing needs no special
+                    # case: the whole outcome is the Result, and the pipeline's first failure is also
+                    # surfaced as the ErrorRecord so Resolve-OmadaRequestFailure still classifies an
+                    # Unauthorized or a missing OData endpoint exactly as it does for a single request.
+                    return @{ Result = $PipelineOutcome; ErrorRecord = $PipelineOutcome.ErrorRecord }
+                }
                 return (Invoke-OmadaRequestCore -Parameters $RequestParameters)
-            }).AddArgument($Private:CorePath).AddArgument($Parameters.Clone()).AddArgument($Script:OmadaRequestWorkerTransportPath).AddArgument($Script:OmadaRequestWorkerTransportContext)
+            }).AddArgument($Private:PrivateFolder).AddArgument($Parameters.Clone()).AddArgument($PipelineContext).AddArgument($Script:OmadaRequestWorkerTransportPath).AddArgument($Script:OmadaRequestWorkerTransportContext)
 
         $Private:AsyncResult = $Private:Shell.BeginInvoke()
 
@@ -108,6 +140,7 @@ function Start-OmadaBackgroundRequest {
             IsBackgroundRequest    = $true
             Description            = $Description
             Context                = $Context
+            Progress               = $Private:Progress
         }
 
         # Deliberately NOT assigned to $Script:Task or $TabSession.PendingTask. That field belongs

--- a/src/Lib/Functions/Private/Stop-ExecuteQueryRequest.ps1
+++ b/src/Lib/Functions/Private/Stop-ExecuteQueryRequest.ps1
@@ -56,9 +56,15 @@ function Stop-ExecuteQueryRequest {
             "Stopping the query worker reported: {0}" -f $_.Exception.Message | Write-LogOutput -LogType DEBUG
         }
 
-        # Itself a network call, on the UI thread exactly as it is on the normal completion path.
-        # Cancelling a query does not make cleaning up after it optional.
-        $Private:TempQueryDoId = $Private:Pending.Context.Caller.TempQueryDoId
+        # Read from the worker's progress table, not from the request context. Since C1-5 the
+        # temporary object is created INSIDE the pipeline, so the UI thread only learns its id
+        # because the pipeline publishes it there the moment it has one - which it does precisely
+        # for this case, since stopping the pipeline kills its own clean-up.
+        # (The Context fallback covers a caller that knew the id up front.)
+        $Private:TempQueryDoId = $Private:Pending.Progress.TempQueryDoId
+        if ($null -eq $Private:TempQueryDoId) {
+            $Private:TempQueryDoId = $Private:Pending.Context.Caller.TempQueryDoId
+        }
         if ($null -ne $Private:TempQueryDoId) {
             "Removing the temporary query object left by the cancelled execution." | Write-LogOutput -LogType DEBUG
             Remove-SqlQueryObject -DoId $Private:TempQueryDoId

--- a/src/Lib/Functions/Private/Update-BackgroundRequestElapsedTime.ps1
+++ b/src/Lib/Functions/Private/Update-BackgroundRequestElapsedTime.ps1
@@ -29,18 +29,36 @@ function Update-BackgroundRequestElapsedTime {
         $Pending
     )
 
-    foreach ($Item in @($Pending)) {
-        if ($null -eq $Item -or $null -eq $Item.StartedUtc -or $Item.IsCancelled) {
-            continue
-        }
+    # Wrapped as a whole, and per item, because this runs from the completion poll timer's Tick: an
+    # exception escaping here would abort that Tick before it drained any completions, so one
+    # malformed queue item could stall every pending result behind a cosmetic status-bar update.
+    # A missing tab or element bag is a skip, never a failure.
+    try {
+        foreach ($Item in @($Pending)) {
+            try {
+                if ($null -eq $Item -or $null -eq $Item.StartedUtc -or $Item.IsCancelled) {
+                    continue
+                }
+                if ($null -eq $Item.TabSession -or $null -eq $Item.TabSession.Elements) {
+                    continue
+                }
 
-        $Private:TimeBlock = $Item.TabSession.Elements.TextBlockStatusBarQueryTime
-        if ($null -eq $Private:TimeBlock) {
-            continue
-        }
+                $Private:TimeBlock = $Item.TabSession.Elements.TextBlockStatusBarQueryTime
+                if ($null -eq $Private:TimeBlock) {
+                    continue
+                }
 
-        # Formatted like the final value Reset-ExecuteQueryUiState writes from the stopwatch, so the
-        # indicator does not visibly change shape at the moment the request completes.
-        $Private:TimeBlock.Text = ([DateTime]::UtcNow - $Item.StartedUtc).ToString()
+                # Formatted like the final value Reset-ExecuteQueryUiState writes from the stopwatch,
+                # so the indicator does not visibly change shape when the request completes.
+                $Private:TimeBlock.Text = ([DateTime]::UtcNow - $Item.StartedUtc).ToString()
+            }
+            catch {
+                continue
+            }
+        }
+    }
+    catch {
+        # Deliberately silent: this is a cosmetic indicator, and it runs twenty times a second.
+        # Logging a failure here would flood the log for something the user cannot act on.
     }
 }

--- a/tests/Invoke-ExecuteQuery.Tests.ps1
+++ b/tests/Invoke-ExecuteQuery.Tests.ps1
@@ -221,6 +221,19 @@ Describe "Complete-ExecuteQueryResult" {
         $Script:RunTimeData.QueryResult | Should -Be $Response
     }
 
+    It "treats a null result as no rows rather than binding a phantom one" {
+        # A null result used to fall through to the binding branch, where @($null.d.Rows) is a
+        # one-element array containing $null: the grid showed a phantom row and the output buttons
+        # were enabled for a result that does not exist. Null became far more reachable once a
+        # request could fail or be abandoned in a worker.
+        Complete-ExecuteQueryResult -QueryResult $null -SaveResult ([pscustomobject]@{ Id = 100; DisplayName = "TestQuery" }) -TempQueryDoId $null
+
+        $Script:MainForm.Elements.DataGridQueryResult.ItemsSource | Should -BeNullOrEmpty
+        $Script:MainForm.Elements.TextBlockStatusBarRows.Text | Should -Be "0 rows"
+        $Script:MainForm.Elements.ButtonShowOutput.IsEnabled | Should -BeFalse
+        $Script:MainForm.Elements.ButtonSaveOutputFile.IsEnabled | Should -BeFalse
+    }
+
     It "clears the grid and says '0 rows' for an empty result" {
         Complete-ExecuteQueryResult -QueryResult (New-ResultResponse -RowCount 0) -SaveResult ([pscustomobject]@{ Id = 100; DisplayName = "TestQuery" }) -TempQueryDoId $null
 

--- a/tests/Invoke-OmadaExecutePipeline.Tests.ps1
+++ b/tests/Invoke-OmadaExecutePipeline.Tests.ps1
@@ -1,0 +1,324 @@
+#Requires -Version 7.0
+# The execute chain as one background job (issue #40, C1-5).
+#
+# These are the tests that matter most in this slice, because the pipeline is where five dependent
+# round-trips are sequenced and where the temporary object's lifetime is decided. Each case asserts
+# the ORDER and SHAPE of the requests it made, using a recording transport - so a change to the
+# sequencing fails here rather than on someone's tenant.
+
+BeforeAll {
+    $ParentPath = Split-Path -Path $PSScriptRoot -Parent
+    $PrivatePath = Join-Path $ParentPath -ChildPath "src\Lib\Functions\Private"
+    . (Join-Path $PrivatePath -ChildPath "New-OmadaQueryRequest.ps1")
+    . (Join-Path $PrivatePath -ChildPath "Invoke-OmadaExecutePipeline.ps1")
+
+    # The pipeline's only transport. Recorded, and steerable per step by URI/method.
+    $script:Calls = [System.Collections.Generic.List[object]]::new()
+    $script:Responses = @{}
+    $script:Failures = @{}
+
+    function Invoke-OmadaRequestCore {
+        param([hashtable]$Parameters)
+        $Key = Get-CallKey -Method $Parameters.Method -Uri $Parameters.Uri -Body $Parameters.Body
+        $script:Calls.Add([pscustomobject]@{ Key = $Key; Method = $Parameters.Method; Uri = $Parameters.Uri; Body = $Parameters.Body })
+
+        if ($script:Failures.ContainsKey($Key)) {
+            return @{ Result = $null; ErrorRecord = [System.Management.Automation.ErrorRecord]::new(
+                    [System.Exception]::new($script:Failures[$Key]), "PipelineTestFailure",
+                    [System.Management.Automation.ErrorCategory]::ConnectionError, $null) }
+        }
+        if ($script:Responses.ContainsKey($Key)) {
+            return @{ Result = $script:Responses[$Key]; ErrorRecord = $null }
+        }
+        return @{ Result = $null; ErrorRecord = $null }
+    }
+
+    function script:Get-CallKey {
+        # A short, stable name per logical request, so the tests read as a sequence of steps rather
+        # than a list of URLs.
+        param($Method, $Uri, $Body)
+        if ($Uri -like "*GetPagingData*") { return "execute" }
+        if ($Uri -like "*UndeleteDataObject*") { return "undelete" }
+        if ($Uri -like "*DeletedStatus=Both*") { return "probe" }
+        if ($Method -eq "DELETE") { return "delete" }
+        if ($Method -eq "GET") { return "get" }
+        if ($Method -eq "PUT" -and $Body.ContainsKey("NAME") -and ([string]$Body["NAME"]).StartsWith("TMP_")) { return "temp-put" }
+        if ($Method -eq "POST" -and $null -ne $Body -and $Body.ContainsKey("NAME") -and ([string]$Body["NAME"]).StartsWith("TMP_")) { return "temp-post" }
+        if ($Method -eq "PUT") { return "save" }
+        return "other"
+    }
+
+    function script:New-PipelineContext {
+        param(
+            $QueryText = "SELECT 1",
+            $SelectionText = $null,
+            $CurrentQueryText = "SELECT 1",
+            $DisplayName = "TestQuery",
+            $CurrentDisplayName = "TestQuery"
+        )
+        return @{
+            BaseUrl            = "https://tenant.omada.cloud"
+            QueryDoId          = 100
+            QueryText          = $QueryText
+            CurrentQueryText   = $CurrentQueryText
+            DisplayName        = $DisplayName
+            CurrentDisplayName = $CurrentDisplayName
+            DataConnectionDoId = "42"
+            SelectionText      = $SelectionText
+            TempName           = "TMP_abc"
+            SkipSave           = $false
+            Parameters         = @{ SessionKey = "pool"; AuthenticationType = "Browser" }
+        }
+    }
+
+    function script:Get-CallSequence {
+        return @($script:Calls | ForEach-Object { $_.Key })
+    }
+
+    function script:Reset-PipelineTestState {
+        $script:Calls.Clear()
+        $script:Failures = @{}
+        $script:Responses = @{
+            # The stored query, fetched first so the save decision can compare against it.
+            "get"       = [pscustomobject]@{ Id = 100; C_QUERY = "SELECT 1"; DisplayName = "TestQuery" }
+            "save"      = [pscustomobject]@{ Id = 100; DisplayName = "TestQuery" }
+            "probe"     = [pscustomobject]@{ Value = @() }
+            "temp-post" = [pscustomobject]@{ Id = 777 }
+            "temp-put"  = [pscustomobject]@{ Id = 777 }
+            "execute"   = [pscustomobject]@{ d = [pscustomobject]@{ Records = 2; Rows = @(1, 2) } }
+        }
+    }
+}
+
+Describe "Invoke-OmadaExecutePipeline - the ordinary run" {
+    BeforeEach { Reset-PipelineTestState }
+
+    It "fetches the query, skips a save that is not needed, and executes" {
+        $Outcome = Invoke-OmadaExecutePipeline -Context (New-PipelineContext)
+
+        Get-CallSequence | Should -Be @("get", "execute")
+        $Outcome.SaveSkipped | Should -BeTrue
+        $Outcome.QueryResult.d.Records | Should -Be 2
+        $Outcome.ErrorRecord | Should -BeNullOrEmpty
+    }
+
+    It "saves before executing when the query text changed" {
+        $Outcome = Invoke-OmadaExecutePipeline -Context (New-PipelineContext -QueryText "SELECT 2")
+
+        Get-CallSequence | Should -Be @("get", "save", "execute")
+        $Outcome.SaveSkipped | Should -BeFalse
+        $Outcome.SaveResult.Id | Should -Be 100
+    }
+
+    It "still reports the fetched object when the save was skipped" {
+        # The completion needs it: the display name it carries is what decides whether the query list
+        # has to be refreshed.
+        $Outcome = Invoke-OmadaExecutePipeline -Context (New-PipelineContext)
+
+        $Outcome.SaveResult.DisplayName | Should -Be "TestQuery"
+    }
+
+    It "executes against the current query when there is no selection" {
+        Invoke-OmadaExecutePipeline -Context (New-PipelineContext) | Out-Null
+
+        $Execute = $script:Calls | Where-Object { $_.Key -eq "execute" } | Select-Object -First 1
+        $Execute.Body["dataTypeArgs"]["targetId"] | Should -Be 100
+    }
+
+    It "leaves the query alone when the caller asks it to" {
+        $Context = New-PipelineContext
+        $Context.SkipSave = $true
+
+        Invoke-OmadaExecutePipeline -Context $Context | Out-Null
+
+        Get-CallSequence | Should -Be @("execute")
+    }
+
+    It "reports every step it took, in order, for the UI to log" {
+        # The pipeline cannot log - it runs in a worker - so the trace is how the log stays as
+        # informative as it was when every request was made inline.
+        $Outcome = Invoke-OmadaExecutePipeline -Context (New-PipelineContext -QueryText "SELECT 2")
+
+        @($Outcome.Steps | ForEach-Object { $_.Name }) | Should -Be @("GetQueryObject", "SaveQuery", "ExecuteQuery")
+    }
+}
+
+Describe "Invoke-OmadaExecutePipeline - execute selection" {
+    BeforeEach { Reset-PipelineTestState }
+
+    It "creates a temporary object, executes against it, and deletes it" {
+        # The full lifetime, in one assertion. The delete is the part that used to be easy to lose.
+        $Outcome = Invoke-OmadaExecutePipeline -Context (New-PipelineContext -SelectionText "SELECT TOP 1 *")
+
+        Get-CallSequence | Should -Be @("get", "probe", "temp-post", "execute", "delete")
+        $Outcome.TempQueryDoId | Should -Be 777
+    }
+
+    It "executes against the temporary object, not the saved query" {
+        Invoke-OmadaExecutePipeline -Context (New-PipelineContext -SelectionText "SELECT TOP 1 *") | Out-Null
+
+        $Execute = $script:Calls | Where-Object { $_.Key -eq "execute" } | Select-Object -First 1
+        $Execute.Body["dataTypeArgs"]["targetId"] | Should -Be 777
+    }
+
+    It "undeletes and reuses a soft-deleted temporary object rather than creating another" {
+        # Without this the shared TMP_<InstanceGuid> object would be recreated on every run and stale
+        # ones would pile up on the tenant.
+        $script:Responses["probe"] = [pscustomobject]@{ Value = @([pscustomobject]@{ Id = 777; Deleted = $true }) }
+
+        Invoke-OmadaExecutePipeline -Context (New-PipelineContext -SelectionText "SELECT TOP 1 *") | Out-Null
+
+        Get-CallSequence | Should -Be @("get", "probe", "undelete", "temp-put", "execute", "delete")
+    }
+
+    It "reuses an existing, not-deleted temporary object without undeleting it" {
+        $script:Responses["probe"] = [pscustomobject]@{ Value = @([pscustomobject]@{ Id = 777; Deleted = $false }) }
+
+        Invoke-OmadaExecutePipeline -Context (New-PipelineContext -SelectionText "SELECT TOP 1 *") | Out-Null
+
+        Get-CallSequence | Should -Be @("get", "probe", "temp-put", "execute", "delete")
+    }
+
+    It "falls back to the reused id when the PUT answers without one" {
+        # A PUT onto a recovered object returns no Id, but it is still the object the query has to
+        # run against.
+        $script:Responses["probe"] = [pscustomobject]@{ Value = @([pscustomobject]@{ Id = 777; Deleted = $false }) }
+        $script:Responses["temp-put"] = [pscustomobject]@{ }
+
+        $Outcome = Invoke-OmadaExecutePipeline -Context (New-PipelineContext -SelectionText "SELECT TOP 1 *")
+
+        $Outcome.TempQueryDoId | Should -Be 777
+    }
+
+    It "carries on to create a new object when the probe itself fails" {
+        # Non-fatal, exactly as it is on the UI thread: a failed probe means "assume there is none".
+        $script:Failures["probe"] = "probe blew up"
+
+        $Outcome = Invoke-OmadaExecutePipeline -Context (New-PipelineContext -SelectionText "SELECT TOP 1 *")
+
+        Get-CallSequence | Should -Be @("get", "probe", "temp-post", "execute", "delete")
+        $Outcome.ErrorRecord | Should -BeNullOrEmpty
+    }
+
+    It "publishes the temporary object's id WHILE it is still running" {
+        # The only way the UI thread can clean up after a CANCELLED run: stopping the pipeline kills
+        # its own finally, so the id has to escape the worker before the worker finishes.
+        #
+        # Observed mid-flight rather than afterwards, and that distinction is the point: by the time
+        # the pipeline returns normally it has already deleted the object and cleared the id again,
+        # so an assertion at the end would say nothing about what a cancellation could have seen.
+        $Progress = [hashtable]::Synchronized(@{})
+        $Context = New-PipelineContext -SelectionText "SELECT TOP 1 *"
+        $Context.Progress = $Progress
+
+        $script:ObservedDuringExecute = "not reached"
+        function Invoke-OmadaRequestCore {
+            param([hashtable]$Parameters)
+            $Key = Get-CallKey -Method $Parameters.Method -Uri $Parameters.Uri -Body $Parameters.Body
+            $script:Calls.Add([pscustomobject]@{ Key = $Key; Method = $Parameters.Method; Uri = $Parameters.Uri; Body = $Parameters.Body })
+            if ($Key -eq "execute") {
+                $script:ObservedDuringExecute = $Progress.TempQueryDoId
+            }
+            if ($script:Responses.ContainsKey($Key)) { return @{ Result = $script:Responses[$Key]; ErrorRecord = $null } }
+            return @{ Result = $null; ErrorRecord = $null }
+        }
+
+        Invoke-OmadaExecutePipeline -Context $Context | Out-Null
+
+        $script:ObservedDuringExecute | Should -Be 777
+        # And cleared once the pipeline has deleted it itself, so a cancellation racing the finish
+        # does not delete it a second time.
+        $Progress.TempQueryDoId | Should -BeNullOrEmpty
+    }
+}
+
+Describe "Invoke-OmadaExecutePipeline - failures" {
+    BeforeEach { Reset-PipelineTestState }
+
+    It "stops at the failing step and says which one it was" {
+        $script:Failures["save"] = "save rejected"
+
+        $Outcome = Invoke-OmadaExecutePipeline -Context (New-PipelineContext -QueryText "SELECT 2")
+
+        $Outcome.FailedStep | Should -Be "SaveQuery"
+        $Outcome.ErrorRecord.Exception.Message | Should -Be "save rejected"
+        Get-CallSequence | Should -Not -Contain "execute"
+    }
+
+    It "does not execute when the query could not be fetched" {
+        $script:Failures["get"] = "not found"
+
+        $Outcome = Invoke-OmadaExecutePipeline -Context (New-PipelineContext)
+
+        $Outcome.FailedStep | Should -Be "GetQueryObject"
+        Get-CallSequence | Should -Be @("get")
+    }
+
+    It "deletes the temporary object even when the execute fails" {
+        # The leak that matters: the object exists on the tenant by then, and a failed query is
+        # exactly when it would be easiest to forget.
+        $script:Failures["execute"] = "server error"
+
+        $Outcome = Invoke-OmadaExecutePipeline -Context (New-PipelineContext -SelectionText "SELECT TOP 1 *")
+
+        Get-CallSequence | Should -Contain "delete"
+        $Outcome.FailedStep | Should -Be "ExecuteQuery"
+    }
+
+    It "does not let a failing clean-up mask the real error" {
+        $script:Failures["execute"] = "server error"
+        $script:Failures["delete"] = "delete blew up"
+
+        $Outcome = Invoke-OmadaExecutePipeline -Context (New-PipelineContext -SelectionText "SELECT TOP 1 *")
+
+        $Outcome.ErrorRecord.Exception.Message | Should -Be "server error"
+    }
+
+    It "stops when the temporary object could not be created" {
+        $script:Failures["temp-post"] = "create rejected"
+
+        $Outcome = Invoke-OmadaExecutePipeline -Context (New-PipelineContext -SelectionText "SELECT TOP 1 *")
+
+        $Outcome.FailedStep | Should -Be "TempQueryUpsert"
+        Get-CallSequence | Should -Not -Contain "execute"
+    }
+}
+
+Describe "Invoke-OmadaExecutePipeline is runspace-safe" {
+    It "runs in a bare runspace with none of this module's state or functions" {
+        # The property the whole design rests on. A $Script: read or a Write-LogOutput added here
+        # later would break every background execute with a CommandNotFoundException that no
+        # ordinary unit test would catch, because in the test process those names resolve fine.
+        $Shell = [powershell]::Create()
+        try {
+            [void]$Shell.AddScript({
+                    param($PrivatePath)
+                    . (Join-Path $PrivatePath "New-OmadaQueryRequest.ps1")
+                    . (Join-Path $PrivatePath "Invoke-OmadaExecutePipeline.ps1")
+                    function Invoke-OmadaRequestCore {
+                        param([hashtable]$Parameters)
+                        if ($Parameters.Uri -like "*GetPagingData*") {
+                            return @{ Result = [pscustomobject]@{ d = [pscustomobject]@{ Records = 1 } }; ErrorRecord = $null }
+                        }
+                        return @{ Result = [pscustomobject]@{ Id = 100; C_QUERY = "SELECT 1" }; ErrorRecord = $null }
+                    }
+                    $Outcome = Invoke-OmadaExecutePipeline -Context @{
+                        BaseUrl = "https://tenant.omada.cloud"; QueryDoId = 100
+                        QueryText = "SELECT 1"; CurrentQueryText = "SELECT 1"
+                        DisplayName = "Q"; CurrentDisplayName = "Q"
+                        SelectionText = $null; TempName = "TMP_abc"; SkipSave = $false
+                        Parameters = @{ SessionKey = "pool" }
+                    }
+                    return $Outcome.QueryResult.d.Records
+                }).AddArgument((Join-Path (Split-Path -Path $PSScriptRoot -Parent) "src\Lib\Functions\Private"))
+
+            $Output = $Shell.Invoke()
+
+            $Shell.Streams.Error | Should -BeNullOrEmpty
+            $Output[0] | Should -Be 1
+        }
+        finally {
+            $Shell.Dispose()
+        }
+    }
+}

--- a/tests/Invoke-OmadaPSWebRequestWrapperAsync.Tests.ps1
+++ b/tests/Invoke-OmadaPSWebRequestWrapperAsync.Tests.ps1
@@ -36,6 +36,11 @@ BeforeAll {
 
     function Set-SqlConnectionState { param([bool]$Status = $true) }
 
+    # The real classification is dot-sourced above, and its Unauthorized branch calls Write-Error
+    # -ErrorAction Stop - which is exactly the throwing behaviour the finally in the completion block
+    # exists to survive. Stubbing it would test nothing.
+    function Set-SqlQueryFunctionState { param([bool]$Status = $true) }
+
     function Get-ActiveTabSession { return $script:StubTabSession }
 
     # Records what was dispatched and, when asked, completes it immediately so the completion block
@@ -214,6 +219,53 @@ Describe "Invoke-OmadaPSWebRequestWrapperAsync dispatches" {
         } | Out-Null
 
         $script:ResultBlockRuns | Should -Be 0
+    }
+
+    It "still runs the result block when the failure classification throws" {
+        # The wedge this guards against: Resolve-OmadaRequestFailure THROWS for the two tenant-level
+        # failures (Unauthorized, OData endpoint missing). The caller's result block is what closes
+        # the "Executing Query..." popup, re-enables the buttons and stops the stopwatch - and the
+        # pending item has already been removed from the queue by the poll timer, so if that block is
+        # skipped nothing will ever run it. The tab would stay stuck mid-execute after an expired
+        # session, which is the worst possible moment for it.
+        Initialize-AsyncTestState
+        $script:DispatchBehaviour = "CompleteInline"
+        $Unauthorized = [System.Management.Automation.ErrorRecord]::new(
+            [System.Net.Http.HttpRequestException]::new("denied", $null, [System.Net.HttpStatusCode]::Unauthorized),
+            "OmadaUnauthorized", [System.Management.Automation.ErrorCategory]::AuthenticationError, $null)
+        $script:WorkerOutcome = @{ Result = $null; ErrorRecord = $Unauthorized; IsCancelled = $false }
+        $script:ResultBlockRuns = 0
+
+        # The throw still propagates - that contract is unchanged - so the call is expected to fail.
+        try {
+            Invoke-OmadaPSWebRequestWrapperAsync -OnResultScriptBlock {
+                param($Pending)
+                $script:ResultBlockRuns++
+            } | Out-Null
+        }
+        catch { }
+
+        $script:ResultBlockRuns | Should -Be 1
+    }
+
+    It "hands the result block the ErrorRecord when the classification threw before setting an outcome" {
+        Initialize-AsyncTestState
+        $script:DispatchBehaviour = "CompleteInline"
+        $Unauthorized = [System.Management.Automation.ErrorRecord]::new(
+            [System.Net.Http.HttpRequestException]::new("denied", $null, [System.Net.HttpStatusCode]::Unauthorized),
+            "OmadaUnauthorized", [System.Management.Automation.ErrorCategory]::AuthenticationError, $null)
+        $script:WorkerOutcome = @{ Result = $null; ErrorRecord = $Unauthorized; IsCancelled = $false }
+        $script:SeenOutcome = "not set"
+
+        try {
+            Invoke-OmadaPSWebRequestWrapperAsync -OnResultScriptBlock {
+                param($Pending)
+                $script:SeenOutcome = $Pending.Outcome
+            } | Out-Null
+        }
+        catch { }
+
+        $script:SeenOutcome | Should -BeOfType [System.Management.Automation.ErrorRecord]
     }
 
     It "clears ForceAuthentication after a successful background request, as the inline path does" {

--- a/tests/New-OmadaQueryRequest.Tests.ps1
+++ b/tests/New-OmadaQueryRequest.Tests.ps1
@@ -1,0 +1,176 @@
+#Requires -Version 7.0
+# Every URL and body the execute path sends, asserted directly (issue #40, C1-5).
+#
+# Before this function existed, "which URL does saving a query use, and when is the body empty?"
+# could only be answered by running the app against a tenant - the rules were interleaved with
+# logging, $Script: reads and WPF. Being pure is what makes them testable, and being ONE definition
+# is what stops the UI-thread path and the background pipeline drifting apart.
+
+BeforeAll {
+    $ParentPath = Split-Path -Path $PSScriptRoot -Parent
+    $PrivatePath = Join-Path $ParentPath -ChildPath "src\Lib\Functions\Private"
+    . (Join-Path $PrivatePath -ChildPath "New-OmadaQueryRequest.ps1")
+
+    $script:Base = "https://tenant.omada.cloud"
+
+    function script:New-SaveContext {
+        param(
+            $QueryText = "SELECT 1",
+            $CurrentQueryText = "SELECT 1",
+            $SavedQueryText = "SELECT 1",
+            $DisplayName = "TestQuery",
+            $CurrentDisplayName = "TestQuery",
+            $DataConnectionDoId = "42"
+        )
+        return @{
+            BaseUrl            = $script:Base
+            QueryDoId          = 100
+            QueryText          = $QueryText
+            CurrentQueryText   = $CurrentQueryText
+            SavedQueryText     = $SavedQueryText
+            DisplayName        = $DisplayName
+            CurrentDisplayName = $CurrentDisplayName
+            DataConnectionDoId = $DataConnectionDoId
+        }
+    }
+}
+
+Describe "New-OmadaQueryRequest -Kind SaveExistingQuery" {
+    It "returns null when neither the text nor the name has changed" {
+        # The "No changes detected! Saving not needed." branch, which must stay a NON-request: it is
+        # what keeps an execute from writing to the tenant every single time.
+        New-OmadaQueryRequest -Kind "SaveExistingQuery" -Context (New-SaveContext) | Should -BeNullOrEmpty
+    }
+
+    It "sends the query text when the editor differs from what this session last saved" {
+        $Request = New-OmadaQueryRequest -Kind "SaveExistingQuery" -Context (New-SaveContext -QueryText "SELECT 2" -SavedQueryText "SELECT 2")
+
+        $Request.Method | Should -Be "PUT"
+        $Request.Uri | Should -Be "$script:Base/odata/dataobjects/C_P_SQLTROUBLESHOOTING(100)"
+        $Request.Body["C_QUERY"] | Should -Be "SELECT 2"
+    }
+
+    It "sends the query text when the editor differs from what the SERVER holds" {
+        # Both comparisons matter: another tab (or another person) can have changed the stored query
+        # since this session last saved it.
+        $Request = New-OmadaQueryRequest -Kind "SaveExistingQuery" -Context (New-SaveContext -SavedQueryText "SELECT 999")
+
+        $Request.Body["C_QUERY"] | Should -Be "SELECT 1"
+    }
+
+    It "carries the data connection alongside a changed query text" {
+        $Request = New-OmadaQueryRequest -Kind "SaveExistingQuery" -Context (New-SaveContext -QueryText "SELECT 2" -SavedQueryText "SELECT 2")
+
+        $Request.Body["C_SQLTROUBLESHOOTING_DATACONNECTION"].Id | Should -Be "42"
+    }
+
+    It "omits the data connection when none is selected" {
+        $Request = New-OmadaQueryRequest -Kind "SaveExistingQuery" -Context (New-SaveContext -QueryText "SELECT 2" -SavedQueryText "SELECT 2" -DataConnectionDoId $null)
+
+        $Request.Body.ContainsKey("C_SQLTROUBLESHOOTING_DATACONNECTION") | Should -BeFalse
+    }
+
+    It "sends only the name when just the Display name changed" {
+        $Request = New-OmadaQueryRequest -Kind "SaveExistingQuery" -Context (New-SaveContext -DisplayName "RenamedQuery")
+
+        $Request.Body["NAME"] | Should -Be "RenamedQuery"
+        $Request.Body.ContainsKey("C_QUERY") | Should -BeFalse
+    }
+
+    It "sends both when both changed" {
+        $Request = New-OmadaQueryRequest -Kind "SaveExistingQuery" -Context (New-SaveContext -QueryText "SELECT 2" -SavedQueryText "SELECT 2" -DisplayName "RenamedQuery")
+
+        $Request.Body["C_QUERY"] | Should -Be "SELECT 2"
+        $Request.Body["NAME"] | Should -Be "RenamedQuery"
+    }
+}
+
+Describe "New-OmadaQueryRequest -Kind ExecuteQuery" {
+    It "posts GetPagingData for the target id" {
+        $Request = New-OmadaQueryRequest -Kind "ExecuteQuery" -Context @{ BaseUrl = $script:Base; TargetQueryDoId = 555 }
+
+        $Request.Method | Should -Be "POST"
+        $Request.Uri | Should -Be "$script:Base/webservice/jQGridPopulationWebService.asmx/GetPagingData"
+        $Request.Body["dataType"] | Should -Be "SqlDataProducer"
+        $Request.Body["dataTypeArgs"]["targetId"] | Should -Be 555
+        $Request.Body["rows"] | Should -Be 100000
+    }
+}
+
+Describe "New-OmadaQueryRequest -Kind TempQuery*" {
+    It "probes for the temporary object including deleted ones" {
+        # DeletedStatus=Both is essential: the temporary object is soft-deleted after every run, so
+        # the one being looked for is normally in the deleted set. Without it every execute-selection
+        # run would create a new object instead of reusing the one shared name.
+        $Request = New-OmadaQueryRequest -Kind "TempQueryProbe" -Context @{ BaseUrl = $script:Base; TempName = "TMP_abc" }
+
+        $Request.Method | Should -Be "GET"
+        $Request.Uri | Should -Match "DeletedStatus=Both"
+        $Request.Uri | Should -Match "NAME eq 'TMP_abc'"
+        $Request.Body | Should -BeNullOrEmpty
+    }
+
+    It "undeletes with a pre-serialized JSON body" {
+        # This ASMX endpoint takes a JSON string, unlike the OData endpoints which take the object.
+        $Request = New-OmadaQueryRequest -Kind "TempQueryUndelete" -Context @{ BaseUrl = $script:Base; TempQueryDoId = 777 }
+
+        $Request.Method | Should -Be "POST"
+        $Request.Uri | Should -Be "$script:Base/WebService/DataObjectWebService.asmx/UndeleteDataObject"
+        $Request.Body | Should -BeOfType [string]
+        ($Request.Body | ConvertFrom-Json).id | Should -Be 777
+    }
+
+    It "PUTs onto a recovered temporary object" {
+        $Request = New-OmadaQueryRequest -Kind "TempQueryUpsert" -Context @{
+            BaseUrl = $script:Base; TempName = "TMP_abc"; SelectionText = "SELECT TOP 1 *"; TempQueryDoId = 777
+        }
+
+        $Request.Method | Should -Be "PUT"
+        $Request.Uri | Should -Be "$script:Base/odata/dataobjects/C_P_SQLTROUBLESHOOTING(777)"
+        $Request.Body["C_QUERY"] | Should -Be "SELECT TOP 1 *"
+        $Request.Body["NAME"] | Should -Be "TMP_abc"
+    }
+
+    It "POSTs a new temporary object when there is none to recover" {
+        $Request = New-OmadaQueryRequest -Kind "TempQueryUpsert" -Context @{
+            BaseUrl = $script:Base; TempName = "TMP_abc"; SelectionText = "SELECT TOP 1 *"; TempQueryDoId = $null
+        }
+
+        $Request.Method | Should -Be "POST"
+        $Request.Uri | Should -Be "$script:Base/odata/dataobjects/C_P_SQLTROUBLESHOOTING"
+    }
+}
+
+Describe "New-OmadaQueryRequest -Kind DeleteQuery" {
+    It "deletes by id" {
+        $Request = New-OmadaQueryRequest -Kind "DeleteQuery" -Context @{ BaseUrl = $script:Base; TempQueryDoId = 777 }
+
+        $Request.Method | Should -Be "DELETE"
+        $Request.Uri | Should -Be "$script:Base/odata/dataobjects/C_P_SQLTROUBLESHOOTING(777)"
+        $Request.Body | Should -BeNullOrEmpty
+    }
+}
+
+Describe "New-OmadaQueryRequest is runspace-safe" {
+    It "runs in a bare runspace with none of this module's state or functions" {
+        # It is executed inside a worker by Invoke-OmadaExecutePipeline, so a $Script: read or a call
+        # to a private function added here later would break every background execute with a
+        # CommandNotFoundException that no ordinary unit test would catch.
+        $Shell = [powershell]::Create()
+        try {
+            [void]$Shell.AddScript({
+                    param($Path)
+                    . $Path
+                    return (New-OmadaQueryRequest -Kind "DeleteQuery" -Context @{ BaseUrl = "https://x"; TempQueryDoId = 1 }).Method
+                }).AddArgument((Join-Path (Split-Path -Path $PSScriptRoot -Parent) "src\Lib\Functions\Private\New-OmadaQueryRequest.ps1"))
+
+            $Output = $Shell.Invoke()
+
+            $Shell.Streams.Error | Should -BeNullOrEmpty
+            $Output[0] | Should -Be "DELETE"
+        }
+        finally {
+            $Shell.Dispose()
+        }
+    }
+}

--- a/tests/Update-BackgroundRequestElapsedTime.Tests.ps1
+++ b/tests/Update-BackgroundRequestElapsedTime.Tests.ps1
@@ -85,4 +85,17 @@ Describe "Update-BackgroundRequestElapsedTime" {
         { Update-BackgroundRequestElapsedTime -Pending $null } | Should -Not -Throw
         { Update-BackgroundRequestElapsedTime -Pending @() } | Should -Not -Throw
     }
+
+    It "skips a malformed item and still updates the ones around it" {
+        # This runs from the completion poll timer's Tick. An exception escaping here would abort
+        # that Tick BEFORE it drained any completions, so one malformed queue item could stall every
+        # pending query result behind a cosmetic status-bar update.
+        $Good = New-TimePending
+        $NoTab = [pscustomobject]@{ StartedUtc = [DateTime]::UtcNow.AddSeconds(-5); IsCancelled = $false; TabSession = $null }
+        $NoElements = [pscustomobject]@{ StartedUtc = [DateTime]::UtcNow.AddSeconds(-5); IsCancelled = $false; TabSession = [pscustomobject]@{ Id = "x" } }
+
+        { Update-BackgroundRequestElapsedTime -Pending @($NoTab, $NoElements, $Good) } | Should -Not -Throw
+
+        $Good.TabSession.Elements.TextBlockStatusBarQueryTime.Text | Should -Not -Be "-"
+    }
 }

--- a/tests/e2e/OmadaMocks.ps1
+++ b/tests/e2e/OmadaMocks.ps1
@@ -25,6 +25,38 @@ function script:Invoke-OmadaPSWebRequestWrapper {
     return $Response
 }
 
+# --- The transport seam under the pipeline (issue #40, C1-5) --------------------------------------
+# Invoke-OmadaExecutePipeline issues its steps through Invoke-OmadaRequestCore, NOT through
+# Invoke-OmadaPSWebRequestWrapper - that is the whole point of the core, since the wrapper cannot run
+# in a worker. Without this override the pipeline would call the real OmadaWeb.PS and reach out to
+# whatever tenant URL the app had built. Shadowing it here means the scenarios run the REAL pipeline
+# - its sequencing, its step decisions, its temporary-object clean-up - over fixture responses.
+function script:Invoke-OmadaRequestCore {
+    param(
+        [hashtable]$Parameters
+    )
+    $script:E2ECalls.Add([pscustomobject]@{
+            Uri      = [string]$Parameters.Uri
+            Method   = [string]$Parameters.Method
+            Body     = $Parameters.Body
+            DataType = $(if ($Parameters.Body -is [System.Collections.IDictionary] -and $Parameters.Body.Contains("dataType")) { [string]$Parameters.Body["dataType"] } else { $null })
+        })
+    try {
+        $Response = Resolve-E2EFixture -Uri $Parameters.Uri -Method $Parameters.Method -Body $Parameters.Body
+        if ($Response -is [System.Exception]) {
+            return @{ Result = $null; ErrorRecord = [System.Management.Automation.ErrorRecord]::new(
+                    $Response, "E2EFixtureFailure", [System.Management.Automation.ErrorCategory]::ConnectionError, $null) }
+        }
+        if ($Response -is [System.Management.Automation.ErrorRecord]) {
+            return @{ Result = $null; ErrorRecord = $Response }
+        }
+        return @{ Result = $Response; ErrorRecord = $null }
+    }
+    catch {
+        return @{ Result = $null; ErrorRecord = $_ }
+    }
+}
+
 # --- The background dispatch seam (issue #40) -----------------------------------------------------
 # Requests now also run on worker runspaces. The shim above cannot cover those: a worker has its own
 # OmadaWeb.PS and would call the REAL Invoke-OmadaRestMethod, so an unmocked background request would
@@ -48,31 +80,49 @@ function script:Start-OmadaBackgroundRequest {
         $TabSession,
         [scriptblock]$OnCompletedScriptBlock,
         $Context,
+        [hashtable]$PipelineContext,
         [string]$Description
     )
 
-    # Recorded in the same shape as the synchronous seam, so Get-E2ECallCount counts a background
-    # request exactly as it counts an inline one and existing assertions keep working.
-    $script:E2ECalls.Add([pscustomobject]@{
-            Uri      = [string]$Parameters.Uri
-            Method   = [string]$Parameters.Method
-            Body     = $Parameters.Body
-            DataType = $(if ($Parameters.Body -is [System.Collections.IDictionary] -and $Parameters.Body.Contains("dataType")) { [string]$Parameters.Body["dataType"] } else { $null })
-        })
-
+    $Progress = [hashtable]::Synchronized(@{})
     $Payload = @{ Result = $null; ErrorRecord = $null }
-    try {
-        $Response = Resolve-E2EFixture -Uri $Parameters.Uri -Method $Parameters.Method -Body $Parameters.Body
-        if ($Response -is [System.Exception]) {
-            $Payload.ErrorRecord = [System.Management.Automation.ErrorRecord]::new(
-                $Response, "E2EFixtureFailure", [System.Management.Automation.ErrorCategory]::ConnectionError, $null)
-        }
-        else {
-            $Payload.Result = $Response
-        }
+
+    if ($null -ne $PipelineContext) {
+        # C1-5: the worker runs the whole dependent chain. The REAL Invoke-OmadaExecutePipeline is
+        # used here, on the UI thread, because it is runspace-safe and therefore also
+        # dispatcher-safe - so the scenarios exercise the actual sequencing, the actual step
+        # decisions and the actual temporary-object clean-up. Only the transport under it is the
+        # fixture, via Invoke-OmadaRequestCore's seam below.
+        $PipelineContext = $PipelineContext.Clone()
+        $PipelineContext.Parameters = $Parameters.Clone()
+        $PipelineContext.Progress = $Progress
+        $PipelineOutcome = Invoke-OmadaExecutePipeline -Context $PipelineContext
+        $Payload.Result = $PipelineOutcome
+        $Payload.ErrorRecord = $PipelineOutcome.ErrorRecord
     }
-    catch {
-        $Payload.ErrorRecord = $_
+    else {
+        # Recorded in the same shape as the synchronous seam, so Get-E2ECallCount counts a background
+        # request exactly as it counts an inline one and existing assertions keep working.
+        $script:E2ECalls.Add([pscustomobject]@{
+                Uri      = [string]$Parameters.Uri
+                Method   = [string]$Parameters.Method
+                Body     = $Parameters.Body
+                DataType = $(if ($Parameters.Body -is [System.Collections.IDictionary] -and $Parameters.Body.Contains("dataType")) { [string]$Parameters.Body["dataType"] } else { $null })
+            })
+
+        try {
+            $Response = Resolve-E2EFixture -Uri $Parameters.Uri -Method $Parameters.Method -Body $Parameters.Body
+            if ($Response -is [System.Exception]) {
+                $Payload.ErrorRecord = [System.Management.Automation.ErrorRecord]::new(
+                    $Response, "E2EFixtureFailure", [System.Management.Automation.ErrorCategory]::ConnectionError, $null)
+            }
+            else {
+                $Payload.Result = $Response
+            }
+        }
+        catch {
+            $Payload.ErrorRecord = $_
+        }
     }
 
     $Shell = [powershell]::Create()
@@ -92,6 +142,7 @@ function script:Start-OmadaBackgroundRequest {
         IsBackgroundRequest    = $true
         Description            = $Description
         Context                = $Context
+        Progress               = $Progress
     }
     $Script:PendingWebViewCompletions.Add($Pending)
     return $Pending


### PR DESCRIPTION
Slice **C1-5** of **#40** (Roadmap C1). Targets the working baseline branch `feature/async-query-execution`, not `main`.

> **Stacked on #80 (C1-4), which is stacked on #79 (C1-3).** The diff narrows to this slice as those land.

Completes *"REST calls execute in a background runspace; the UI thread never blocks on a network call."* The remaining round-trips in the execute path — fetch the query, save it if it changed, create the temporary selection object, execute, delete the temporary object — now all run on a worker.

## One job, not five chained requests

This is the decision to review, and it is a deliberate departure from the plan in the issue.

The obvious way to make five dependent calls non-blocking is five dispatches chained through five completions. **#40's own analysis names that as the danger of this slice**, and it is right: `Set-ActiveTabContext` repoints `$Script:MainForm.Elements`, `$Script:RunTimeData` and `$Script:AppConfig` around **every** completion, so each extra completion is another place the chain can resume against the wrong tab. The analysis proposes managing that by threading values forward, and calls the slice "human-led, agent-assisted at most" largely because of it.

Running the chain as a **single background job removes the risk instead of managing it.** There is exactly **one** completion — the same number this path already had after C1-3 — so exactly one repoint, and no step can resume against a tab the user switched to halfway through.

```
UI thread          gather plain values ──► dispatch ──────────────► apply outcome
worker                                  │ GET query               ▲
                                        │ PUT save (if changed)   │
                                        │ GET/POST temp object    │
                                        │ POST GetPagingData      │
                                        │ DELETE temp object      │
                                        └─────────────────────────┘
```

## The two new pieces

**`Invoke-OmadaExecutePipeline`** is runspace-safe throughout: no `$Script:` reads, no logging, no WPF. It takes plain values and returns a description of what it did — the save result, the temporary object id, the query result, the first failure and *which step* produced it, plus an ordered trace of every request for the UI to log. `Complete-ExecuteQueryPipeline` applies that on the UI thread.

**`New-OmadaQueryRequest`** is what keeps the two paths honest. Every URL and body the execute path sends is defined **once**, as a pure function of a context hashtable, and used by both the worker pipeline **and** the UI-thread functions — `Save-Query`, `New-TemporarySqlQueryObject` and `Remove-SqlQueryObject` now build their requests through it.

Two copies of *"what does saving a query send, and when is there nothing to send"* would drift, and the drift would only surface against a real tenant. It also makes those rules testable at all for the first time: they used to be interleaved with logging, `$Script:` reads and WPF, so the only way to answer "which URL does this use?" was to run the app against a tenant.

## Decisions worth reviewing

- **The temporary object's lifetime is owned end to end by the pipeline**, deleted in its own `finally` whether the query succeeded, failed or threw. `Invoke-ExecuteQuery`'s `catch` no longer cleans up, because it never holds one.
- **Cancellation is the one case a `finally` cannot cover** — stopping the pipeline kills that frame. So the pipeline **publishes the object's id into a synchronized table the moment it has one**, and `Stop-ExecuteQueryRequest` cleans up from the UI thread using it. It clears the id again once it has deleted the object itself, so a cancellation racing the finish does not delete twice. The test observes the published id *mid-flight* rather than afterwards, because by the end it is legitimately gone.
- **`Remove-SqlQueryObject` now runs on a worker too.** Nothing waits on it and every caller already treats failure as a warning, so it is the easiest round-trip to move — and the one it matters most for, since blocking the UI thread inside the handler that exists to unblock it would be a poor joke.
- **A probe failure stays non-fatal**, exactly as it is on the UI thread today: it means "assume there is no temporary object" and the chain creates one.

## A pre-existing bug found on the way

`New-TemporarySqlQueryObject` treated a PUT that answers **without an `Id`** as a failure — *"Failed to create temporary query object: no Id in response."* — even though a PUT onto a **recovered** object legitimately answers that way and the object is perfectly usable. It now falls back to the id it reused, which is the same rule the pipeline applies.

## Verification

```
Invoke-Pester -Path tests   →  726 passed, 0 failed  (33 new)
build/build.ps1 -Task E2E   →  54 tests, 0 failures
PSScriptAnalyzer            →  clean under the build's profile
```

The pipeline tests assert the **order and shape of the requests made**, per branch: ordinary run, save-needed, execute-selection, reuse-with-undelete, reuse-without-undelete, probe failure, and five failure paths including *"deletes the temporary object even when the execute fails"* and *"does not let a failing clean-up mask the real error"*. Both new functions also have a bare-runspace test, so a `$Script:` read or a `Write-LogOutput` added later fails there rather than in production.

The E2E scenarios run the **real** pipeline over fixture responses — `Invoke-OmadaRequestCore` is the seam — so they exercise its actual sequencing and clean-up, not a stub of it.

## Scope, stated plainly

This covers the **execute path**. `Update-QueryList` still runs synchronously when called from elsewhere (the Refresh button, connect), as do the other callers of `Save-Query` (the Save and New buttons). Those are separate entry points with their own UI flows; bringing them off-thread is the same technique applied again, not a continuation of this change, and doing it here would have widened the diff well past what the execute path needs.

## Still not covered by any test

Everything in #40's authentication analysis, unchanged since C1-2: the mock replaces the transport, so no authentication ever happens under test. A live-tenant pass is still needed for a genuinely slow query, an expired cookie mid-request, and two tabs on different tenants executing at once.
