### PR TITLE
Narrow the reentrancy suppression to the call that can open a window (C1-6)

### DIFF
--- a/src/Lib/Functions/Private/Invoke-OmadaPSWebRequestWrapper.ps1
+++ b/src/Lib/Functions/Private/Invoke-OmadaPSWebRequestWrapper.ps1
@@ -7,13 +7,30 @@ function Invoke-OmadaPSWebRequestWrapper {
     # Invoke-OmadaRestMethod (OmadaWeb.PS) can show its own interactive WebView2/Browser login
     # popup when authentication is needed - a modal window this app does not own, but which pumps
     # this thread's messages while blocked exactly like our own dialogs (see
-    # Suspend-WebViewCompletionPolling.ps1). Without suspending here, the WebViewCompletionPollTimer
-    # can fire reentrantly during that popup and process a DIFFERENT tab's WebView2 completion,
-    # repointing $Script:MainForm.Elements/$Script:AppConfig/etc. mid-call - corrupting which tab's
-    # UI this function's own status updates (and any Set-SqlConnectionState a caller makes right
-    # after it returns) end up applying to. This is the single choke point every Omada REST call in
-    # this app goes through, so suspending here covers all of them.
-    Suspend-WebViewCompletionPolling
+    # Suspend-WebViewCompletionPolling.ps1). Without suspending, the WebViewCompletionPollTimer can
+    # fire reentrantly during that popup and process a DIFFERENT tab's WebView2 completion,
+    # repointing $Script:MainForm.Elements/$Script:AppConfig/etc. mid-call.
+    #
+    # Issue #40's last criterion asks for this suppression to be "simplified or removed where it is
+    # no longer needed". Removing it from here would be exactly backwards, and it is worth writing
+    # down why, because the plan for that slice assumed the opposite.
+    #
+    # Before #40 this was the single choke point every Omada request went through, so it covered all
+    # of them - most of which could never have opened a dialog. Now the requests that cannot open a
+    # dialog do not come through here at all: they go to a worker, and
+    # Invoke-OmadaPSWebRequestWrapperAsync suspends nothing, because there is nothing on the UI
+    # thread to protect. What is left calling this function is precisely the set of cases
+    # Test-OmadaBackgroundRequestEligible refuses to dispatch - a tab that has not authenticated, or
+    # a request that explicitly asks to authenticate again - which is to say: the login prompt now
+    # happens HERE, by design, and nowhere else. The suppression is more necessary than it was, not
+    # less.
+    #
+    # The simplification that IS available is narrowing it. It used to be held across parameter
+    # preparation, two rounds of redaction and logging, and the whole error classification - during
+    # all of which no dialog can appear, and every completion in the queue was needlessly delayed.
+    # It now covers just the call that can actually show a window. (Write-LogOutput and
+    # Set-SqlConnectionState open their own dialogs on some paths and suspend for themselves; the
+    # helper is idempotent, so a nested suspend is harmless either way.)
     try {
         if (!$Script:RunTimeData.SkipRetryRequest) {
             # Preparation and failure classification live in Build-OmadaRequestParameter and
@@ -30,7 +47,14 @@ function Invoke-OmadaPSWebRequestWrapper {
             # The core returns the failure instead of throwing it, so this rethrows to keep the
             # control flow identical: a rethrown ErrorRecord keeps its Exception, ErrorDetails and
             # FullyQualifiedErrorId, which is all the classification reads.
-            $Private:Outcome = Invoke-OmadaRequestCore -Parameters $Private:Parameters
+            Suspend-WebViewCompletionPolling
+            try {
+                $Private:Outcome = Invoke-OmadaRequestCore -Parameters $Private:Parameters
+            }
+            finally {
+                Resume-WebViewCompletionPolling
+            }
+
             if ($null -ne $Private:Outcome.ErrorRecord) {
                 throw $Private:Outcome.ErrorRecord
             }
@@ -54,8 +78,5 @@ function Invoke-OmadaPSWebRequestWrapper {
     }
     catch {
         Resolve-OmadaRequestFailure -ErrorRecord $_
-    }
-    finally {
-        Resume-WebViewCompletionPolling
     }
 }

--- a/tests/Invoke-OmadaPSWebRequestWrapper.Tests.ps1
+++ b/tests/Invoke-OmadaPSWebRequestWrapper.Tests.ps1
@@ -41,9 +41,13 @@ BeforeAll {
         process { }
     }
 
-    function Suspend-WebViewCompletionPolling { }
+    # Recorded rather than no-ops: issue #40's last criterion is about WHERE this suppression is
+    # held, so the tests below assert on the order of these against the network call.
+    $script:PollingEvents = [System.Collections.Generic.List[string]]::new()
 
-    function Resume-WebViewCompletionPolling { }
+    function Suspend-WebViewCompletionPolling { $script:PollingEvents.Add("suspend") }
+
+    function Resume-WebViewCompletionPolling { $script:PollingEvents.Add("resume") }
 
     # The single network seam. Behaviour per test is steered by $script:RestMethodBehaviour.
     function Invoke-OmadaRestMethod {
@@ -51,6 +55,7 @@ BeforeAll {
         param(
             [Parameter(ValueFromRemainingArguments = $true)]$IgnoredRest
         )
+        $script:PollingEvents.Add("request")
         if ($script:RestMethodBehaviour -eq "ODataMissing") {
             $ErrorRecord = [System.Management.Automation.ErrorRecord]::new(
                 [System.Exception]::new("odata failure"), "OmadaODataMissing",
@@ -106,6 +111,7 @@ BeforeAll {
         # The tab is NOT connected: the whole point is that a successful request must not change that.
         $Script:ConnectionStatus = $false
         $script:ConnectionStateCalls.Clear()
+        $script:PollingEvents.Clear()
         $script:RestMethodBehaviour = "Success"
     }
 }
@@ -147,6 +153,45 @@ Describe "Invoke-OmadaPSWebRequestWrapper connection state" {
         # state machine, which updates button, status bar, dropdowns and Display name together.
         $script:ConnectionStateCalls.Count | Should -Be 1
         $script:ConnectionStateCalls[0] | Should -BeFalse
+    }
+}
+
+Describe "Invoke-OmadaPSWebRequestWrapper reentrancy suppression" {
+    # Issue #40's last criterion, "simplify or remove the reentrancy suppression where it is no
+    # longer needed". It is NOT removed here, and that is deliberate: since the eligibility gate
+    # sends everything that cannot open a dialog to a worker, what is left calling this function is
+    # exactly the set of cases where an interactive login CAN appear. The suppression is more
+    # necessary than it was, not less. What changed is how much it covers.
+
+    It "still suspends the completion poll timer around the network call" {
+        Initialize-WrapperTestState
+
+        Invoke-OmadaPSWebRequestWrapper | Out-Null
+
+        $script:PollingEvents | Should -Be @("suspend", "request", "resume")
+    }
+
+    It "resumes even when the request throws" {
+        Initialize-WrapperTestState
+        $script:RestMethodBehaviour = "ODataMissing"
+
+        { Invoke-OmadaPSWebRequestWrapper } | Should -Throw
+
+        # The classification that follows a failure opens dialogs of its own (Write-LogOutput,
+        # Set-SqlConnectionState), and each suspends for itself - so leaving the timer stopped across
+        # all of it, as this used to, delayed every queued completion for no reason.
+        $script:PollingEvents | Should -Be @("suspend", "request", "resume")
+    }
+
+    It "does not hold the suspension across a request that is never made" {
+        # SkipRetryRequest answers $null without touching the network, so there is nothing to
+        # protect and no reason to stop the timer at all.
+        Initialize-WrapperTestState
+        $Script:RunTimeData.SkipRetryRequest = $true
+
+        Invoke-OmadaPSWebRequestWrapper | Out-Null
+
+        $script:PollingEvents.Count | Should -Be 0
     }
 }
 


### PR DESCRIPTION
Slice **C1-6** of **#40** (Roadmap C1) — the last acceptance criterion. Targets the working baseline branch `feature/async-query-execution`, not `main`.

> **Stacked on #81 (C1-5) → #80 (C1-4) → #79 (C1-3).** The diff narrows to this slice as those land.

The criterion: *"Reentrancy suppression around modal dialogs is simplified or removed where it is no longer needed."*

## The plan for this slice was wrong, and that is the finding

#40's analysis concludes that the `Suspend`/`Resume-WebViewCompletionPolling` pair at `Invoke-OmadaPSWebRequestWrapper` is the one of the nine sites that can go, *"if the worker is guaranteed never to open a dialog."*

The worker is indeed guaranteed never to open a dialog. **That does not make this site removable — it makes it more necessary.**

Before #40 this was the single choke point every Omada request went through, so the suppression covered all of them, the overwhelming majority of which could never have shown a login window. Now the requests that cannot open a dialog **do not come through here at all**: they go to a worker, and `Invoke-OmadaPSWebRequestWrapperAsync` suspends nothing, because there is nothing on the UI thread to protect.

What is left calling this function is precisely the set `Test-OmadaBackgroundRequestEligible` **refuses** to dispatch — a tab that has not authenticated, or a request that explicitly asks to authenticate again. In other words, the earlier slices concentrated the interactive login into exactly this function. Removing the guard from the one place it is still needed would be the opposite of the criterion's intent.

**The suppression stays, and the reasoning is now recorded in the function** so the next person to read the criterion does not have to rediscover it.

## What is simplified

A real narrowing. The suspension used to be held across:

- parameter preparation,
- two rounds of redaction and logging,
- the entire error classification,

during **none** of which a dialog can appear — and throughout all of which every queued completion was needlessly delayed, including background query results that had nothing to do with this request.

It now covers just the `Invoke-OmadaRequestCore` call, which is the only statement that can show a window. A request that is never made (`SkipRetryRequest`) no longer stops the timer at all.

`Write-LogOutput` and `Set-SqlConnectionState` open their own dialogs on some paths and suspend for themselves; the helper is idempotent, so nesting is harmless either way.

## The other eight sites

Untouched, and correctly so. Every one wraps a real `ShowDialog()` or `MessageBox.Show()` — `Open-ChoiceForm`, `Save-QueryResultToFile`, `Open-SqlHistoryForm`, `LogForm.Elements.ButtonExportLogFile`, `SqlHistoryForm.Elements.ButtonExportHistory` (×2), `SqlHistoryForm.Elements.ButtonRestoreQuery`, `Write-LogOutput` — and none of them is affected by anything in this issue.

The ninth site is new, added in C1-3: the dispatcher pump in the Execute click handler, where suppression was **missing** and its absence was causing real tab-context corruption. So across the issue the machinery ends up applied more precisely in both directions — added where it was needed, narrowed where it was over-broad.

## Verification

```
Invoke-Pester -Path tests   →  729 passed, 0 failed
build/build.ps1 -Task E2E   →  54 tests, 0 failures
```

Three new cases assert the **order** of suspend / request / resume rather than merely that the calls happen, so a future change that widens the window again fails here rather than silently costing latency:

- still suspends around the network call
- resumes even when the request throws
- does not hold the suspension across a request that is never made
