### PR TITLE
Fall back to the UI thread when a worker cannot run the request

### DIFF
--- a/src/Lib/Functions/Private/Disable-OmadaBackgroundRequest.ps1
+++ b/src/Lib/Functions/Private/Disable-OmadaBackgroundRequest.ps1
@@ -1,0 +1,47 @@
+function Disable-OmadaBackgroundRequest {
+    <#
+    .SYNOPSIS
+    Stop offering background execution for the rest of this session, and say so once.
+
+    .DESCRIPTION
+    Issue #40 assumed that a tab which authenticated on the UI thread can also be served from a
+    worker runspace, because OmadaWeb.PS keeps an encrypted cookie cache on disk and a fresh worker
+    would load it. Live-tenant testing showed that is not universally true: with some tenants and
+    authentication options the worker's own OmadaWeb.PS instance cannot establish a session at all,
+    and every background request fails.
+
+    That assumption was never testable - the mock replaces Invoke-OmadaRestMethod outright, so no
+    authentication ever happens under test - so rather than keep guessing at it, eligibility is now
+    settled by OBSERVATION. The first background request that fails without reaching the tenant calls
+    this, and from then on Test-OmadaBackgroundRequestEligible refuses to dispatch: every later
+    request goes straight down the synchronous path that has always worked, with no doomed round-trip
+    in front of it.
+
+    Deliberately session-scoped and one-way. Whether a worker can authenticate is a property of the
+    tenant and the authentication option, not of the moment, so re-probing it per query would cost a
+    failed request every time for an answer that will not have changed. Restarting the application
+    re-probes.
+
+    .PARAMETER Reason
+    What went wrong, included in the single warning this writes.
+    #>
+    [CmdLetBinding()]
+    param(
+        [string]$Reason
+    )
+
+    if ($Script:OmadaBackgroundRequestsDisabled) {
+        return
+    }
+
+    $Script:OmadaBackgroundRequestsDisabled = $true
+
+    # WARNING, once, and not a dialog: nothing is broken from the user's point of view - the query
+    # they asked for is about to run on the UI thread and succeed. What they lose is the window
+    # staying responsive while it does, and that is worth one line in the log rather than a popup
+    # interrupting them.
+    "Background query execution is not available for this connection; falling back to running queries on the UI thread for the rest of this session. The window will not stay responsive during a query. Reason: {0}" -f $Reason | Write-LogOutput -LogType WARNING -SkipDialog
+
+    # The pool's workers are of no further use, and they are real threads.
+    Close-OmadaRequestPool
+}

