### PR TITLE
Report a failed execute once, and put the pipeline's log back

### DIFF
--- a/src/Lib/Events/MainForm.Definition.ps1
+++ b/src/Lib/Events/MainForm.Definition.ps1
@@ -92,7 +92,14 @@ $Script:WebViewCompletionPollTimer.Add_Tick({
             }
         }
         catch {
-            $_.Exception.Message | Write-LogOutput -LogType ERROR -ErrorObject $_
+            # Contained, and this is the outermost guarantee that a completion cannot cascade.
+            # Write-LogOutput ends every ERROR with Write-Error, which under this application's
+            # ErrorActionPreference = Stop is terminating - so reporting an error from HERE would
+            # throw out of the Tick handler into the dispatcher's unhandled-exception handler, which
+            # logs another ERROR, which throws again. One tenant failure produced five stacked error
+            # dialogs and a log entry containing four nested copies of itself. There is nothing above
+            # a timer tick to unwind to, so an error reported here is reported and contained.
+            $_.Exception.Message | Write-ContainedErrorLog -ErrorObject $_
         }
     })
 $Script:WebViewCompletionPollTimer.Start()

--- a/src/Lib/Functions/Private/Get-SqlSchema.ps1
+++ b/src/Lib/Functions/Private/Get-SqlSchema.ps1
@@ -151,7 +151,7 @@ function Get-SqlSchemaObject {
         }
     }
     catch {
-        $_.Exception.Message | Write-LogOutput -LogType ERROR -ErrorObject $_
+        $_.Exception.Message | Write-ContainedErrorLog -ErrorObject $_
     }
 }
 
@@ -318,6 +318,6 @@ function Complete-SqlSchemaRetrieval {
             Request-SqlSyntaxValidation -TabSession (Get-ActiveTabSession)
     }
     catch {
-        $_.Exception.Message | Write-LogOutput -LogType ERROR -ErrorObject $_
+        $_.Exception.Message | Write-ContainedErrorLog -ErrorObject $_
     }
 }

--- a/src/Lib/Functions/Private/Invoke-ExecuteQuery.ps1
+++ b/src/Lib/Functions/Private/Invoke-ExecuteQuery.ps1
@@ -121,7 +121,7 @@ function Invoke-ExecuteQuery {
                     return
                 }
                 elseif ($Script:Task.Status -eq "Faulted") {
-                    "Task failed: {0}" -f $Script:Task.Status | Write-LogOutput -LogType ERROR
+                    "Task failed: {0}" -f $Script:Task.Status | Write-ContainedErrorLog
                 }
                 else {
                     "Task result: {0}" -f $Script:Task.Status | Write-LogOutput -LogType DEBUG
@@ -133,14 +133,14 @@ function Invoke-ExecuteQuery {
                 # object for its whole lifetime and deletes it in its own finally, so this frame
                 # never holds one to leak.
                 Reset-ExecuteQueryUiState
-                $_.Exception.Message | Write-LogOutput -LogType ERROR -ErrorObject $_
+                $_.Exception.Message | Write-ContainedErrorLog -ErrorObject $_
             }
         }
         Invoke-ExecuteScriptWithResultAsync -ScriptToExecute $ScriptToExecute -OnCompletedScriptBlock $OnCompletedScriptBlock
     }
     catch {
         Reset-ExecuteQueryUiState
-        $_.Exception.Message | Write-LogOutput -LogType ERROR -ErrorObject $_
+        $_.Exception.Message | Write-ContainedErrorLog -ErrorObject $_
     }
 }
 
@@ -204,7 +204,7 @@ function Reset-ExecuteQueryUiState {
         }
     }
     catch {
-        $_.Exception.Message | Write-LogOutput -LogType ERROR -ErrorObject $_
+        $_.Exception.Message | Write-ContainedErrorLog -ErrorObject $_
     }
 }
 
@@ -272,7 +272,7 @@ function Invoke-ExecuteQueryOnUiThread {
             # Nothing to re-run with. Reported rather than silently ignored: this would mean the
             # context was lost between dispatch and completion, which is a bug here rather than a
             # problem at the tenant.
-            "Cannot retry the query on the UI thread: the request context is no longer available." | Write-LogOutput -LogType ERROR
+            "Cannot retry the query on the UI thread: the request context is no longer available." | Write-ContainedErrorLog
             Complete-ExecuteQueryResult -QueryResult $null -SaveResult $null -TempQueryDoId $null
             return
         }
@@ -284,7 +284,7 @@ function Invoke-ExecuteQueryOnUiThread {
     }
     catch {
         Reset-ExecuteQueryUiState
-        $_.Exception.Message | Write-LogOutput -LogType ERROR -ErrorObject $_
+        $_.Exception.Message | Write-ContainedErrorLog -ErrorObject $_
     }
 }
 
@@ -326,16 +326,17 @@ function Complete-ExecuteQueryPipeline {
             return
         }
 
-        # The steps the worker actually took, logged here because it could not log them itself. This
-        # is what keeps the log as informative as it was when every request was made inline.
-        foreach ($Private:Step in @($Outcome.Steps)) {
-            "Pipeline step {0}: {1} {2}" -f $Private:Step.Name, $Private:Step.Method, $Private:Step.Uri | Write-LogOutput -LogType DEBUG
-        }
+        # Everything the worker would have written to the log, replayed here at the levels it chose.
+        # A worker cannot log - no $Script: state, no log file, no window - so without this, moving
+        # the chain off the UI thread silently cost this application most of its diagnostic value.
+        # For a troubleshooting tool that is not an acceptable price for responsiveness.
+        #
+        # Redaction happens HERE, not in the worker: ConvertTo-RedactedLogString is a UI-thread
+        # function and stays one, so there is a single place that decides how much of a request or a
+        # response may be written down. The worker records what to log; this decides what is safe.
+        Write-ExecutePipelineLog -Log $Outcome.Log
 
