### PR TITLE
Let a worker reuse the session, and stop the start-up error dialogs

### DIFF
--- a/src/Lib/Functions/Private/Build-OmadaRequestParameter.ps1
+++ b/src/Lib/Functions/Private/Build-OmadaRequestParameter.ps1
@@ -25,6 +25,30 @@ function Build-OmadaRequestParameter {
 
     $Private:Parameters.UseWebView2 = $Private:Parameters.AuthenticationType -eq "Browser" ? $($Script:RunTimeConfig.UseWebView2Auth) : $false
 
+    # ForceAuthentication is passed ONLY when it is actually true, and this is not cosmetic.
+    #
+    # OmadaWeb.PS decides whether to load its encrypted cookie cache with
+    # "$BoundParams.Keys -notcontains 'ForceAuthentication'" - it tests whether the parameter was
+    # BOUND, not what it was set to. This application has always splatted ForceAuthentication = $false
+    # on every request, so that test was always false and the cookie cache was never read by anyone,
+    # ever. On the UI thread that is invisible: the module's in-memory session already holds the
+    # cookie after the first authentication.
+    #
+    # It stopped being invisible when requests moved to a worker runspace (issue #40). A worker has
+    # its own OmadaWeb.PS instance with an empty session table, so with the cache unreadable it had no
+    # choice but to authenticate - and an interactive WebView2 login in an MTA worker fails with
+    # "Couldn't find a compatible Webview2 Runtime installation to host WebViews". That was every
+    # background request on a live tenant.
+    #
+    # Removing the key restores the behaviour the cache was written for: a fresh runspace picks up the
+    # session the UI thread established. A genuinely stale cookie still fails safely - Test-OmadaConnection
+    # retries with ForceAuthentication = $true, which binds the parameter and forces a real login.
+    if ($true -ne $Private:Parameters.ForceAuthentication) {
+        if ($Private:Parameters.ContainsKey("ForceAuthentication")) {
+            $Private:Parameters.Remove("ForceAuthentication")
+        }
+    }
+
     if ($null -eq $Private:Parameters.Body) {
         if ($Private:Parameters.ContainsKey("Body")) {
             $Private:Parameters.Remove("Body")

--- a/src/Lib/Functions/Private/Get-SqlSchema.ps1
+++ b/src/Lib/Functions/Private/Get-SqlSchema.ps1
@@ -274,20 +274,37 @@ function Complete-SqlSchemaRetrieval {
 
         "Schema for Monaco editor: {0}" -f $SchemaObjectsJson | Write-LogOutput -LogType VERBOSE
         $OnCompletedScriptBlock = {
+            param($Pending)
             try {
-                # -ne, not "!... -eq". The original read !$Script:Task.Status -eq "RanToCompletion",
-                # where ! binds to the property first: a non-empty status string becomes $false, and
-                # $false -eq "RanToCompletion" is always $false - so the failure branch never ran and
-                # every editor push, successful or not, was logged as a success.
-                if ($Script:Task.Status -ne "RanToCompletion") {
-                    "Monaco Editor Task failed: {0}" -f $Script:Task.Status | Write-LogOutput -LogType ERROR -ErrorObject $_
+                # THIS push's task, taken from the queue item - not $Script:Task.
+                #
+                # $Script:Task is the ACTIVE tab's pending editor task, which by the time this runs is
+                # very often a different, still-running one: Set-ActiveTabContext swaps it per tab,
+                # and a schema push during start-up races the editor loads of every other restored
+                # tab. Reading it reported the wrong task's status, and reported it as a failure
+                # ("WaitingForActivation" is a perfectly normal transient state for a task that has
+                # not finished). At ERROR that also means a modal dialog per occurrence, which is the
+                # cascade of pop-ups seen when reconnecting several tabs at start-up.
+                #
+                # The poll timer only invokes this once $Pending.Task.IsCompleted, so the item's own
+                # task is by definition finished and its status is the real answer.
+                $Private:Task = $Pending.Task
+                if ($null -eq $Private:Task) {
+                    return
+                }
+
+                if ($Private:Task.Status -ne "RanToCompletion") {
+                    # WARNING -SkipDialog, never ERROR: failing to push IntelliSense metadata into
+                    # the editor costs the user completion hints, not their work, and it must not
+                    # interrupt them with a dialog - least of all several at once during start-up.
+                    "Monaco editor schema push did not complete: {0}" -f $Private:Task.Status | Write-LogOutput -LogType WARNING -SkipDialog
                 }
                 else {
                     "Monaco Editor Task completed successfully." | Write-LogOutput -LogType DEBUG
                 }
             }
             catch {
-                $Script:Task.Exception.Message | Write-LogOutput -LogType ERROR -ErrorObject $_
+                $_.Exception.Message | Write-LogOutput -LogType WARNING -SkipDialog
             }
         }
 

--- a/tests/Build-OmadaRequestParameter.Tests.ps1
+++ b/tests/Build-OmadaRequestParameter.Tests.ps1
@@ -73,6 +73,51 @@ Describe "Build-OmadaRequestParameter" {
         [object]::ReferenceEquals((Build-OmadaRequestParameter), $Script:RunTimeData.RestMethodParam) | Should -BeTrue
     }
 
+    Context "ForceAuthentication is passed only when it is true" {
+        # OmadaWeb.PS decides whether to load its encrypted cookie cache with
+        # "$BoundParams.Keys -notcontains 'ForceAuthentication'" - it tests whether the parameter was
+        # BOUND, not its value. Splatting $false on every request therefore meant the cache was never
+        # read by anyone, ever. Invisible on the UI thread, where the in-memory session already holds
+        # the cookie - and fatal in a worker runspace, which has no session and so was forced into an
+        # interactive WebView2 login that cannot work there.
+
+        It "removes the key when it is false" {
+            Initialize-PreparationState
+            $Script:RunTimeData.RestMethodParam.ForceAuthentication = $false
+
+            (Build-OmadaRequestParameter).ContainsKey("ForceAuthentication") | Should -BeFalse
+        }
+
+        It "removes the key when it is absent or null" {
+            Initialize-PreparationState
+            $Script:RunTimeData.RestMethodParam.ForceAuthentication = $null
+
+            (Build-OmadaRequestParameter).ContainsKey("ForceAuthentication") | Should -BeFalse
+        }
+
+        It "keeps the key when it is true, so a forced login still forces one" {
+            # Test-OmadaConnection sets this on retry precisely to bypass the cache. That has to keep
+            # working, or a stale cookie could never be replaced.
+            Initialize-PreparationState
+            $Script:RunTimeData.RestMethodParam.ForceAuthentication = $true
+
+            $Prepared = Build-OmadaRequestParameter
+            $Prepared.ContainsKey("ForceAuthentication") | Should -BeTrue
+            $Prepared.ForceAuthentication | Should -BeTrue
+        }
+
+        It "is idempotent across the app's set-false-after-success cycle" {
+            # The wrapper writes ForceAuthentication = $false back onto the live hashtable after every
+            # successful request, so preparation must be able to strip it again next time.
+            Initialize-PreparationState
+            $Script:RunTimeData.RestMethodParam.ForceAuthentication = $true
+            (Build-OmadaRequestParameter).ContainsKey("ForceAuthentication") | Should -BeTrue
+
+            $Script:RunTimeData.RestMethodParam.ForceAuthentication = $false
+            (Build-OmadaRequestParameter).ContainsKey("ForceAuthentication") | Should -BeFalse
+        }
+    }
+
     Context "SkipBodyRedaction capability check" {
         It "does not add the key when the installed OmadaWeb.PS does not declare it" {
             # Splatting a parameter a cmdlet does not have is a terminating error, so the key must

--- a/tests/Get-SqlSchema.Tests.ps1
+++ b/tests/Get-SqlSchema.Tests.ps1
@@ -35,6 +35,10 @@ BeforeAll {
     # --- Stubs for everything outside the function under test --------------------------------------
     $Script:Tracer = [System.Diagnostics.Trace]
 
+    # Records what was logged, and crucially at what level and whether a dialog was suppressed: the
+    # start-up pop-up cascade this file now guards against was a matter of level, not of message.
+    $script:LoggedMessages = [System.Collections.Generic.List[object]]::new()
+
     function Write-LogOutput {
         param(
             [Parameter(ValueFromPipeline = $true)]$InputObject,
@@ -42,7 +46,13 @@ BeforeAll {
             $ErrorObject,
             [switch]$SkipDialog
         )
-        process { }
+        process {
+            $script:LoggedMessages.Add([pscustomobject]@{
+                    LogType    = $LogType
+                    Message    = [string]$InputObject
+                    SkipDialog = [bool]$SkipDialog
+                })
+        }
     }
 
     # The real wrapper suspends the WebView2 completion poll timer around every call; there is no
@@ -55,6 +65,9 @@ BeforeAll {
     # The editor push seam. Recorded rather than executed so the connected case can be proven to
     # have reached setSchema(...).
     $script:PushedEditorScripts = [System.Collections.Generic.List[string]]::new()
+    # The completion block is captured, not invoked: the tests below drive it with the queue item the
+    # real poll timer would pass, which is the whole point of the regression they guard.
+    $script:PushedCompletionBlocks = [System.Collections.Generic.List[scriptblock]]::new()
 
     function Invoke-ExecuteScriptAsync {
         param(
@@ -62,6 +75,9 @@ BeforeAll {
             $OnCompletedScriptBlock
         )
         $script:PushedEditorScripts.Add([string]$ScriptToExecute)
+        if ($null -ne $OnCompletedScriptBlock) {
+            $script:PushedCompletionBlocks.Add($OnCompletedScriptBlock)
+        }
     }
 
     # A schema push also re-triggers the debounced syntax validation (issue #61): a new connection
@@ -264,5 +280,68 @@ Describe "Get-SqlSchemaObject background dispatch (issue #40)" {
 
         $Script:SqlSchemaCache.Count | Should -Be 0
         $script:PushedEditorScripts.Count | Should -Be 0
+    }
+}
+
+Describe "Get-SqlSchemaObject's Monaco push completion" {
+    # Regression guard for a cascade of error dialogs when reconnecting several tabs at start-up.
+    #
+    # The block used to read $Script:Task - the ACTIVE tab's pending editor task - rather than the
+    # task of the push it was invoked for. During start-up that is very often a different,
+    # still-running task, so it reported "WaitingForActivation" (a perfectly normal transient state)
+    # as a failure, at ERROR, which means a modal dialog each time. The poll timer only invokes a
+    # completion once its own item's task has completed, so the item's task is the real answer.
+
+    BeforeEach {
+        Initialize-SchemaTestState -Connected $true
+        $script:PushedCompletionBlocks.Clear()
+        # Serve the schema inline so a push - and therefore a completion block - is produced.
+        $script:AsyncDispatchBehaviour = "Fallback"
+        Get-SqlSchemaObject
+        $script:LoggedMessages.Clear()
+    }
+
+    It "captures a completion block for the push" {
+        $script:PushedCompletionBlocks.Count | Should -BeGreaterThan 0
+    }
+
+    It "says nothing at ERROR or WARNING for a push that completed" {
+        $Block = $script:PushedCompletionBlocks | Select-Object -Last 1
+
+        & $Block ([pscustomobject]@{ Task = [pscustomobject]@{ Status = "RanToCompletion" } })
+
+        @($script:LoggedMessages | Where-Object { $_.LogType -in @("ERROR", "WARNING") }).Count | Should -Be 0
+    }
+
+    It "reads the task from the queue item, not from the active tab" {
+        # The discriminating case: the ACTIVE tab's task is mid-flight while the item's own task
+        # finished. Reading $Script:Task would report a failure that did not happen - which is
+        # exactly what produced the start-up dialogs.
+        $Block = $script:PushedCompletionBlocks | Select-Object -Last 1
+        $Script:Task = [pscustomobject]@{ Status = "WaitingForActivation" }
+
+        & $Block ([pscustomobject]@{ Task = [pscustomobject]@{ Status = "RanToCompletion" } })
+
+        @($script:LoggedMessages | Where-Object { $_.LogType -in @("ERROR", "WARNING") }).Count | Should -Be 0
+    }
+
+    It "reports a genuinely failed push as a WARNING, without a dialog" {
+        # Failing to push IntelliSense metadata costs the user completion hints, not their work, so it
+        # must never interrupt them with a modal - least of all several at once during start-up.
+        $Block = $script:PushedCompletionBlocks | Select-Object -Last 1
+
+        & $Block ([pscustomobject]@{ Task = [pscustomobject]@{ Status = "Faulted" } })
+
+        @($script:LoggedMessages | Where-Object { $_.LogType -eq "ERROR" }).Count | Should -Be 0
+        $Warnings = @($script:LoggedMessages | Where-Object { $_.LogType -eq "WARNING" })
+        $Warnings.Count | Should -Be 1
+        $Warnings[0].SkipDialog | Should -BeTrue
+    }
+
+    It "does nothing at all when the queue item carries no task" {
+        $Block = $script:PushedCompletionBlocks | Select-Object -Last 1
+
+        { & $Block ([pscustomobject]@{ Task = $null }) } | Should -Not -Throw
+        @($script:LoggedMessages | Where-Object { $_.LogType -in @("ERROR", "WARNING") }).Count | Should -Be 0
     }
 }


### PR DESCRIPTION
Two root causes from the second live-tenant log, both now **named by the log** rather than inferred. Targets the working baseline branch, not `main`.

## 1. Background execution never worked, because the cookie cache was never read — by anyone, ever

The fallback added last time did its job: it named the error.

```
The SQL schema could not be retrieved on a background worker:
Start-WebView2Login - Error creating CoreWebView2Environment …
  ---> WebView2RuntimeNotFoundException: Couldn't find a compatible Webview2 Runtime installation to host WebViews.
```

The worker was **attempting an interactive login**. It should never have needed to — the tab was already connected.

`OmadaWeb.PS.psm1:2199`:

```powershell
if ($BoundParams.Keys -notcontains "ForceAuthentication" -and (Test-Path $SessionContext.CookieCacheFilePath -PathType Leaf)) {
```

It tests whether the parameter was **bound**, not what it was set to. This application has always splatted `ForceAuthentication = $false` on every request — visible in every parameter block in both logs — so that condition was **always false and the encrypted cookie cache was never loaded**.

On the UI thread that is invisible: the module's in-memory session already holds the cookie after the first authentication. It stopped being invisible the moment requests moved to a worker runspace, which has its own OmadaWeb.PS instance with an empty session table. With the cache unreadable it had no choice but to authenticate — and a WebView2 login in an MTA worker fails exactly as above.

So the MTA decision worked as designed: it turned an ownerless login window into a clean, diagnosable failure. But the login should never have been reached.

**Fix:** pass `ForceAuthentication` only when it is actually `$true`.

This restores the behaviour the cache was written for — a fresh runspace picks up the session the UI thread established. It is also entirely within this repository; no OmadaWeb.PS change is needed.

A genuinely stale cookie still fails safely: `Test-OmadaConnection` retries with `ForceAuthentication = $true`, which binds the parameter and forces a real login. The app already uses `$true` deliberately in `Test-OmadaConnection`, `Set-OmadaUrl` and `Reset-Application`, so this makes the flag mean what those call sites always intended.

### Worth knowing

This also fixes something that was never noticed: the cookie cache has never worked **on the UI thread either**. The app may now prompt for login less often across restarts, which is what the cache exists for.

## 2. The start-up error dialogs

```
ERROR - Get-SqlSchema.ps1 (283): Monaco Editor Task failed: WaitingForActivation
```

The Monaco schema-push completion read `$Script:Task` — the **active tab's** pending editor task — instead of the task of the push it was invoked for. During start-up that is very often a different, still-running task, so it reported `WaitingForActivation` (a perfectly normal transient state) as a failure.

At `ERROR`, `Write-LogOutput` shows a modal dialog. Its `catch` then dereferenced a null `Exception`, logged that too, and the `ErrorActionPreference = Stop` dispatcher handler turned the pair into the cascade visible at the end of the log.

**This one is mine.** C1-6 corrected `!$x -eq "…"` to `-ne` in that block — right in itself, but it made a latent bug start firing.

**Fix:** the block takes its task from the queue item it is handed. The poll timer only invokes a completion once *that* item's task has completed, so it is the real answer. A genuine failure is now a `WARNING -SkipDialog`: failing to push IntelliSense metadata costs completion hints, not the user's work, and must never interrupt them — least of all several times at once during start-up.

## Verification

```
Invoke-Pester -Path tests   →  773 passed, 0 failed  (9 new)
build/build.ps1 -Task E2E   →  54 tests, 0 failures
PSScriptAnalyzer            →  clean under the build's profile
```

New coverage: 4 cases pinning the `ForceAuthentication` contract (removed when false or null, **kept when true** so a forced login still forces one, idempotent across the app's set-false-after-success cycle), and 5 on the push completion — including the discriminating one, that a mid-flight *active tab* task is ignored while the item's own completed task is what gets reported, and that a real failure raises no dialog.

## What to expect on re-test

If the diagnosis is right, the next run should show **no** `Background query execution is not available` warning, **no** start-up error dialogs, and background execution actually working — which is what makes criteria 2, 3, 4 and 7 testable for the first time.

If the warning still appears, its `DEBUG` line will again name the reason, and it will be a different one.