--- a/src/Lib/Functions/Private/Get-SqlSchema.ps1
+++ b/src/Lib/Functions/Private/Get-SqlSchema.ps1
@@ -102,22 +102,32 @@ function Get-SqlSchemaObject {
             $Private:Pending = Invoke-OmadaPSWebRequestWrapperAsync -Description $Script:SqlSchemaRequestDescription -Context @{
                 SchemaCacheKey = $SchemaCacheKey
                 Uri            = $Script:RunTimeData.RestMethodParam.Uri
+                Method         = $Script:RunTimeData.RestMethodParam.Method
                 Body           = $Script:RunTimeData.RestMethodParam.Body
             } -OnResultScriptBlock {
                 param($Pending)
                 # A worker that could not run the request at all is not an answer. Retry once on the
                 # UI thread, where authentication works - the same fallback the execute path takes,
                 # and for the same reason: a fresh worker runspace cannot always establish an
-                # OmadaWeb.PS session. Safe to retry whatever the cause, because this is a GET that
-                # changes nothing.
-                if ($null -eq $Pending.Outcome -or $Pending.Outcome -is [System.Management.Automation.ErrorRecord]) {
+                # OmadaWeb.PS session.
+                #
+                # Safe to retry whatever the cause: GetSqlSchema is POST-shaped but purely a read, so
+                # running it twice changes nothing on the tenant. (The execute path needs a far more
+                # careful gate for exactly this reason - see CompletedSteps there.)
+                #
+                # Not retried for a tab that is no longer connected: Resolve-OmadaRequestFailure tears
+                # the tab down for the two tenant-level failures before throwing, and those are the
+                # tenant's answer rather than a worker that could not do its job.
+                if (($null -eq $Pending.Outcome -or $Pending.Outcome -is [System.Management.Automation.ErrorRecord]) -and $Script:ConnectionStatus) {
                     $Private:Reason = if ($null -eq $Pending.Outcome) { "the background worker returned no result" } else { $Pending.Outcome.Exception.Message }
                     "The SQL schema could not be retrieved on a background worker: {0}" -f $Private:Reason | Write-LogOutput -LogType DEBUG
                     Disable-OmadaBackgroundRequest -Reason $Private:Reason
 
+                    # Method carried alongside Uri and Body rather than hard-coded, so the retry
+                    # cannot drift from the request that was actually dispatched.
                     "Retrying the SQL schema retrieval on the UI thread." | Write-LogOutput -LogType DEBUG
                     $Script:RunTimeData.RestMethodParam.Uri = $Pending.Context.Caller.Uri
-                    $Script:RunTimeData.RestMethodParam.Method = "POST"
+                    $Script:RunTimeData.RestMethodParam.Method = $Pending.Context.Caller.Method
                     $Script:RunTimeData.RestMethodParam.Body = $Pending.Context.Caller.Body
                     Complete-SqlSchemaRetrieval -SchemaResponse (Invoke-OmadaPSWebRequestWrapper) -SchemaCacheKey $Pending.Context.Caller.SchemaCacheKey
                     return

--- a/src/Lib/Functions/Private/Get-SqlSchema.ps1
+++ b/src/Lib/Functions/Private/Get-SqlSchema.ps1
@@ -94,8 +94,34 @@ function Get-SqlSchemaObject {
             # $Pending.Context.Caller instead of re-deriving it: by the time it runs, the user may
             # have switched to a tab with a different SessionKey or data connection, and the key must
             # be the one this request was issued for.
-            $Private:Pending = Invoke-OmadaPSWebRequestWrapperAsync -Description $Script:SqlSchemaRequestDescription -Context @{ SchemaCacheKey = $SchemaCacheKey } -OnResultScriptBlock {
+            # The request itself travels on the context, not just the cache key. A retry cannot simply
+            # re-use $Script:RunTimeData.RestMethodParam: that hashtable is overwritten by whatever
+            # request the tab makes next, so by the time this completion runs it may describe an
+            # entirely different call. (That staleness is visible in the logs - the dispatch of an
+            # execute records the schema request's URI, because nothing had overwritten it yet.)
+            $Private:Pending = Invoke-OmadaPSWebRequestWrapperAsync -Description $Script:SqlSchemaRequestDescription -Context @{
+                SchemaCacheKey = $SchemaCacheKey
+                Uri            = $Script:RunTimeData.RestMethodParam.Uri
+                Body           = $Script:RunTimeData.RestMethodParam.Body
+            } -OnResultScriptBlock {
                 param($Pending)
+                # A worker that could not run the request at all is not an answer. Retry once on the
+                # UI thread, where authentication works - the same fallback the execute path takes,
+                # and for the same reason: a fresh worker runspace cannot always establish an
+                # OmadaWeb.PS session. Safe to retry whatever the cause, because this is a GET that
+                # changes nothing.
+                if ($null -eq $Pending.Outcome -or $Pending.Outcome -is [System.Management.Automation.ErrorRecord]) {
+                    $Private:Reason = if ($null -eq $Pending.Outcome) { "the background worker returned no result" } else { $Pending.Outcome.Exception.Message }
+                    "The SQL schema could not be retrieved on a background worker: {0}" -f $Private:Reason | Write-LogOutput -LogType DEBUG
+                    Disable-OmadaBackgroundRequest -Reason $Private:Reason
+
+                    "Retrying the SQL schema retrieval on the UI thread." | Write-LogOutput -LogType DEBUG
+                    $Script:RunTimeData.RestMethodParam.Uri = $Pending.Context.Caller.Uri
+                    $Script:RunTimeData.RestMethodParam.Method = "POST"
+                    $Script:RunTimeData.RestMethodParam.Body = $Pending.Context.Caller.Body
+                    Complete-SqlSchemaRetrieval -SchemaResponse (Invoke-OmadaPSWebRequestWrapper) -SchemaCacheKey $Pending.Context.Caller.SchemaCacheKey
+                    return
+                }
                 Complete-SqlSchemaRetrieval -SchemaResponse $Pending.Outcome -SchemaCacheKey $Pending.Context.Caller.SchemaCacheKey
             }
 

--- a/src/Lib/Functions/Private/Invoke-ExecuteQuery.ps1
+++ b/src/Lib/Functions/Private/Invoke-ExecuteQuery.ps1
@@ -95,11 +95,15 @@ function Invoke-ExecuteQuery {
 
                     "Retrieve query output, please wait..." | Write-LogOutput
 
+                    # The context travels on the pending item as well as into the worker, so a
+                    # completion that finds the worker could not run the chain can re-run it inline.
+                    # On the item rather than in module scope: two tabs can have a query in flight at
+                    # once, and a shared slot would hand one tab's retry the other tab's query.
                     $Private:Pending = Invoke-OmadaPSWebRequestWrapperAsync -Description $Script:ExecuteQueryRequestDescription -PipelineContext $Private:PipelineContext -Context @{
-                        DisplayName = $Private:PipelineContext.DisplayName
+                        PipelineContext = $Private:PipelineContext
                     } -OnResultScriptBlock {
                         param($Pending)
-                        Complete-ExecuteQueryPipeline -Outcome $Pending.Outcome
+                        Complete-ExecuteQueryPipeline -Outcome $Pending.Outcome -PipelineContext $Pending.Context.Caller.PipelineContext
                     }
 
                     if ($null -ne $Private:Pending) {
@@ -204,6 +208,72 @@ function Reset-ExecuteQueryUiState {
     }
 }
 
+function Invoke-ExecuteQueryOnUiThread {
+    <#
+    .SYNOPSIS
+    Re-run the execute chain synchronously after a background worker failed to run it at all, and
+    stop offering background execution for the rest of the session.
+
+    .DESCRIPTION
+    The half of issue #40's authentication policy that was designed but never built. The policy was:
+    interactive authentication happens on the UI thread, and "a 401 returned to the UI thread from a
+    worker is re-driven on the UI thread". Only the gate was implemented -
+    Test-OmadaBackgroundRequestEligible - which assumed a connected tab's session would be
+    recoverable in a worker from OmadaWeb.PS's encrypted cookie cache.
+
+    Live-tenant testing showed the assumption does not hold for every tenant and authentication
+    option: the worker's own OmadaWeb.PS instance could not establish a session, so every background
+    request failed. Because the failure was then reported through the empty-result path, the user saw
+    "Query did not return any results!" on every execute and the real error was never logged.
+
+    So the re-drive is built now, and it does two things:
+
+      - runs the identical chain inline, so the user gets their result. It is the same function the
+        worker runs, with the same context, so the requests and their order are identical - just
+        slower, and blocking, exactly as the application behaved before #40.
+      - disables background execution for the session, so the next query does not pay for another
+        doomed round-trip before falling back again.
+
+    Only ever called when NOTHING reached the tenant, so re-running cannot repeat work the server has
+    already done.
+
+    .PARAMETER PipelineContext
+    The context the failed request was dispatched with, carried on the pending item rather than held
+    in module scope - two tabs can have a query in flight at once, and a single shared slot would
+    hand one tab's retry the other tab's query.
+
+    .PARAMETER Reason
+    Why the worker could not run it, for the single warning Disable-OmadaBackgroundRequest writes.
+    #>
+    [CmdLetBinding()]
+    param(
+        [hashtable]$PipelineContext,
+        [string]$Reason
+    )
+
+    try {
+        Disable-OmadaBackgroundRequest -Reason $Reason
+
+        if ($null -eq $PipelineContext) {
+            # Nothing to re-run with. Reported rather than silently ignored: this would mean the
+            # context was lost between dispatch and completion, which is a bug here rather than a
+            # problem at the tenant.
+            "Cannot retry the query on the UI thread: the request context is no longer available." | Write-LogOutput -LogType ERROR
+            Complete-ExecuteQueryResult -QueryResult $null -SaveResult $null -TempQueryDoId $null
+            return
+        }
+
+        "Retrying the query on the UI thread." | Write-LogOutput -LogType DEBUG
+        $Private:RetryContext = $PipelineContext.Clone()
+        $Private:RetryContext.Parameters = Build-OmadaRequestParameter
+        Complete-ExecuteQueryPipeline -Outcome (Invoke-OmadaExecutePipeline -Context $Private:RetryContext)
+    }
+    catch {
+        Reset-ExecuteQueryUiState
+        $_.Exception.Message | Write-LogOutput -LogType ERROR -ErrorObject $_
+    }
+}
+
 function Complete-ExecuteQueryPipeline {
     <#
     .SYNOPSIS
@@ -221,18 +291,24 @@ function Complete-ExecuteQueryPipeline {
     .PARAMETER Outcome
     The pipeline's outcome hashtable - or an ErrorRecord, when the failure was one of the two
     tenant-level kinds Resolve-OmadaRequestFailure classifies and returns in place of a result.
+
+    .PARAMETER PipelineContext
+    The context the request was dispatched with. Only used to re-run the chain on the UI thread when
+    the worker could not run it at all; $null on the inline path, which has nothing to fall back to.
     #>
     [CmdLetBinding()]
     param(
-        $Outcome
+        $Outcome,
+        [hashtable]$PipelineContext
     )
 
     try {
-        # The classified-failure case: the request never got far enough to produce an outcome, and
-        # Set-SqlConnectionState has already torn the tab down. Complete-ExecuteQueryResult reports
-        # it the same way a failed single request has always been reported.
+        # The worker produced no outcome object at all - it could not run the chain. That is not a
+        # result, and reporting it as one is what made a failed query look like an empty one.
         if ($Outcome -is [System.Management.Automation.ErrorRecord] -or $null -eq $Outcome -or $null -eq $Outcome.Steps) {
-            Complete-ExecuteQueryResult -QueryResult $Outcome -SaveResult $null -TempQueryDoId $null
+            $Private:Reason = if ($Outcome -is [System.Management.Automation.ErrorRecord]) { $Outcome.Exception.Message } else { "the background worker returned no result" }
+            "The query could not be run on a background worker: {0}" -f $Private:Reason | Write-LogOutput -LogType DEBUG
+            Invoke-ExecuteQueryOnUiThread -PipelineContext $PipelineContext -Reason $Private:Reason
             return
         }
 
@@ -250,6 +326,19 @@ function Complete-ExecuteQueryPipeline {
         }
 
         if ($null -ne $Outcome.ErrorRecord) {
+            # Nothing reached the tenant: the very first request failed, so no query ran, nothing was
+            # saved and no temporary object exists. The worker could not do its job - almost always
+            # because its own OmadaWeb.PS instance has no session - and the UI thread can, so run it
+            # there rather than telling the user their query returned nothing.
+            #
+            # Gated on CompletedSteps precisely so this cannot re-run work the tenant already did. If
+            # any step succeeded, the failure is the tenant's answer and is reported as such.
+            if ([int]$Outcome.CompletedSteps -le 0) {
+                "The query could not be run on a background worker: {0}" -f $Outcome.ErrorRecord.Exception.Message | Write-LogOutput -LogType DEBUG
+                Invoke-ExecuteQueryOnUiThread -PipelineContext $PipelineContext -Reason $Outcome.ErrorRecord.Exception.Message
+                return
+            }
+
             "The query pipeline failed at step '{0}': {1}" -f $Outcome.FailedStep, $Outcome.ErrorRecord.Exception.Message | Write-LogOutput -LogType ERROR -ErrorObject $Outcome.ErrorRecord
             Complete-ExecuteQueryResult -QueryResult $Outcome.ErrorRecord -SaveResult $Outcome.SaveResult -TempQueryDoId $null
             return

--- a/src/Lib/Functions/Private/Invoke-ExecuteQuery.ps1
+++ b/src/Lib/Functions/Private/Invoke-ExecuteQuery.ps1
@@ -252,6 +252,20 @@ function Invoke-ExecuteQueryOnUiThread {
     )
 
     try {
+        # A tab that is no longer connected must not be retried against. Resolve-OmadaRequestFailure
+        # tears the tab down through Set-SqlConnectionState for the two tenant-level failures
+        # (Unauthorized, OData endpoint missing) and then throws - and the completion still runs,
+        # because the async wrapper invokes it in a finally. Those are the tenant's answer, not a
+        # worker that could not do its job: retrying would fail again at best, and disabling
+        # background execution over an expired session would be the wrong conclusion entirely.
+        # $Script:ConnectionStatus is the signal, and it also covers the user disconnecting while a
+        # query was in flight.
+        if (-not $Script:ConnectionStatus) {
+            "Not retrying the query on the UI thread: the tab is no longer connected." | Write-LogOutput -LogType DEBUG
+            Complete-ExecuteQueryResult -QueryResult $null -SaveResult $null -TempQueryDoId $null
+            return
+        }
+
         Disable-OmadaBackgroundRequest -Reason $Reason
 
         if ($null -eq $PipelineContext) {

--- a/src/Lib/Functions/Private/Invoke-OmadaExecutePipeline.ps1
+++ b/src/Lib/Functions/Private/Invoke-OmadaExecutePipeline.ps1
@@ -49,13 +49,18 @@ function Invoke-OmadaExecutePipeline {
     )
 
     $Outcome = @{
-        SaveResult    = $null
-        SaveSkipped   = $false
-        TempQueryDoId = $null
-        QueryResult   = $null
-        ErrorRecord   = $null
-        FailedStep    = $null
-        Steps         = [System.Collections.Generic.List[object]]::new()
+        SaveResult     = $null
+        SaveSkipped    = $false
+        TempQueryDoId  = $null
+        QueryResult    = $null
+        ErrorRecord    = $null
+        FailedStep     = $null
+        Steps          = [System.Collections.Generic.List[object]]::new()
+        # How many requests came back WITHOUT an error. The caller uses this to tell "the worker
+        # could not talk to the tenant at all" from "the tenant refused something": only the first is
+        # safe to retry on the UI thread, because only then is it certain that nothing was changed
+        # server-side by the attempt.
+        CompletedSteps = 0
     }
 
     # One local helper rather than a call out to another file: this runs in a worker runspace, and
@@ -72,7 +77,11 @@ function Invoke-OmadaExecutePipeline {
             $Parameters.Body = $Request.Body
         }
         $Outcome.Steps.Add(@{ Name = $StepName; Method = $Request.Method; Uri = $Request.Uri })
-        return Invoke-OmadaRequestCore -Parameters $Parameters
+        $StepOutcome = Invoke-OmadaRequestCore -Parameters $Parameters
+        if ($null -eq $StepOutcome.ErrorRecord) {
+            $Outcome.CompletedSteps = $Outcome.CompletedSteps + 1
+        }
+        return $StepOutcome
     }
 
     try {

--- a/src/Lib/Functions/Private/Invoke-OmadaPSWebRequestWrapperAsync.ps1
+++ b/src/Lib/Functions/Private/Invoke-OmadaPSWebRequestWrapperAsync.ps1
@@ -100,17 +100,27 @@ function Invoke-OmadaPSWebRequestWrapperAsync {
                 return
             }
 
+            # What the caller will receive. A worker that ran a pipeline returns its own outcome
+            # object, and that object MUST survive the classification below: it carries the step
+            # trace and which step failed, which is the only description of what actually happened.
+            # Replacing it with the bare ErrorRecord - as this used to - left the execute completion
+            # with nothing to report, so a failed query surfaced as the misleading "Query did not
+            # return any results!" and the real error was never logged at all.
+            $Private:Payload = $Private:Outcome.Result
+
             try {
                 if ($null -ne $Private:Outcome.ErrorRecord) {
-                    # Same classification as the inline path. The two tenant-level branches throw,
-                    # which the poll timer catches and logs; the third returns the ErrorRecord, which
-                    # is what callers test with -is [ErrorRecord].
-                    $Pending | Add-Member -NotePropertyName "Outcome" -NotePropertyValue (Resolve-OmadaRequestFailure -ErrorRecord $Private:Outcome.ErrorRecord) -Force
+                    # Same classification as the inline path, for its side effects as much as its
+                    # value: the two tenant-level branches tear the tab down and throw, and the third
+                    # returns the ErrorRecord, which is what callers test with -is [ErrorRecord].
+                    $Private:Classified = Resolve-OmadaRequestFailure -ErrorRecord $Private:Outcome.ErrorRecord
+                    if ($null -eq $Private:Payload) {
+                        $Private:Payload = $Private:Classified
+                    }
                 }
                 else {
                     "Result: {0}" -f (ConvertTo-RedactedLogString -InputObject $Private:Outcome.Result) | Write-LogOutput -LogType VERBOSE
                     $Script:RunTimeData.RestMethodParam.ForceAuthentication = $false
-                    $Pending | Add-Member -NotePropertyName "Outcome" -NotePropertyValue $Private:Outcome.Result -Force
                 }
             }
             finally {
@@ -124,9 +134,10 @@ function Invoke-OmadaPSWebRequestWrapperAsync {
                 #
                 # The throw still propagates afterwards, so the "tenant-level failures throw"
                 # contract is unchanged; the poll timer catches and logs it as before.
-                if ($null -eq $Pending.Outcome) {
-                    $Pending | Add-Member -NotePropertyName "Outcome" -NotePropertyValue $Private:Outcome.ErrorRecord -Force
+                if ($null -eq $Private:Payload) {
+                    $Private:Payload = $Private:Outcome.ErrorRecord
                 }
+                $Pending | Add-Member -NotePropertyName "Outcome" -NotePropertyValue $Private:Payload -Force
                 & $Pending.Context.OnResult $Pending
             }
         }

--- a/src/Lib/Functions/Private/Test-OmadaBackgroundRequestEligible.ps1
+++ b/src/Lib/Functions/Private/Test-OmadaBackgroundRequestEligible.ps1
@@ -44,6 +44,14 @@ function Test-OmadaBackgroundRequestEligible {
         [hashtable]$Parameters
     )
 
+    # Settled by observation, and checked first: once a background request has been seen to fail
+    # without reaching the tenant, this session has proved that its workers cannot serve authenticated
+    # requests. Every later request goes straight down the synchronous path rather than paying for a
+    # doomed round-trip first. See Disable-OmadaBackgroundRequest.
+    if ($Script:OmadaBackgroundRequestsDisabled) {
+        return $false
+    }
+
     if (-not $Script:ConnectionStatus) {
         return $false
     }

--- a/src/Lib/Functions/Private/Write-LoadedComponentLog.ps1
+++ b/src/Lib/Functions/Private/Write-LoadedComponentLog.ps1
@@ -1,0 +1,107 @@
+function Write-LoadedComponentLog {
+    <#
+    .SYNOPSIS
+    Record which versions of the application's dependencies this session is actually running: the
+    OmadaWeb.PS module, and the native/managed assemblies loaded from disk.
+
+    .DESCRIPTION
+    Written once at start-up, at INFO, so that any log sent in for diagnosis says what it was
+    produced by. Several of the hardest problems in this application depend on exactly this
+    information and none of it was in the log before: which OmadaWeb.PS is loaded (its behaviour on
+    authentication differs between releases), whether the WebView2 assemblies came from the verified
+    bundle or from the download cache, and whether the optional ScriptDom parser is present at all.
+
+    Reports what is loaded and where it came from, not what is pinned - the point is to describe the
+    running session, so a mismatch with the lock file is exactly the kind of thing this should make
+    visible rather than hide.
+
+    Every lookup is guarded. This is diagnostic output: it must never be the reason the application
+    fails to start, and a missing optional component is information, not an error.
+    #>
+    [CmdLetBinding()]
+    param()
+
+    try {
+        # --- The application itself -------------------------------------------------------------
+        "Application: {0} {1}" -f $Script:RunTimeConfig.ApplicationName, $Script:RunTimeConfig.ApplicationVersion | Write-LogOutput
+        "PowerShell: {0} ({1}), {2}" -f $PSVersionTable.PSVersion, $PSVersionTable.PSEdition, [System.Runtime.InteropServices.RuntimeInformation]::FrameworkDescription | Write-LogOutput -LogType DEBUG
+
+        # --- OmadaWeb.PS --------------------------------------------------------------------------
+        # The module the whole transport layer rests on, and the one whose version most often
+        # explains a difference in authentication behaviour between two machines.
+        $Private:OmadaWeb = Get-Module -Name "OmadaWeb.PS" | Sort-Object Version -Descending | Select-Object -First 1
+        if ($null -ne $Private:OmadaWeb) {
+            "OmadaWeb.PS: {0} loaded from '{1}'" -f $Private:OmadaWeb.Version, $Private:OmadaWeb.ModuleBase | Write-LogOutput
+        }
+        else {
+            "OmadaWeb.PS: not loaded." | Write-LogOutput -LogType WARNING -SkipDialog
+        }
+
+        # --- Assemblies loaded from disk ----------------------------------------------------------
+        # Source matters as much as version: WebView2 is either the hash-verified bundle shipped with
+        # the module or a download in the user's profile, and which one is in use is not otherwise
+        # visible anywhere.
+        "WebView2 assemblies resolved from the {0} at '{1}'" -f ([string]$Script:WebView2Source).ToLowerInvariant(), $Script:WebView2BasePath | Write-LogOutput
+
+        $Private:Components = [ordered]@{
+            "WebView2.Core"     = $Script:WebView2CorePath
+            "WebView2.Wpf"      = $Script:WebView2WpfPath
+            "WebView2.WinForms" = $Script:WebView2WinFormsPath
+            "WebView2Loader"    = $Script:WebView2LoaderPath
+            "ScriptDom"         = $Script:ScriptDomPath
+        }
+
+        foreach ($Private:Name in $Private:Components.Keys) {
+            Write-LoadedAssemblyLog -Name $Private:Name -Path $Private:Components[$Private:Name]
+        }
+    }
+    catch {
+        # Diagnostics must never stop the application starting.
+        "Could not record the loaded component versions: {0}" -f $_.Exception.Message | Write-LogOutput -LogType DEBUG
+    }
+}
+
+function Write-LoadedAssemblyLog {
+    <#
+    .SYNOPSIS
+    Log one assembly's file version and location, or say plainly that it is not there.
+
+    .DESCRIPTION
+    Split out so each component is independently guarded: a single unreadable file must not cost the
+    log every other component's line.
+
+    The FILE version is reported rather than an assembly identity, because it is what the dependency
+    lock pins and what the vendor's release notes quote - and because it can be read without loading
+    the assembly, which for a native library like WebView2Loader.dll is not possible anyway.
+    #>
+    [CmdLetBinding()]
+    param(
+        [string]$Name,
+        [string]$Path
+    )
+
+    try {
+        if ([string]::IsNullOrWhiteSpace($Path)) {
+            "{0}: not configured." -f $Name | Write-LogOutput -LogType DEBUG
+            return
+        }
+
+        if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+            # DEBUG, not WARNING: ScriptDom is optional and legitimately absent until first use, and
+            # a WebView2 file that is genuinely missing fails loudly elsewhere with a better message.
+            "{0}: not present at '{1}'." -f $Name, $Path | Write-LogOutput -LogType DEBUG
+            return
+        }
+
+        $Private:Item = Get-Item -LiteralPath $Path
+        $Private:Version = $Private:Item.VersionInfo.FileVersion
+        if ([string]::IsNullOrWhiteSpace($Private:Version)) {
+            $Private:Version = "unknown version"
+        }
+
+        "{0}: {1} ({2:n0} bytes) at '{3}'" -f $Name, $Private:Version, $Private:Item.Length, $Path | Write-LogOutput
+    }
+    catch {
+        "{0}: could not be read at '{1}': {2}" -f $Name, $Path, $_.Exception.Message | Write-LogOutput -LogType DEBUG
+    }
+}

--- a/src/Lib/Functions/Public/Invoke-OmadaSqlTroubleshooter.ps1
+++ b/src/Lib/Functions/Public/Invoke-OmadaSqlTroubleshooter.ps1
@@ -147,6 +147,12 @@ function Invoke-OmadaSqlTroubleshooter {
     }
     #endregion
 
+    # Which OmadaWeb.PS and which assemblies this session is actually running. Written here because
+    # it is the first point where the log level and the log file are both settled, and before
+    # anything that might fail in a way these versions explain - so a log sent in for diagnosis
+    # always says what produced it.
+    Write-LoadedComponentLog
+
     #region wpf
     $null  = Open-SplashScreenForm
     "Loading Main Form Object" | Write-LogOutput -LogType DEBUG

--- a/tests/Disable-OmadaBackgroundRequest.Tests.ps1
+++ b/tests/Disable-OmadaBackgroundRequest.Tests.ps1
@@ -1,0 +1,79 @@
+#Requires -Version 7.0
+# Eligibility settled by observation rather than assumption.
+#
+# Issue #40 assumed a tab that authenticated on the UI thread could also be served from a worker,
+# because OmadaWeb.PS keeps an encrypted cookie cache on disk that a fresh worker would load. Live
+# testing disproved it: with some tenants and authentication options the worker's own OmadaWeb.PS
+# cannot establish a session, and every background request fails. The assumption was never testable -
+# the mock replaces Invoke-OmadaRestMethod outright, so no authentication happens under test - so it
+# is now settled by watching what actually happens.
+
+BeforeAll {
+    $ParentPath = Split-Path -Path $PSScriptRoot -Parent
+    $PrivatePath = Join-Path $ParentPath -ChildPath "src\Lib\Functions\Private"
+    . (Join-Path $PrivatePath -ChildPath "Disable-OmadaBackgroundRequest.ps1")
+    . (Join-Path $PrivatePath -ChildPath "Test-OmadaBackgroundRequestEligible.ps1")
+
+    $script:LogMessages = [System.Collections.Generic.List[object]]::new()
+    function Write-LogOutput {
+        param(
+            [Parameter(ValueFromPipeline = $true)]$InputObject,
+            [string]$LogType,
+            $ErrorObject,
+            [switch]$SkipDialog
+        )
+        process { $script:LogMessages.Add([pscustomobject]@{ LogType = $LogType; Message = [string]$InputObject }) }
+    }
+
+    $script:PoolClosures = 0
+    function Close-OmadaRequestPool { $script:PoolClosures++ }
+
+    function script:Initialize-DisableTestState {
+        $script:LogMessages.Clear()
+        $script:PoolClosures = 0
+        $Script:OmadaBackgroundRequestsDisabled = $false
+        $Script:ConnectionStatus = $true
+    }
+}
+
+Describe "Disable-OmadaBackgroundRequest" {
+    BeforeEach { Initialize-DisableTestState }
+
+    It "stops further requests being dispatched" {
+        Test-OmadaBackgroundRequestEligible -Parameters @{ ForceAuthentication = $false } | Should -BeTrue
+
+        Disable-OmadaBackgroundRequest -Reason "no session in the worker"
+
+        Test-OmadaBackgroundRequestEligible -Parameters @{ ForceAuthentication = $false } | Should -BeFalse
+    }
+
+    It "warns once, and says what the user actually loses" {
+        # Not a dialog, and not repeated per query: nothing is broken from the user's point of view -
+        # their query is about to run on the UI thread and succeed. What they lose is the window
+        # staying responsive, which is worth one line rather than a popup.
+        Disable-OmadaBackgroundRequest -Reason "no session in the worker"
+        Disable-OmadaBackgroundRequest -Reason "no session in the worker"
+        Disable-OmadaBackgroundRequest -Reason "something else"
+
+        $Warnings = @($script:LogMessages | Where-Object { $_.LogType -eq "WARNING" })
+        $Warnings.Count | Should -Be 1
+        $Warnings[0].Message | Should -Match "UI thread"
+        $Warnings[0].Message | Should -Match "no session in the worker"
+    }
+
+    It "releases the pool's worker threads, once" {
+        Disable-OmadaBackgroundRequest -Reason "no session in the worker"
+        Disable-OmadaBackgroundRequest -Reason "no session in the worker"
+
+        $script:PoolClosures | Should -Be 1
+    }
+
+    It "is checked before the connection state, so a connected tab is still refused" {
+        # The discriminating case: the tab IS connected and the request is not forcing
+        # authentication, so every other gate says yes. Only the observed failure stops it.
+        $Script:ConnectionStatus = $true
+        Disable-OmadaBackgroundRequest -Reason "no session in the worker"
+
+        Test-OmadaBackgroundRequestEligible -Parameters @{ ForceAuthentication = $false } | Should -BeFalse
+    }
+}

--- a/tests/Invoke-ExecuteQuery.Tests.ps1
+++ b/tests/Invoke-ExecuteQuery.Tests.ps1
@@ -446,3 +446,41 @@ Describe "Complete-ExecuteQueryPipeline falls back to the UI thread" {
         $script:InlinePipelineRuns.Count | Should -Be 1
     }
 }
+
+Describe "Complete-ExecuteQueryPipeline does not retry a tab that was torn down" {
+    # Resolve-OmadaRequestFailure disconnects the tab through Set-SqlConnectionState for the two
+    # tenant-level failures (Unauthorized, OData endpoint missing) and then throws - and the
+    # completion still runs, because the async wrapper invokes it in a finally. Those are the
+    # tenant's answer, not a worker that could not do its job.
+
+    BeforeEach {
+        Initialize-ExecuteQueryTestState
+        $script:RetryContext = @{ BaseUrl = "https://tenant.omada.cloud"; QueryDoId = 100 }
+        $Script:ConnectionStatus = $false
+    }
+
+    It "does not re-run the query when the tab is no longer connected" {
+        Complete-ExecuteQueryPipeline -Outcome (New-TestErrorRecord "Access denied") -PipelineContext $script:RetryContext
+
+        $script:InlinePipelineRuns.Count | Should -Be 0
+    }
+
+    It "does not disable background execution over an expired session" {
+        # The wrong conclusion to draw: a 401 says nothing about whether workers can authenticate,
+        # and turning the feature off for the session because of one would be a permanent penalty
+        # for a transient condition.
+        Complete-ExecuteQueryPipeline -Outcome (New-TestErrorRecord "Access denied") -PipelineContext $script:RetryContext
+
+        $script:DisableReasons.Count | Should -Be 0
+    }
+
+    It "still leaves the tab in a usable state" {
+        Complete-ExecuteQueryPipeline -Outcome (New-TestErrorRecord "Access denied") -PipelineContext $script:RetryContext
+
+        # Disconnected, so the query controls stay disabled - but the popup is closed, the stopwatch
+        # stopped and the button reads Execute rather than Cancel.
+        $Script:PopupWindowExecuteQuery | Should -BeNullOrEmpty
+        $Script:MainForm.Elements.ButtonExecuteQueryText.Text | Should -Be "_Execute"
+        $Script:RunTimeData.StopWatch.IsRunning | Should -BeFalse
+    }
+}

--- a/tests/Invoke-ExecuteQuery.Tests.ps1
+++ b/tests/Invoke-ExecuteQuery.Tests.ps1
@@ -32,6 +32,49 @@ BeforeAll {
 
     function Get-ActiveTabSession { return [pscustomobject]@{ Id = "tab-A" } }
 
+    # --- Collaborators of the UI-thread re-drive ---------------------------------------------------
+    $script:DisableReasons = [System.Collections.Generic.List[string]]::new()
+    function Disable-OmadaBackgroundRequest {
+        param([string]$Reason)
+        $script:DisableReasons.Add([string]$Reason)
+    }
+
+    function Build-OmadaRequestParameter { return @{ SessionKey = "pool" } }
+
+    # Records what the inline retry was asked to run, and answers with whatever the test set up.
+    $script:InlinePipelineRuns = [System.Collections.Generic.List[object]]::new()
+    function Invoke-OmadaExecutePipeline {
+        param([hashtable]$Context)
+        $script:InlinePipelineRuns.Add($Context)
+        return $script:InlinePipelineOutcome
+    }
+
+    function script:New-PipelineOutcome {
+        param(
+            $QueryResult = $null,
+            $ErrorRecord = $null,
+            [int]$CompletedSteps = 1,
+            $SaveResult = ([pscustomobject]@{ Id = 100; DisplayName = "TestQuery" })
+        )
+        return @{
+            SaveResult     = $SaveResult
+            SaveSkipped    = $false
+            TempQueryDoId  = $null
+            QueryResult    = $QueryResult
+            ErrorRecord    = $ErrorRecord
+            FailedStep     = $(if ($null -ne $ErrorRecord) { "GetQueryObject" } else { $null })
+            Steps          = @(@{ Name = "GetQueryObject"; Method = "GET"; Uri = "https://tenant/x" })
+            CompletedSteps = $CompletedSteps
+        }
+    }
+
+    function script:New-TestErrorRecord {
+        param([string]$Message = "no session")
+        return [System.Management.Automation.ErrorRecord]::new(
+            [System.Exception]::new($Message), "TestFailure",
+            [System.Management.Automation.ErrorCategory]::ConnectionError, $null)
+    }
+
     function Write-LogOutput {
         param(
             [Parameter(ValueFromPipeline = $true)]$InputObject,
@@ -78,6 +121,9 @@ BeforeAll {
         $script:RemovedQueryObjects.Clear()
         $script:ConfigWrites.Clear()
         $script:QueryListRefreshes = 0
+        $script:DisableReasons.Clear()
+        $script:InlinePipelineRuns.Clear()
+        $script:InlinePipelineOutcome = New-PipelineOutcome -QueryResult (New-ResultResponse -RowCount 2)
 
         $Script:RunTimeConfig = [PSCustomObject]@{ ApplicationName = "Test" }
         # The tab is connected unless a test says otherwise: the teardown only re-enables the query
@@ -308,5 +354,95 @@ Describe "Complete-ExecuteQueryResult" {
 
         { Complete-ExecuteQueryResult -QueryResult $ErrorRecord -SaveResult ([pscustomobject]@{ Id = 100; DisplayName = "TestQuery" }) -TempQueryDoId $null } | Should -Not -Throw
         $Script:MainForm.Elements.ButtonExecuteQuery.IsEnabled | Should -BeTrue
+    }
+}
+
+Describe "Complete-ExecuteQueryPipeline falls back to the UI thread" {
+    # The bug this suite exists for, found on a live tenant: every background request failed because
+    # the worker's own OmadaWeb.PS could not establish a session, and the failure was reported through
+    # the empty-result path - so every single query said "Query did not return any results!" and the
+    # real error never reached the log at all.
+
+    BeforeEach {
+        Initialize-ExecuteQueryTestState
+        $script:RetryContext = @{ BaseUrl = "https://tenant.omada.cloud"; QueryDoId = 100 }
+    }
+
+    It "re-runs the query on the UI thread when the worker returned nothing" {
+        Complete-ExecuteQueryPipeline -Outcome $null -PipelineContext $script:RetryContext
+
+        $script:InlinePipelineRuns.Count | Should -Be 1
+        # And the user actually gets their result, rather than a warning about an empty one.
+        @($Script:MainForm.Elements.DataGridQueryResult.ItemsSource).Count | Should -Be 2
+    }
+
+    It "re-runs the query on the UI thread when the worker returned only an error" {
+        Complete-ExecuteQueryPipeline -Outcome (New-TestErrorRecord) -PipelineContext $script:RetryContext
+
+        $script:InlinePipelineRuns.Count | Should -Be 1
+        @($Script:MainForm.Elements.DataGridQueryResult.ItemsSource).Count | Should -Be 2
+    }
+
+    It "re-runs the query when the pipeline failed without reaching the tenant" {
+        # CompletedSteps 0: the very first request failed, so no query ran, nothing was saved and no
+        # temporary object exists. Retrying cannot repeat work the server already did.
+        $Failed = New-PipelineOutcome -ErrorRecord (New-TestErrorRecord) -CompletedSteps 0
+
+        Complete-ExecuteQueryPipeline -Outcome $Failed -PipelineContext $script:RetryContext
+
+        $script:InlinePipelineRuns.Count | Should -Be 1
+        @($Script:MainForm.Elements.DataGridQueryResult.ItemsSource).Count | Should -Be 2
+    }
+
+    It "does NOT re-run when a request had already reached the tenant" {
+        # The other side of the gate, and the one that protects the user's data: if any step
+        # succeeded, the failure is the tenant's answer. Re-running could execute the query twice.
+        $Failed = New-PipelineOutcome -ErrorRecord (New-TestErrorRecord "SQL error") -CompletedSteps 2
+
+        Complete-ExecuteQueryPipeline -Outcome $Failed -PipelineContext $script:RetryContext
+
+        $script:InlinePipelineRuns.Count | Should -Be 0
+    }
+
+    It "disables background execution for the session when it falls back" {
+        Complete-ExecuteQueryPipeline -Outcome (New-TestErrorRecord "no session") -PipelineContext $script:RetryContext
+
+        $script:DisableReasons.Count | Should -Be 1
+        $script:DisableReasons[0] | Should -Match "no session"
+    }
+
+    It "does not disable background execution for a genuine tenant failure" {
+        $Failed = New-PipelineOutcome -ErrorRecord (New-TestErrorRecord "SQL error") -CompletedSteps 2
+
+        Complete-ExecuteQueryPipeline -Outcome $Failed -PipelineContext $script:RetryContext
+
+        $script:DisableReasons.Count | Should -Be 0
+    }
+
+    It "retries with a COPY of the context, leaving the caller's untouched" {
+        # The retry adds the prepared transport splat. Mutating the caller's hashtable would leave a
+        # stale Parameters key on a context that may be reused.
+        Complete-ExecuteQueryPipeline -Outcome $null -PipelineContext $script:RetryContext
+
+        $script:RetryContext.ContainsKey("Parameters") | Should -BeFalse
+        $script:InlinePipelineRuns[0].ContainsKey("Parameters") | Should -BeTrue
+    }
+
+    It "reports the failure rather than doing nothing when there is no context to retry with" {
+        Complete-ExecuteQueryPipeline -Outcome $null -PipelineContext $null
+
+        $script:InlinePipelineRuns.Count | Should -Be 0
+        # Still leaves the tab usable: the popup closed and the buttons back.
+        $Script:MainForm.Elements.ButtonExecuteQuery.IsEnabled | Should -BeTrue
+    }
+
+    It "does not retry a second time when the inline run also fails" {
+        # Guards against a fallback loop: the inline outcome goes through the same completion, and
+        # must not send it round again.
+        $script:InlinePipelineOutcome = New-PipelineOutcome -ErrorRecord (New-TestErrorRecord) -CompletedSteps 0
+
+        Complete-ExecuteQueryPipeline -Outcome $null -PipelineContext $script:RetryContext
+
+        $script:InlinePipelineRuns.Count | Should -Be 1
     }
 }

--- a/tests/Write-LoadedComponentLog.Tests.ps1
+++ b/tests/Write-LoadedComponentLog.Tests.ps1
@@ -1,0 +1,112 @@
+#Requires -Version 7.0
+# The start-up record of what this session is actually running.
+#
+# Every hard problem in this application so far has turned on information that was not in the log:
+# which OmadaWeb.PS is loaded, whether the WebView2 assemblies came from the verified bundle or the
+# download cache, whether the optional ScriptDom parser is present. These tests hold that line - and
+# hold the harder one, that diagnostics must never be the reason the application fails to start.
+
+BeforeAll {
+    $ParentPath = Split-Path -Path $PSScriptRoot -Parent
+    $PrivatePath = Join-Path $ParentPath -ChildPath "src\Lib\Functions\Private"
+    . (Join-Path $PrivatePath -ChildPath "Write-LoadedComponentLog.ps1")
+
+    $script:LogMessages = [System.Collections.Generic.List[object]]::new()
+    function Write-LogOutput {
+        param(
+            [Parameter(ValueFromPipeline = $true)]$InputObject,
+            [string]$LogType,
+            $ErrorObject,
+            [switch]$SkipDialog
+        )
+        process { $script:LogMessages.Add([pscustomobject]@{ LogType = $LogType; Message = [string]$InputObject }) }
+    }
+
+    function script:Get-LoggedText {
+        return (@($script:LogMessages | ForEach-Object { $_.Message }) -join "`n")
+    }
+
+    function script:Initialize-ComponentLogState {
+        $script:LogMessages.Clear()
+        $Script:RunTimeConfig = @{ ApplicationName = "OmadaSqlTroubleshooter"; ApplicationVersion = "1.2.3.4" }
+        $Script:WebView2Source = "BUNDLE"
+        $Script:WebView2BasePath = "C:\Modules\OmadaSqlTroubleshooter\Bin\WebView2Dlls\win-x64"
+        $Script:WebView2CorePath = $null
+        $Script:WebView2WpfPath = $null
+        $Script:WebView2WinFormsPath = $null
+        $Script:WebView2LoaderPath = $null
+        $Script:ScriptDomPath = $null
+    }
+}
+
+Describe "Write-LoadedComponentLog" {
+    BeforeEach { Initialize-ComponentLogState }
+
+    It "records the application name and version" {
+        Write-LoadedComponentLog
+
+        Get-LoggedText | Should -Match "OmadaSqlTroubleshooter 1\.2\.3\.4"
+    }
+
+    It "records the loaded OmadaWeb.PS version and where it came from" {
+        # The module whose version most often explains a difference in authentication behaviour
+        # between two machines - and the one the background-worker session problem turned on.
+        Write-LoadedComponentLog
+
+        $Text = Get-LoggedText
+        if ($null -ne (Get-Module -Name "OmadaWeb.PS")) {
+            $Text | Should -Match "OmadaWeb\.PS: \d+"
+        }
+        else {
+            $Text | Should -Match "OmadaWeb\.PS: not loaded"
+        }
+    }
+
+    It "records whether WebView2 came from the bundle or a download" {
+        # Source matters as much as version: which of the two folders is in use is not otherwise
+        # visible anywhere in the log.
+        Write-LoadedComponentLog
+
+        Get-LoggedText | Should -Match "WebView2 assemblies resolved from the bundle at"
+    }
+
+    It "reports a real assembly's file version and location" {
+        $Real = (Get-Process -Id $PID).MainModule.FileName   # any file that certainly exists
+        $Script:ScriptDomPath = $Real
+
+        Write-LoadedComponentLog
+
+        Get-LoggedText | Should -Match "ScriptDom: .+ at '"
+    }
+
+    It "says plainly when an optional component is not there" {
+        # ScriptDom is legitimately absent until first use. That is information, not an error, and
+        # must not be logged as one.
+        $Script:ScriptDomPath = Join-Path ([System.IO.Path]::GetTempPath()) "definitely-not-here.dll"
+
+        Write-LoadedComponentLog
+
+        Get-LoggedText | Should -Match "ScriptDom: not present at"
+        @($script:LogMessages | Where-Object { $_.LogType -in @("ERROR", "FATAL") }).Count | Should -Be 0
+    }
+
+    It "does not throw, or log an error, when nothing is configured at all" {
+        # The line that matters most: this runs during start-up, and a diagnostic must never be the
+        # reason the application fails to start.
+        $Script:RunTimeConfig = $null
+        $Script:WebView2Source = $null
+        $Script:WebView2BasePath = $null
+
+        { Write-LoadedComponentLog } | Should -Not -Throw
+        @($script:LogMessages | Where-Object { $_.LogType -in @("ERROR", "FATAL") }).Count | Should -Be 0
+    }
+
+    It "keeps logging the other components when one of them cannot be read" {
+        # Guarded per component: one unreadable file must not cost the log every other line.
+        $Script:ScriptDomPath = "\\?\this-is-not-a-valid-path"
+        $Script:WebView2CorePath = (Get-Process -Id $PID).MainModule.FileName
+
+        { Write-LoadedComponentLog } | Should -Not -Throw
+        Get-LoggedText | Should -Match "WebView2\.Core: "
+    }
+}


### PR DESCRIPTION
Fixes the live-tenant regression: **every query reported "Query did not return any results!"**. Targets the working baseline branch `feature/async-query-execution`, not `main`.

## What the log says

3062 lines of verbose logging, and the shape of it is decisive:

| Observation | Count |
|---|---|
| `Query did not return any results!` | 6 (every execute) |
| `No SQL schema returned` | 6 (every schema fetch) |
| `ERROR` lines | **0** |
| `Pipeline step …` lines | **0** |
| Synchronous requests that failed | **0** |

Everything that went to a worker failed. Everything synchronous worked. And the failure produced **no error and no step trace at all**.

### Layer 1 — the environment

The worker runspace's own OmadaWeb.PS instance could not establish a session for this tenant and authentication option, so every authenticated request made from a worker failed.

That is exactly the assumption #40 could never test. The mock replaces `Invoke-OmadaRestMethod` outright, so **no authentication ever happens under test** — it was called out as the largest unverifiable risk in the issue, in every slice PR, and in the merge gate. The live tenant has now answered it: **it does not hold.**

I verified separately that the machinery itself is sound — the module imports in an MTA worker, `Invoke-OmadaRestMethod` and `Invoke-OmadaRequestCore` both resolve, and the `@{ Result; ErrorRecord }` contract survives the runspace boundary intact. The failure is at the authenticated request, not in the plumbing.

### Layer 2 — my code hid it

`Invoke-OmadaPSWebRequestWrapperAsync` replaced the pipeline's own outcome object with the bare classified `ErrorRecord`. `Complete-ExecuteQueryPipeline` then lost the step trace and `FailedStep`, took its "no outcome" branch, and reported through `Complete-ExecuteQueryResult` — the **empty-result** path.

So a failed query looked like an empty one, and the actual error was never written down. That is the worse of the two bugs, because it is the one that made the first undiagnosable.

## Three fixes

**1. The pipeline's outcome survives classification.** A failure is now logged with the step that produced it, instead of being reported as an empty result.

**2. Re-drive on the UI thread.** When a background attempt fails *without having reached the tenant*, the identical chain runs inline — where authentication works. The user gets their result; the app behaves as it did before #40, just without the responsiveness.

This is the half of the agreed authentication policy that was designed and never built: *"a 401 returned to the UI thread from a worker is re-driven on the UI thread."* Only the gate (`Test-OmadaBackgroundRequestEligible`) had been implemented.

Gated on a new `CompletedSteps` count from the pipeline, so a retry **can never repeat work the tenant already did**. If any request succeeded, the failure is the tenant's answer and is reported as one — there is a test for each side of that line.

**3. Eligibility by observation, not assumption.** The first such failure calls `Disable-OmadaBackgroundRequest`: background dispatch stops for the session, the pool is closed, and one `WARNING` says what was lost ("the window will not stay responsive during a query"). Every later query goes straight down the synchronous path rather than paying for another doomed round-trip. Restarting re-probes.

Not a dialog, deliberately: nothing is broken from the user's point of view — their query runs and succeeds. What they lose is a performance property, and that is worth a log line, not an interruption.

## The schema fetch, and a staleness bug it exposed

The schema path gets the same fallback. It also now carries its **request** on the pending item, not just the cache key: a retry cannot re-use `$Script:RunTimeData.RestMethodParam`, because that hashtable is overwritten by whatever the tab does next.

The log shows exactly that staleness — the dispatch of an *execute* records the *schema* request's URI, because nothing had overwritten it in between. Harmless today (the pipeline builds each step's request itself) but not something to leave sitting under a retry.

## Also: start-up component logging (as requested)

`Write-LoadedComponentLog` writes, once, at start-up:

- the application name and version, and the PowerShell/.NET it is running on
- **the loaded OmadaWeb.PS version and the folder it came from** — the module whose version most often explains a difference in authentication behaviour between two machines, and the one this whole investigation turned on
- whether the **WebView2 assemblies came from the hash-verified bundle or the download cache**, which was not visible anywhere in the log before
- the file version, size and path of each assembly: `WebView2.Core`, `.Wpf`, `.WinForms`, `WebView2Loader`, and the optional `ScriptDom`

It reports what is *loaded*, not what is *pinned* — a mismatch with the dependency lock is exactly the kind of thing this should make visible rather than hide. Every lookup is guarded per component: a diagnostic must never be why the application fails to start, and a missing optional component is information, not an error.

## Verification

```
Invoke-Pester -Path tests   →  761 passed, 0 failed  (20 new)
build/build.ps1 -Task E2E   →  54 tests, 0 failures
PSScriptAnalyzer            →  clean under the build's profile
```

New coverage: 9 cases on the fallback (including *"does NOT re-run when a request had already reached the tenant"* and *"does not retry a second time when the inline run also fails"*), 4 on the session disable, 7 on the component log.

## What this does not do

It does not make background execution work on that tenant. Why a worker's OmadaWeb.PS cannot pick up the session is not answerable from here without a tenant — it may need a change in OmadaWeb.PS itself, which #40's analysis flagged as a possible cross-repository dependency.

What changed is that the condition is now **survivable and diagnosable**: queries work, and the next log will name the actual error instead of hiding it behind an empty-result warning.