-        if ($Outcome.SaveSkipped) {
-            "No changes detected! Saving not needed." | Write-LogOutput -LogType DEBUG
-        }
-        elseif ($null -ne $Outcome.SaveResult) {
+        if ($null -ne $Outcome.SaveResult -and -not $Outcome.SaveSkipped) {
             "Query saved!" | Write-LogOutput
         }
 
@@ -353,7 +354,7 @@ function Complete-ExecuteQueryPipeline {
                 return
             }
 
-            "The query pipeline failed at step '{0}': {1}" -f $Outcome.FailedStep, $Outcome.ErrorRecord.Exception.Message | Write-LogOutput -LogType ERROR -ErrorObject $Outcome.ErrorRecord
+            "The query pipeline failed at step '{0}': {1}" -f $Outcome.FailedStep, $Outcome.ErrorRecord.Exception.Message | Write-ContainedErrorLog -ErrorObject $Outcome.ErrorRecord
             Complete-ExecuteQueryResult -QueryResult $Outcome.ErrorRecord -SaveResult $Outcome.SaveResult -TempQueryDoId $null
             return
         }
@@ -364,7 +365,7 @@ function Complete-ExecuteQueryPipeline {
     }
     catch {
         Reset-ExecuteQueryUiState
-        $_.Exception.Message | Write-LogOutput -LogType ERROR -ErrorObject $_
+        $_.Exception.Message | Write-ContainedErrorLog -ErrorObject $_
     }
 }
 
@@ -464,6 +465,6 @@ function Complete-ExecuteQueryResult {
         # The temporary object is already gone by here - it is deleted before anything that can throw
         # - so this only has to put the UI back.
         Reset-ExecuteQueryUiState
-        $_.Exception.Message | Write-LogOutput -LogType ERROR -ErrorObject $_
+        $_.Exception.Message | Write-ContainedErrorLog -ErrorObject $_
     }
 }

--- a/src/Lib/Functions/Private/Invoke-ExecuteQuery.ps1
+++ b/src/Lib/Functions/Private/Invoke-ExecuteQuery.ps1
@@ -121,7 +121,15 @@ function Invoke-ExecuteQuery {
                     return
                 }
                 elseif ($Script:Task.Status -eq "Faulted") {
-                    "Task failed: {0}" -f $Script:Task.Status | Write-ContainedErrorLog
+                    # "Task failed: Faulted" - which is what this used to say - tells the reader only
+                    # that the status is the status. A faulted Task carries an AggregateException, so
+                    # the message worth having is the base exception's, not the wrapper's.
+                    $Private:TaskFailure = "no exception was recorded"
+                    if ($null -ne $Script:Task.Exception) {
+                        $Private:TaskFailure = $Script:Task.Exception.GetBaseException().Message
+                    }
+
+                    "Reading the editor's contents failed: {0}" -f $Private:TaskFailure | Write-ContainedErrorLog -ErrorObject $Script:Task.Exception
                 }
                 else {
                     "Task result: {0}" -f $Script:Task.Status | Write-LogOutput -LogType DEBUG

--- a/src/Lib/Functions/Private/Invoke-OmadaExecutePipeline.ps1
+++ b/src/Lib/Functions/Private/Invoke-OmadaExecutePipeline.ps1
@@ -40,7 +40,9 @@ function Invoke-OmadaExecutePipeline {
       QueryResult    the execute response
       ErrorRecord    the first failure, or $null
       FailedStep     which step failed, or $null
-      Steps          an ordered trace of @{ Name; Method; Uri } for the UI to log
+      CompletedSteps how many requests came back without an error
+      Steps          an ordered trace of @{ Name; Method; Uri }
+      Log            an ordered list of log entries for the UI thread to replay - see below
     #>
     [CmdletBinding()]
     param(
@@ -61,6 +63,24 @@ function Invoke-OmadaExecutePipeline {
         # safe to retry on the UI thread, because only then is it certain that nothing was changed
         # server-side by the attempt.
         CompletedSteps = 0
+        # What the worker WOULD have logged, had it been able to. Replayed verbatim on the UI thread
+        # by Complete-ExecuteQueryPipeline, at these levels, so the log of a background execute reads
+        # the same as it did when every request was made inline. Without this, moving the chain into a
+        # worker silently cost this application most of its diagnostic value - which for a
+        # troubleshooting tool is not an acceptable trade for responsiveness.
+        Log            = [System.Collections.Generic.List[object]]::new()
+    }
+
+    # Entries carry either finished text, or an object plus a format string. The object form exists
+    # because redaction (ConvertTo-RedactedLogString) is a UI-thread function and must stay one: the
+    # worker records WHAT to log, the UI thread decides how much of it may be written down.
+    $Log = {
+        param($Level, $Text)
+        $Outcome.Log.Add(@{ Level = $Level; Text = $Text })
+    }
+    $LogObject = {
+        param($Level, $Format, $Object, $ShapeOnly)
+        $Outcome.Log.Add(@{ Level = $Level; Format = $Format; Redact = $Object; ShapeOnly = [bool]$ShapeOnly })
     }
 
     # One local helper rather than a call out to another file: this runs in a worker runspace, and
@@ -76,10 +96,27 @@ function Invoke-OmadaExecutePipeline {
         else {
             $Parameters.Body = $Request.Body
         }
+
         $Outcome.Steps.Add(@{ Name = $StepName; Method = $Request.Method; Uri = $Request.Uri })
+
+        # The same three lines the inline path wrote before every request, in the same order and at
+        # the same levels.
+        & $Log "DEBUG" ("QueryUrl: {0}" -f $Request.Uri)
+        if ($null -ne $Request.Body) {
+            & $LogObject "VERBOSE" "Body: {0}" $Request.Body $true
+        }
+        & $LogObject "VERBOSE" "Parameters: {0}" $Parameters $false
+
         $StepOutcome = Invoke-OmadaRequestCore -Parameters $Parameters
+
         if ($null -eq $StepOutcome.ErrorRecord) {
             $Outcome.CompletedSteps = $Outcome.CompletedSteps + 1
+            & $LogObject "VERBOSE" "Result: {0}" $StepOutcome.Result $false
+        }
+        else {
+            # DEBUG, not ERROR: the pipeline reports its failure through the outcome, and the caller
+            # decides how loudly to say so. An ERROR written from here would be written twice.
+            & $Log "DEBUG" ("Step '{0}' failed: {1}" -f $StepName, $StepOutcome.ErrorRecord.Exception.Message)
         }
         return $StepOutcome
     }
@@ -90,6 +127,7 @@ function Invoke-OmadaExecutePipeline {
         # Save-Query has always compared the editor text against C_QUERY as well as against what this
         # session last saved.
         if (-not $Context.SkipSave) {
+            & $Log "INFO" ("Retrieve query {0}" -f $Context.QueryDoId)
             $Private:Fetch = & $Invoke "GetQueryObject" (@{
                     Method = "GET"
                     Uri    = "{0}/odata/dataobjects/C_P_SQLTROUBLESHOOTING({1})" -f $Context.BaseUrl, $Context.QueryDoId
@@ -108,10 +146,12 @@ function Invoke-OmadaExecutePipeline {
             if ($null -eq $Private:SaveRequest) {
                 # "No changes detected! Saving not needed." - the caller still needs the fetched
                 # object, because it carries the display name the completion reads.
+                & $Log "DEBUG" "No changes detected! Saving not needed."
                 $Outcome.SaveSkipped = $true
                 $Outcome.SaveResult = $Private:Fetch.Result
             }
             else {
+                & $Log "INFO" "Save query"
                 $Private:Save = & $Invoke "SaveQuery" $Private:SaveRequest
                 if ($null -ne $Private:Save.ErrorRecord) {
                     $Outcome.ErrorRecord = $Private:Save.ErrorRecord
@@ -124,6 +164,7 @@ function Invoke-OmadaExecutePipeline {
 
         # --- 2. The temporary object, for an execute-selection run ---------------------------------
         if (![string]::IsNullOrWhiteSpace($Context.SelectionText)) {
+            & $Log "DEBUG" "Execute selection mode: creating temporary query object"
             $Private:ReuseDoId = $null
 
             # A probe failure is not fatal, exactly as it is not on the UI thread: the existing
@@ -177,6 +218,7 @@ function Invoke-OmadaExecutePipeline {
         # --- 3. The query itself -------------------------------------------------------------------
         $Private:ExecuteContext = $Context.Clone()
         $Private:ExecuteContext.TargetQueryDoId = if ($null -ne $Outcome.TempQueryDoId) { $Outcome.TempQueryDoId } else { $Context.QueryDoId }
+        & $Log "INFO" "Retrieve query output, please wait..."
         $Private:Execute = & $Invoke "ExecuteQuery" (New-OmadaQueryRequest -Kind "ExecuteQuery" -Context $Private:ExecuteContext)
 
         if ($null -ne $Private:Execute.ErrorRecord) {

--- a/src/Lib/Functions/Private/Stop-ExecuteQueryRequest.ps1
+++ b/src/Lib/Functions/Private/Stop-ExecuteQueryRequest.ps1
@@ -79,6 +79,6 @@ function Stop-ExecuteQueryRequest {
         # Whatever went wrong, the tab must not be left in the executing state - that would leave the
         # user with a Cancel button that cancels nothing and no way back to Execute.
         Reset-ExecuteQueryUiState
-        $_.Exception.Message | Write-LogOutput -LogType ERROR -ErrorObject $_
+        $_.Exception.Message | Write-ContainedErrorLog -ErrorObject $_
     }
 }

--- a/src/Lib/Functions/Private/Write-ContainedErrorLog.ps1
+++ b/src/Lib/Functions/Private/Write-ContainedErrorLog.ps1
@@ -1,0 +1,49 @@
+function Write-ContainedErrorLog {
+    <#
+    .SYNOPSIS
+    Report an error to the user exactly as Write-LogOutput -LogType ERROR does, without letting the
+    reporting itself unwind the caller.
+
+    .DESCRIPTION
+    Write-LogOutput ends every ERROR with "Write-Error", and this application runs with
+    $ErrorActionPreference = Stop. So logging an ERROR is TERMINATING: it throws.
+
+    That is deliberate and long-standing - it is how an error propagates out to a caller that should
+    stop - and code which logs an ERROR as the last statement of a catch block relies on it. It is
+    also a trap anywhere else, and it caused a real one: reporting a tenant failure from a completion
+    block threw, the completion's own catch logged the throw as another ERROR, which threw again, the
+    poll timer's catch logged THAT, and the dispatcher's unhandled handler logged the result - five
+    stacked error dialogs and a log entry containing four nested copies of itself, for one HTTP 500.
+
+    A completion block is invoked by a timer. There is no caller to unwind to and nothing useful
+    above it, so an error reported from one must be reported and contained. That is what this does:
+    the user still gets the message and the dialog, exactly once, and control returns normally.
+
+    Use this wherever an error is reported from a completion block, or from anywhere that must carry
+    on afterwards. Keep using Write-LogOutput -LogType ERROR directly where the throw is wanted.
+
+    .PARAMETER Message
+    The message to report.
+
+    .PARAMETER ErrorObject
+    The originating error, passed through for the call stack Write-LogOutput records.
+    #>
+    [CmdLetBinding()]
+    param(
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [string]$Message,
+
+        $ErrorObject
+    )
+
+    process {
+        try {
+            $Message | Write-LogOutput -LogType ERROR -ErrorObject $ErrorObject
+        }
+        catch {
+            # Expected, and the entire point: Write-LogOutput has already written the line and shown
+            # the dialog by the time it throws. Swallowing it here is what stops one error becoming
+            # a cascade of them. Nothing is lost - the message has been reported.
+        }
+    }
+}

--- a/src/Lib/Functions/Private/Write-ExecutePipelineLog.ps1
+++ b/src/Lib/Functions/Private/Write-ExecutePipelineLog.ps1
@@ -1,0 +1,58 @@
+function Write-ExecutePipelineLog {
+    <#
+    .SYNOPSIS
+    Replay the log entries a background worker recorded, on the UI thread, at the levels it chose.
+
+    .DESCRIPTION
+    Invoke-OmadaExecutePipeline runs in a worker runspace and cannot log: it has no $Script: state,
+    no log file and no window. Without replaying what it did, moving the execute chain off the UI
+    thread silently cost this application most of its diagnostic value - every URL, body, parameter
+    set and response that used to appear in the log for an execute simply stopped being written down.
+    For a tool whose purpose is troubleshooting, that is not an acceptable price for responsiveness.
+
+    Redaction happens here rather than in the worker, and deliberately: ConvertTo-RedactedLogString
+    is a UI-thread function and stays one, so there remains a single place that decides how much of a
+    request or a response may be written down. The worker records WHAT to log; this decides what is
+    safe to write.
+
+    .PARAMETER Log
+    Ordered entries from the pipeline's outcome. Each is either:
+      @{ Level; Text }                          - a finished line
+      @{ Level; Format; Redact; ShapeOnly }     - an object to redact and format into Format
+
+    .NOTES
+    Every entry is written with -SkipDialog. These are a replay of things that already happened, and
+    a replayed line must never open a modal - a single execute records a dozen of them.
+    #>
+    [CmdLetBinding()]
+    param(
+        $Log
+    )
+
+    foreach ($Private:Entry in @($Log)) {
+        try {
+            if ($null -eq $Private:Entry) {
+                continue
+            }
+
+            $Private:Level = if ([string]::IsNullOrWhiteSpace($Private:Entry.Level)) { "DEBUG" } else { $Private:Entry.Level }
+
+            $Private:Text = $Private:Entry.Text
+            if ($null -ne $Private:Entry.Format) {
+                $Private:Text = $Private:Entry.Format -f (ConvertTo-RedactedLogString -InputObject $Private:Entry.Redact -ShapeOnly:([bool]$Private:Entry.ShapeOnly))
+            }
+
+            if ([string]::IsNullOrWhiteSpace($Private:Text)) {
+                continue
+            }
+
+            $Private:Text | Write-LogOutput -LogType $Private:Level -SkipDialog
+        }
+        catch {
+            # One unloggable entry - an object that will not redact, say - must not cost the log
+            # every entry after it. Deliberately silent: this is itself the logging path, so
+            # reporting the failure has nowhere useful to go.
+            continue
+        }
+    }
+}

--- a/tests/Get-SqlSchema.Tests.ps1
+++ b/tests/Get-SqlSchema.Tests.ps1
@@ -23,6 +23,7 @@ BeforeAll {
     . (Join-Path $PrivatePath -ChildPath "Build-OmadaRequestParameter.ps1")
     . (Join-Path $PrivatePath -ChildPath "Resolve-OmadaRequestFailure.ps1")
     . (Join-Path $PrivatePath -ChildPath "Invoke-OmadaPSWebRequestWrapper.ps1")
+    . (Join-Path $PrivatePath -ChildPath "Write-ContainedErrorLog.ps1")
     . (Join-Path $PrivatePath -ChildPath "Get-SqlSchema.ps1")
 
     . (Join-Path $PSScriptRoot -ChildPath "mock\OmadaMockRouter.ps1")

--- a/tests/Invoke-ExecuteQuery.Tests.ps1
+++ b/tests/Invoke-ExecuteQuery.Tests.ps1
@@ -492,6 +492,62 @@ Describe "Complete-ExecuteQueryPipeline does not retry a tab that was torn down"
     }
 }
 
+Describe "Invoke-ExecuteQuery reports a faulted editor read usefully" {
+    # "Task failed: Faulted" told the reader only that the status is the status. In a PR about the
+    # log's diagnostic value that is exactly the wrong thing to leave behind, so the message now comes
+    # from the Task's base exception - a faulted Task wraps it in an AggregateException, whose own
+    # message is the equally useless "One or more errors occurred."
+
+    BeforeEach {
+        Initialize-ExecuteQueryTestState
+
+        $script:CapturedCompletion = $null
+        function Invoke-ExecuteScriptWithResultAsync {
+            param($ScriptToExecute, $OnCompletedScriptBlock)
+            $script:CapturedCompletion = $OnCompletedScriptBlock
+        }
+
+        function Test-ConnectionRequirements { return $true }
+
+        $script:ErrorLines = [System.Collections.Generic.List[string]]::new()
+        Mock Write-LogOutput {
+            if ($LogType -eq "ERROR") {
+                $script:ErrorLines.Add([string]$InputObject)
+                Write-Error -Message ([string]$InputObject) -ErrorAction Stop
+            }
+        }
+    }
+
+    It "logs what actually failed, not the status name" {
+        Invoke-ExecuteQuery
+        $Script:Task = [System.Threading.Tasks.Task]::FromException([System.InvalidOperationException]::new("The editor is no longer available"))
+
+        & $script:CapturedCompletion
+
+        @($script:ErrorLines).Count | Should -Be 1
+        $script:ErrorLines[0] | Should -Match "The editor is no longer available"
+        $script:ErrorLines[0] | Should -Not -Match "One or more errors occurred"
+    }
+
+    It "says so plainly when a faulted task carries no exception at all" {
+        Invoke-ExecuteQuery
+        $Script:Task = [pscustomobject]@{ Status = "Faulted"; Exception = $null }
+
+        { & $script:CapturedCompletion } | Should -Not -Throw
+
+        $script:ErrorLines[0] | Should -Match "no exception was recorded"
+    }
+
+    It "still returns the UI to a usable state after a faulted read" {
+        Invoke-ExecuteQuery
+        $Script:Task = [System.Threading.Tasks.Task]::FromException([System.InvalidOperationException]::new("gone"))
+
+        & $script:CapturedCompletion
+
+        $Script:MainForm.Elements.ButtonExecuteQuery.IsEnabled | Should -BeTrue
+    }
+}
+
 Describe "Complete-ExecuteQueryPipeline reports a tenant failure once" {
     # Found on a live tenant: one HTTP 500 produced FIVE stacked error dialogs and a log entry
     # containing four nested copies of itself. Write-LogOutput -LogType ERROR ends with Write-Error,

--- a/tests/Invoke-ExecuteQuery.Tests.ps1
+++ b/tests/Invoke-ExecuteQuery.Tests.ps1
@@ -26,6 +26,11 @@ BeforeAll {
     . (Join-Path $PrivatePath -ChildPath "Set-ButtonText.ps1")
     . (Join-Path $PrivatePath -ChildPath "Get-ActiveExecuteQueryRequest.ps1")
     . (Join-Path $PrivatePath -ChildPath "Set-ExecuteQueryButtonState.ps1")
+    # Both are dot-sourced rather than stubbed, and for the same reason as the chain above: the
+    # containment these two provide IS the behaviour under test in the cascade suite, so a stub would
+    # assert nothing.
+    . (Join-Path $PrivatePath -ChildPath "Write-ContainedErrorLog.ps1")
+    . (Join-Path $PrivatePath -ChildPath "Write-ExecutePipelineLog.ps1")
     . (Join-Path $PrivatePath -ChildPath "Invoke-ExecuteQuery.ps1")
 
     $Script:Tracer = [System.Diagnostics.Trace]
@@ -54,9 +59,11 @@ BeforeAll {
             $QueryResult = $null,
             $ErrorRecord = $null,
             [int]$CompletedSteps = 1,
-            $SaveResult = ([pscustomobject]@{ Id = 100; DisplayName = "TestQuery" })
+            $SaveResult = ([pscustomobject]@{ Id = 100; DisplayName = "TestQuery" }),
+            $Log = @()
         )
         return @{
+            Log            = $Log
             SaveResult     = $SaveResult
             SaveSkipped    = $false
             TempQueryDoId  = $null
@@ -482,5 +489,76 @@ Describe "Complete-ExecuteQueryPipeline does not retry a tab that was torn down"
         $Script:PopupWindowExecuteQuery | Should -BeNullOrEmpty
         $Script:MainForm.Elements.ButtonExecuteQueryText.Text | Should -Be "_Execute"
         $Script:RunTimeData.StopWatch.IsRunning | Should -BeFalse
+    }
+}
+
+Describe "Complete-ExecuteQueryPipeline reports a tenant failure once" {
+    # Found on a live tenant: one HTTP 500 produced FIVE stacked error dialogs and a log entry
+    # containing four nested copies of itself. Write-LogOutput -LogType ERROR ends with Write-Error,
+    # which under this application's $ErrorActionPreference = Stop is terminating - so reporting the
+    # pipeline failure threw before the grid was bound, the function's own catch reported the throw
+    # as a second error, which threw again, and so on out to the dispatcher.
+    #
+    # These tests only mean anything with a Write-LogOutput that throws on ERROR the way the real one
+    # does; the suite's default stub is a no-op and would pass whatever the code did.
+
+    BeforeEach {
+        Initialize-ExecuteQueryTestState
+        $script:ErrorLines = [System.Collections.Generic.List[string]]::new()
+        $script:ReplayedLines = [System.Collections.Generic.List[string]]::new()
+        Mock Write-LogOutput {
+            if ($LogType -eq "ERROR") {
+                $script:ErrorLines.Add([string]$InputObject)
+                Write-Error -Message ([string]$InputObject) -ErrorAction Stop
+            }
+            $script:ReplayedLines.Add([string]$InputObject)
+        }
+    }
+
+    It "writes one ERROR, not a cascade of them" {
+        $Failed = New-PipelineOutcome -ErrorRecord (New-TestErrorRecord "Response status code does not indicate success: 500 (Internal Server Error)") -CompletedSteps 2
+
+        { Complete-ExecuteQueryPipeline -Outcome $Failed -PipelineContext @{ BaseUrl = "https://tenant.omada.cloud"; QueryDoId = 100 } } | Should -Not -Throw
+
+        @($script:ErrorLines).Count | Should -Be 1
+        $script:ErrorLines[0] | Should -Match "500"
+    }
+
+    It "still returns the UI to a usable state after the failure" {
+        # The user-visible half of the same bug. The report threw before Complete-ExecuteQueryResult
+        # ran, so the Execute button stayed disabled and the stopwatch kept running: the window was
+        # left believing a query was still in flight.
+        $Failed = New-PipelineOutcome -ErrorRecord (New-TestErrorRecord "500") -CompletedSteps 2
+
+        Complete-ExecuteQueryPipeline -Outcome $Failed -PipelineContext @{ BaseUrl = "https://tenant.omada.cloud"; QueryDoId = 100 }
+
+        $Script:MainForm.Elements.ButtonExecuteQuery.IsEnabled | Should -BeTrue
+        $Script:RunTimeData.StopWatch.IsRunning | Should -BeFalse
+    }
+
+    It "replays what the worker recorded, so an execute is still traceable in the log" {
+        # Moving the chain into a worker took the URLs, bodies and responses out of the log. They come
+        # back through the outcome's Log, and they have to survive a FAILED run - that is precisely
+        # when someone reads the log.
+        $Failed = New-PipelineOutcome -ErrorRecord (New-TestErrorRecord "500") -CompletedSteps 2 -Log @(
+            @{ Level = "DEBUG"; Text = "QueryUrl: https://tenant.omada.cloud/api/x" }
+            @{ Level = "INFO"; Text = "Retrieve query output, please wait..." }
+        )
+
+        Complete-ExecuteQueryPipeline -Outcome $Failed -PipelineContext @{ BaseUrl = "https://tenant.omada.cloud"; QueryDoId = 100 }
+
+        @($script:ReplayedLines) | Should -Contain "QueryUrl: https://tenant.omada.cloud/api/x"
+        @($script:ReplayedLines) | Should -Contain "Retrieve query output, please wait..."
+    }
+
+    It "replays the worker's log on a successful run too" {
+        $Succeeded = New-PipelineOutcome -QueryResult ([pscustomobject]@{ d = [pscustomobject]@{ Records = 2; Rows = @(1, 2) } }) -Log @(
+            @{ Level = "DEBUG"; Text = "QueryUrl: https://tenant.omada.cloud/api/x" }
+        )
+
+        Complete-ExecuteQueryPipeline -Outcome $Succeeded -PipelineContext @{ BaseUrl = "https://tenant.omada.cloud"; QueryDoId = 100 }
+
+        @($script:ReplayedLines) | Should -Contain "QueryUrl: https://tenant.omada.cloud/api/x"
+        @($script:ErrorLines).Count | Should -Be 0
     }
 }

--- a/tests/Invoke-OmadaExecutePipeline.Tests.ps1
+++ b/tests/Invoke-OmadaExecutePipeline.Tests.ps1
@@ -141,6 +141,37 @@ Describe "Invoke-OmadaExecutePipeline - the ordinary run" {
 
         @($Outcome.Steps | ForEach-Object { $_.Name }) | Should -Be @("GetQueryObject", "SaveQuery", "ExecuteQuery")
     }
+
+    It "records the lines the UI thread has to write on its behalf" {
+        # Steps say WHAT ran; Log carries what a person reading the log needs to see - the URL, the
+        # body, the parameter set, the response. Before this, moving the chain into a worker silently
+        # emptied the log of everything an execute used to record.
+        $Outcome = Invoke-OmadaExecutePipeline -Context (New-PipelineContext -QueryText "SELECT 2")
+
+        @($Outcome.Log).Count | Should -BeGreaterThan 0
+        @($Outcome.Log | Where-Object { $_.Text -match "Retrieve query output" }).Count | Should -Be 1
+        @($Outcome.Log | Where-Object { $_.Text -match "Save query" }).Count | Should -Be 1
+        @($Outcome.Log | Where-Object { $_.Text -match "QueryUrl" }).Count | Should -BeGreaterThan 0
+    }
+
+    It "marks the request body as shape-only, so a query's content is never written verbatim" {
+        # Redaction happens on the UI thread, but the DECISION to log a body as a shape is made here.
+        # Getting this wrong would put user data in the log file.
+        $Outcome = Invoke-OmadaExecutePipeline -Context (New-PipelineContext)
+
+        $Private:BodyEntries = @($Outcome.Log | Where-Object { $_.Format -match "Body" })
+        @($Private:BodyEntries).Count | Should -BeGreaterThan 0
+        @($Private:BodyEntries | Where-Object { -not $_.ShapeOnly }).Count | Should -Be 0
+    }
+
+    It "carries a log out of a failed run as well" {
+        # Precisely when someone reads the log.
+        $script:Failures["execute"] = "500 (Internal Server Error)"
+        $Outcome = Invoke-OmadaExecutePipeline -Context (New-PipelineContext)
+
+        $Outcome.ErrorRecord | Should -Not -BeNullOrEmpty
+        @($Outcome.Log | Where-Object { $_.Text -match "QueryUrl" }).Count | Should -BeGreaterThan 0
+    }
 }
 
 Describe "Invoke-OmadaExecutePipeline - execute selection" {

--- a/tests/Stop-ExecuteQueryRequest.Tests.ps1
+++ b/tests/Stop-ExecuteQueryRequest.Tests.ps1
@@ -14,6 +14,7 @@ BeforeAll {
     . (Join-Path $PrivatePath -ChildPath "ConvertTo-RedactedLogString.ps1")
     . (Join-Path $PrivatePath -ChildPath "Set-TextBlockText.ps1")
     . (Join-Path $PrivatePath -ChildPath "Get-ActiveExecuteQueryRequest.ps1")
+    . (Join-Path $PrivatePath -ChildPath "Write-ContainedErrorLog.ps1")
     . (Join-Path $PrivatePath -ChildPath "Stop-ExecuteQueryRequest.ps1")
 
     $Script:Tracer = [System.Diagnostics.Trace]

--- a/tests/Write-ContainedErrorLog.Tests.ps1
+++ b/tests/Write-ContainedErrorLog.Tests.ps1
@@ -1,0 +1,78 @@
+#Requires -Version 7.0
+# The cascade this exists to stop is not hypothetical. One HTTP 500 from the tenant produced five
+# stacked error dialogs and a log entry containing four nested copies of itself, because
+# Write-LogOutput -LogType ERROR ends with Write-Error and this application runs with
+# $ErrorActionPreference = Stop. Every assertion below is about that: the message is reported, and
+# reporting it does not unwind the caller.
+
+BeforeAll {
+    $ParentPath = Split-Path -Path $PSScriptRoot -Parent
+    $PrivatePath = Join-Path $ParentPath -ChildPath "src\Lib\Functions\Private"
+    . (Join-Path $PrivatePath -ChildPath "Write-ContainedErrorLog.ps1")
+
+    $script:LogMessages = [System.Collections.Generic.List[object]]::new()
+
+    # Stands in for the real Write-LogOutput, including the part that matters: an ERROR is written
+    # and THEN throws. A stub that only recorded the call would pass whatever this function did.
+    function Write-LogOutput {
+        param(
+            [Parameter(ValueFromPipeline = $true)]$InputObject,
+            [string]$LogType,
+            $ErrorObject,
+            [switch]$SkipDialog
+        )
+        process {
+            $script:LogMessages.Add([pscustomobject]@{ LogType = $LogType; Message = [string]$InputObject; ErrorObject = $ErrorObject })
+            if ($LogType -eq "ERROR") {
+                Write-Error -Message ([string]$InputObject) -ErrorAction Stop
+            }
+        }
+    }
+}
+
+Describe "Write-ContainedErrorLog" {
+    BeforeEach { $script:LogMessages.Clear() }
+
+    It "reports the message at ERROR, exactly once" {
+        "Response status code does not indicate success: 500" | Write-ContainedErrorLog
+
+        $script:LogMessages.Count | Should -Be 1
+        $script:LogMessages[0].LogType | Should -Be "ERROR"
+        $script:LogMessages[0].Message | Should -Be "Response status code does not indicate success: 500"
+    }
+
+    It "returns normally, so the statement after it still runs" {
+        # The regression in one line. The caller reported a pipeline failure and then bound the grid;
+        # the report threw, so the grid was never bound and the catch reported the throw as a second
+        # error, which threw again.
+        $script:Reached = $false
+        & {
+            "boom" | Write-ContainedErrorLog
+            $script:Reached = $true
+        }
+
+        $script:Reached | Should -BeTrue
+    }
+
+    It "does not rethrow even under ErrorActionPreference = Stop" {
+        $ErrorActionPreference = "Stop"
+
+        { "boom" | Write-ContainedErrorLog } | Should -Not -Throw
+    }
+
+    It "passes the originating error through for the call stack" {
+        $Private:ErrorRecord = $null
+        try { throw "original" } catch { $Private:ErrorRecord = $_ }
+
+        "wrapped" | Write-ContainedErrorLog -ErrorObject $Private:ErrorRecord
+
+        $script:LogMessages[0].ErrorObject | Should -Be $Private:ErrorRecord
+    }
+
+    It "reports every message when several are piped in" {
+        @("first", "second") | Write-ContainedErrorLog
+
+        @($script:LogMessages).Count | Should -Be 2
+        $script:LogMessages[1].Message | Should -Be "second"
+    }
+}

--- a/tests/Write-ExecutePipelineLog.Tests.ps1
+++ b/tests/Write-ExecutePipelineLog.Tests.ps1
@@ -1,0 +1,113 @@
+#Requires -Version 7.0
+# Moving the execute chain into a worker cost this application most of its diagnostic value: the URL,
+# the body, the parameter set and the response used to be in the log for every execute, and after
+# C1-5 none of them were, because a worker runspace has no log file. These tests are about getting
+# that back without moving redaction off the UI thread.
+
+BeforeAll {
+    $ParentPath = Split-Path -Path $PSScriptRoot -Parent
+    $PrivatePath = Join-Path $ParentPath -ChildPath "src\Lib\Functions\Private"
+    . (Join-Path $PrivatePath -ChildPath "Write-ExecutePipelineLog.ps1")
+
+    $script:LogMessages = [System.Collections.Generic.List[object]]::new()
+    function Write-LogOutput {
+        param(
+            [Parameter(ValueFromPipeline = $true)]$InputObject,
+            [string]$LogType,
+            $ErrorObject,
+            [switch]$SkipDialog
+        )
+        process { $script:LogMessages.Add([pscustomobject]@{ LogType = $LogType; Message = [string]$InputObject; SkipDialog = [bool]$SkipDialog }) }
+    }
+
+    $script:RedactCalls = [System.Collections.Generic.List[object]]::new()
+    function ConvertTo-RedactedLogString {
+        param($InputObject, [switch]$ShapeOnly, $MaxDepth)
+        $script:RedactCalls.Add([pscustomobject]@{ InputObject = $InputObject; ShapeOnly = [bool]$ShapeOnly })
+        if ($ShapeOnly) { return "<shape>" }
+        return "<redacted:$($InputObject.Marker)>"
+    }
+}
+
+Describe "Write-ExecutePipelineLog" {
+    BeforeEach {
+        $script:LogMessages.Clear()
+        $script:RedactCalls.Clear()
+    }
+
+    It "replays finished lines at the level the worker chose, in order" {
+        Write-ExecutePipelineLog -Log @(
+            @{ Level = "INFO"; Text = "Retrieve query 1234" }
+            @{ Level = "DEBUG"; Text = "Save query" }
+        )
+
+        @($script:LogMessages).Count | Should -Be 2
+        $script:LogMessages[0].LogType | Should -Be "INFO"
+        $script:LogMessages[0].Message | Should -Be "Retrieve query 1234"
+        $script:LogMessages[1].LogType | Should -Be "DEBUG"
+    }
+
+    It "redacts objects here rather than in the worker" {
+        # The reason this function exists at all rather than the worker formatting its own strings:
+        # ConvertTo-RedactedLogString is a UI-thread function and stays the single place that decides
+        # what may be written down.
+        Write-ExecutePipelineLog -Log @(
+            @{ Level = "VERBOSE"; Format = "Parameters: {0}"; Redact = @{ Marker = "params" } }
+        )
+
+        $script:LogMessages[0].Message | Should -Be "Parameters: <redacted:params>"
+        @($script:RedactCalls).Count | Should -Be 1
+        $script:RedactCalls[0].ShapeOnly | Should -BeFalse
+    }
+
+    It "honours ShapeOnly, so a request body is logged as a shape and not as content" {
+        Write-ExecutePipelineLog -Log @(
+            @{ Level = "VERBOSE"; Format = "Body: {0}"; Redact = @{ Marker = "body" }; ShapeOnly = $true }
+        )
+
+        $script:RedactCalls[0].ShapeOnly | Should -BeTrue
+        $script:LogMessages[0].Message | Should -Be "Body: <shape>"
+    }
+
+    It "writes every entry with SkipDialog" {
+        # A replay must never open a modal. A single execute records a dozen of these, and they
+        # describe things that have already happened.
+        Write-ExecutePipelineLog -Log @(
+            @{ Level = "INFO"; Text = "one" }
+            @{ Level = "DEBUG"; Text = "two" }
+        )
+
+        @($script:LogMessages | Where-Object { -not $_.SkipDialog }).Count | Should -Be 0
+    }
+
+    It "defaults an entry with no level to DEBUG" {
+        Write-ExecutePipelineLog -Log @(@{ Text = "no level" })
+
+        $script:LogMessages[0].LogType | Should -Be "DEBUG"
+    }
+
+    It "skips null and empty entries instead of logging blank lines" {
+        Write-ExecutePipelineLog -Log @($null, @{ Level = "INFO"; Text = "" }, @{ Level = "INFO"; Text = "kept" })
+
+        @($script:LogMessages).Count | Should -Be 1
+        $script:LogMessages[0].Message | Should -Be "kept"
+    }
+
+    It "keeps going when one entry cannot be logged" {
+        # One object that will not redact must not cost the log every entry after it.
+        Mock ConvertTo-RedactedLogString { throw "cannot redact" } -ParameterFilter { $InputObject.Marker -eq "bad" }
+
+        Write-ExecutePipelineLog -Log @(
+            @{ Level = "INFO"; Text = "before" }
+            @{ Level = "VERBOSE"; Format = "{0}"; Redact = @{ Marker = "bad" } }
+            @{ Level = "INFO"; Text = "after" }
+        )
+
+        @($script:LogMessages.Message) | Should -Be @("before", "after")
+    }
+
+    It "accepts a null log without throwing" {
+        { Write-ExecutePipelineLog -Log $null } | Should -Not -Throw
+        @($script:LogMessages).Count | Should -Be 0
+    }
+}


### PR DESCRIPTION
Fixes the two problems found in the third live test of #40.

## 1. One HTTP 500 produced five error dialogs

From the log:

```
Complete-ExecuteQueryPipeline (356) The query pipeline failed at step ExecuteQuery: Response status code does not indicate success: 500 (Internal Server Error)
Complete-ExecuteQueryPipeline (367) <the same message again>
Unhandled dispatcher exception ... "ErrorActionPreference" ... is set to Stop   (x5)
```

`Write-LogOutput` ends every ERROR with `Write-Error` (`Write-LogOutput.ps1:208-210`), and the application runs with `$ErrorActionPreference = Stop`. **Logging an ERROR is terminating.**

That is deliberate and long-standing where an ERROR is the last statement of a `catch` and the caller is meant to stop. It is a trap in a completion block:

1. `Complete-ExecuteQueryPipeline` reported the pipeline failure mid-function → threw
2. so `Complete-ExecuteQueryResult` on the next line never ran — no grid, no `Reset-ExecuteQueryUiState`, Execute button left disabled, stopwatch left running
3. the function's own `catch` logged the throw as a *second* ERROR → threw again
4. the poll timer's `catch` logged *that* → threw again
5. the dispatcher's unhandled handler logged the result

One tenant failure, five stacked modals, and a log line containing four nested copies of itself.

`Write-ContainedErrorLog` reports the error exactly as before — same line, same dialog, same call stack — and returns normally. Applied to the sites that run inside completion blocks, and to the **poll timer's own `catch`**, which is the outermost guarantee that no completion can cascade to the dispatcher again whatever it does.

## 2. The pipeline's output was missing from the log

> *"I do not see any output from the pipeline in the logs. I would expect that those logs are also visible as it was before we had multiple threads."*

Correct, and a real regression from C1-5. `Invoke-OmadaExecutePipeline` runs in a worker runspace: no `$Script:` state, no log file, no window — so it could not log at all. Every URL, body, parameter set and response an execute used to record silently stopped being written down. For a troubleshooting tool that is not an acceptable price for a responsive window.

The pipeline now records **what** to log as it goes; `Write-ExecutePipelineLog` replays it on the UI thread, on both the success and the failure path.

| Restored | Level |
|---|---|
| `Retrieve query {DoId}` | INFO |
| `QueryUrl: {uri}` per step | DEBUG |
| `Body: {shape}` per step | VERBOSE (shape-only) |
| `Parameters: {redacted}` per step | VERBOSE |
| `Result: {redacted}` | VERBOSE |
| `Step '{name}' failed: {message}` | DEBUG |
| `No changes detected! Saving not needed.` / `Save query` | DEBUG / INFO |
| `Execute selection mode: creating temporary query object` | DEBUG |
| `Retrieve query output, please wait...` | INFO |

## Decisions worth reviewing

- **Redaction stays on the UI thread.** The worker records the object and a format string; `ConvertTo-RedactedLogString` runs in `Write-ExecutePipelineLog`. There remains exactly one place that decides how much of a request or response may be written down, rather than a second copy inside a runspace. The worker still makes the *policy* call that a request body is shape-only — that decision belongs with the code that knows what the field is.
- **Every replayed line uses `-SkipDialog`.** A replay describes things that already happened, and one execute records a dozen entries. A replayed line must never open a modal.
- **`Write-ContainedErrorLog` was applied narrowly**, to completion-path sites only (`Invoke-ExecuteQuery.ps1`, `Get-SqlSchema.ps1`, `Stop-ExecuteQueryRequest.ps1`, and the poll timer). The event handlers, tab restore and WebView2 init in `MainForm.Definition.ps1` still use `Write-LogOutput -LogType ERROR` directly — their throw is existing behaviour and outside this fix.
- **One unloggable entry does not cost the log the rest.** `Write-ExecutePipelineLog` catches per entry and continues, silently: it is itself the logging path, so reporting a logging failure has nowhere useful to go.
- **`Complete-ExecuteQueryResult` still receives the `ErrorRecord` as `QueryResult`** on the failure path, so the grid is cleared and the status bar reads `0 rows`. That also means the existing `"Query did not return any results!"` WARNING follows the error line. Honest — there are no rows — but flag it if you would rather the failure path suppressed it.

## Verification

```
./build/build.ps1 -Task TestBuildOnly   →  793 tests, 0 failed; PSScriptAnalyzer clean
./build/build.ps1 -Task E2E             →   54 tests, 0 failed
```

New regression tests assert the things that actually broke: a single ERROR per tenant failure, the UI returning to a usable state after one, the worker's log surviving both a failed and a successful run, and `Write-ContainedErrorLog` returning normally under `ErrorActionPreference = Stop` with a `Write-LogOutput` stub that throws the way the real one does.

Part of #40.
