### PR TITLE
Make the elapsed-time indicator count smoothly

### DIFF
--- a/src/Lib/Events/MainForm.Definition.ps1
+++ b/src/Lib/Events/MainForm.Definition.ps1
@@ -17,10 +17,16 @@ $Script:WebViewCompletionPollTimer.Add_Tick({
         try {
             # Elapsed-time indicator for background requests (issue #40), driven from THIS timer
             # rather than a second one: this is already the only place that knows about pending work,
-            # and it is already suspended around modal dialogs. Every 20th tick is once a second,
-            # which is as often as a duration in seconds can visibly change.
+            # and it is already suspended around modal dialogs.
+            #
+            # Every 2nd tick, so 100 ms. This used to be every 20th - once a second - on the reasoning
+            # that a duration in seconds cannot visibly change more often than that. The reasoning was
+            # wrong, because the indicator has never been rendered in whole seconds: it shows tenths,
+            # so at 1 Hz it sat frozen and then jumped by ten of them. 100 ms matches the digit that
+            # is actually on screen. The work per tick is one string write per in-flight request, and
+            # there is at most one of those per tab.
             $Script:WebViewCompletionTickCount++
-            if ($Script:WebViewCompletionTickCount % 20 -eq 0) {
+            if ($Script:WebViewCompletionTickCount % 2 -eq 0) {
                 Update-BackgroundRequestElapsedTime -Pending $Script:PendingWebViewCompletions
             }
 

--- a/src/Lib/Functions/Private/Format-ElapsedTime.ps1
+++ b/src/Lib/Functions/Private/Format-ElapsedTime.ps1
@@ -1,0 +1,37 @@
+function Format-ElapsedTime {
+    <#
+    .SYNOPSIS
+    Render a duration for the status bar's query-time indicator.
+
+    .DESCRIPTION
+    One formatter for every place that writes that indicator, so the live value and the final value
+    cannot drift apart. Before this there were three literal renderings of the same field and all
+    three used TimeSpan's default format, which produces seven fractional digits - "00:00:03.1234567".
+    Six of those digits are noise on a status bar, and the churn is what made a running query look
+    jittery rather than smooth.
+
+    Tenths only, which is the precision the indicator is refreshed at (the completion poll timer
+    updates it every 100 ms). Whole hours rather than "hh", so a duration past 24 hours keeps counting
+    instead of silently rolling over - a query left running overnight should read 26:14:03.0, not
+    02:14:03.0.
+
+    .PARAMETER TimeSpan
+    The duration to render. A negative value - possible if the system clock moves backwards while a
+    request is in flight - is rendered as zero rather than as a negative duration.
+
+    .OUTPUTS
+    [string] in the form h+:mm:ss.f
+    #>
+    [CmdLetBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [TimeSpan]$TimeSpan
+    )
+
+    if ($TimeSpan.Ticks -lt 0) {
+        $TimeSpan = [TimeSpan]::Zero
+    }
+
+    return "{0:00}:{1:00}:{2:00}.{3:0}" -f [Math]::Floor($TimeSpan.TotalHours), $TimeSpan.Minutes, $TimeSpan.Seconds, [Math]::Floor($TimeSpan.Milliseconds / 100)
+}

--- a/src/Lib/Functions/Private/Format-ElapsedTime.ps1
+++ b/src/Lib/Functions/Private/Format-ElapsedTime.ps1
@@ -20,7 +20,9 @@ function Format-ElapsedTime {
     request is in flight - is rendered as zero rather than as a negative duration.
 
     .OUTPUTS
-    [string] in the form h+:mm:ss.f
+    [string] in the form hh:mm:ss.f - every field fixed-width so the indicator does not shift about as
+    it counts, except hours, which is padded to two digits and grows beyond them rather than rolling
+    over: a query running for 26 hours reads "26:00:14.0".
     #>
     [CmdLetBinding()]
     [OutputType([string])]

--- a/src/Lib/Functions/Private/Invoke-ExecuteQuery.ps1
+++ b/src/Lib/Functions/Private/Invoke-ExecuteQuery.ps1
@@ -207,7 +207,7 @@ function Reset-ExecuteQueryUiState {
             $Script:RunTimeData.StopWatch.Stop()
             if (-not $SkipStatusBarTime) {
                 "Elapsed time: {0}" -f $Script:RunTimeData.StopWatch.Elapsed.ToString() | Write-LogOutput -LogType DEBUG
-                $Script:MainForm.Elements.TextBlockStatusBarQueryTime.Text = $Script:RunTimeData.StopWatch.Elapsed.ToString()
+                $Script:MainForm.Elements.TextBlockStatusBarQueryTime.Text = Format-ElapsedTime -TimeSpan $Script:RunTimeData.StopWatch.Elapsed
             }
         }
     }

--- a/src/Lib/Functions/Private/Set-SqlConnectionState.ps1
+++ b/src/Lib/Functions/Private/Set-SqlConnectionState.ps1
@@ -62,7 +62,7 @@ function Set-SqlConnectionState {
             $Script:MainForm.Elements.ButtonConnectText | Set-ButtonText -Value "_Connect"
             $Script:MainForm.Elements.TextBlockStatusBarUrl | Set-TextBlockText -Text "-"
             $Script:MainForm.Elements.TextBlockStatusBarDatabaseName | Set-TextBlockText -Text "-"
-            $Script:MainForm.Elements.TextBlockStatusBarQueryTime | Set-TextBlockText -Text "00:00:00.0000000"
+            $Script:MainForm.Elements.TextBlockStatusBarQueryTime | Set-TextBlockText -Text (Format-ElapsedTime -TimeSpan ([TimeSpan]::Zero))
             $Script:MainForm.Elements.TextBlockStatusBarRows | Set-TextBlockText -Text "0 rows"
             # The window title is refreshed from the active tab by Update-TabHeaderTitle below
             # (-> Update-ApplicationTitle); it will show "<name> - <connection> - <tenant> - No

--- a/src/Lib/Functions/Private/Update-BackgroundRequestElapsedTime.ps1
+++ b/src/Lib/Functions/Private/Update-BackgroundRequestElapsedTime.ps1
@@ -50,7 +50,7 @@ function Update-BackgroundRequestElapsedTime {
 
                 # Formatted like the final value Reset-ExecuteQueryUiState writes from the stopwatch,
                 # so the indicator does not visibly change shape when the request completes.
-                $Private:TimeBlock.Text = ([DateTime]::UtcNow - $Item.StartedUtc).ToString()
+                $Private:TimeBlock.Text = Format-ElapsedTime -TimeSpan ([DateTime]::UtcNow - $Item.StartedUtc)
             }
             catch {
                 continue

--- a/tests/Format-ElapsedTime.Tests.ps1
+++ b/tests/Format-ElapsedTime.Tests.ps1
@@ -1,0 +1,47 @@
+#Requires -Version 7.0
+# The status bar's query-time indicator used to be rendered three separate times with TimeSpan's
+# default format - "00:00:03.1234567" - and refreshed once a second. Seven fractional digits updated
+# at 1 Hz is what made a running query look jittery: six of those digits are noise, and the ones that
+# are not sat frozen and then jumped by ten tenths at a time.
+
+BeforeAll {
+    $ParentPath = Split-Path -Path $PSScriptRoot -Parent
+    $PrivatePath = Join-Path $ParentPath -ChildPath "src\Lib\Functions\Private"
+    . (Join-Path $PrivatePath -ChildPath "Format-ElapsedTime.ps1")
+}
+
+Describe "Format-ElapsedTime" {
+    It "renders tenths, not ticks" {
+        Format-ElapsedTime -TimeSpan ([TimeSpan]::FromSeconds(3.1234567)) | Should -Be "00:00:03.1"
+    }
+
+    It "renders zero the way a reset status bar shows it" {
+        Format-ElapsedTime -TimeSpan ([TimeSpan]::Zero) | Should -Be "00:00:00.0"
+    }
+
+    It "pads every field to a fixed width, so the indicator does not jump about as it counts" {
+        Format-ElapsedTime -TimeSpan ([TimeSpan]::FromSeconds(5)) | Should -Be "00:00:05.0"
+        Format-ElapsedTime -TimeSpan ([TimeSpan]::FromSeconds(65)) | Should -Be "00:01:05.0"
+        Format-ElapsedTime -TimeSpan ([TimeSpan]::FromSeconds(3725)) | Should -Be "01:02:05.0"
+    }
+
+    It "truncates the tenth rather than rounding it, so the number never runs ahead of the clock" {
+        Format-ElapsedTime -TimeSpan ([TimeSpan]::FromMilliseconds(1999)) | Should -Be "00:00:01.9"
+    }
+
+    It "keeps counting past a day instead of silently rolling over" {
+        # A query left running overnight should read 26 hours, not 2. "hh" in a TimeSpan format string
+        # would have shown 02, which is the same string a two-hour query produces.
+        Format-ElapsedTime -TimeSpan ([TimeSpan]::FromHours(26) + [TimeSpan]::FromSeconds(14)) | Should -Be "26:00:14.0"
+    }
+
+    It "renders a negative duration as zero" {
+        # Possible if the system clock moves backwards while a request is in flight. A status bar
+        # counting downwards past zero would look like a bug in the query, not in the clock.
+        Format-ElapsedTime -TimeSpan ([TimeSpan]::FromSeconds(-5)) | Should -Be "00:00:00.0"
+    }
+
+    It "returns a string, so callers can assign it straight to a TextBlock" {
+        Format-ElapsedTime -TimeSpan ([TimeSpan]::FromSeconds(1)) | Should -BeOfType [string]
+    }
+}

--- a/tests/Invoke-ExecuteQuery.Tests.ps1
+++ b/tests/Invoke-ExecuteQuery.Tests.ps1
@@ -19,6 +19,7 @@ BeforeAll {
     . (Join-Path $PrivatePath -ChildPath "ConvertTo-RedactedLogString.ps1")
     . (Join-Path $PrivatePath -ChildPath "Get-LogResultShape.ps1")
     . (Join-Path $PrivatePath -ChildPath "Set-TextBlockText.ps1")
+    . (Join-Path $PrivatePath -ChildPath "Format-ElapsedTime.ps1")
     # Reset-ExecuteQueryUiState now also flips the Execute/Cancel button (issue #40 / C1-4). The real
     # chain is dot-sourced rather than stubbed: a missing collaborator would throw inside this
     # function's own catch and silently skip the rest of the teardown, which is exactly the failure

--- a/tests/Update-BackgroundRequestElapsedTime.Tests.ps1
+++ b/tests/Update-BackgroundRequestElapsedTime.Tests.ps1
@@ -10,6 +10,7 @@
 BeforeAll {
     $ParentPath = Split-Path -Path $PSScriptRoot -Parent
     $PrivatePath = Join-Path $ParentPath -ChildPath "src\Lib\Functions\Private"
+    . (Join-Path $PrivatePath -ChildPath "Format-ElapsedTime.ps1")
     . (Join-Path $PrivatePath -ChildPath "Update-BackgroundRequestElapsedTime.ps1")
 
     function script:New-TimePending {


### PR DESCRIPTION
The elapsed-time indicator looked jerky during a query. The tick rate was not the cause — the completion poll timer already runs at **50 ms**. Two other things were.

## What was actually wrong

**It was refreshed once a second.** `MainForm.Definition.ps1:22` gated the update to every 20th tick, with this comment justifying it:

> Every 20th tick is once a second, which is as often as a duration in seconds can visibly change.

**But it was never rendered in whole seconds.** All three places that write the field used `TimeSpan`'s default format, which produces seven fractional digits:

| Location | Was |
|---|---|
| `Update-BackgroundRequestElapsedTime.ps1:53` | `([DateTime]::UtcNow - $Item.StartedUtc).ToString()` |
| `Invoke-ExecuteQuery.ps1:210` | `$Script:RunTimeData.StopWatch.Elapsed.ToString()` |
| `Set-SqlConnectionState.ps1:65` | the literal `"00:00:00.0000000"` |

So the status bar showed `00:00:03.1234567`, sat frozen for a full second, then jumped by ten tenths — behind six digits of pure noise. The premise of the 20× gate was wrong, not the gate itself.

## What changed

- The indicator refreshes every **2nd tick (100 ms)**, which matches the digit actually on screen.
- One shared `Format-ElapsedTime` renders it, so the live value and the final value cannot drift apart. Tenths only.

## Decisions worth reviewing

- **100 ms, not 50 ms.** A tenth is the smallest digit displayed, so refreshing faster than that would repaint without changing anything. The work per tick is one string write per in-flight request and there is at most one per tab, so the cost either way is negligible — this is about not doing pointless work, not about affording it.
- **Whole hours, not `hh`.** A `TimeSpan` format string of `hh\:mm\:ss\.f` renders 26 hours as `02:00:14.0` — the same string a two-hour query produces. A query left running overnight now reads `26:00:14.0`. Covered by a test.
- **Truncated, not rounded.** 1999 ms reads `00:00:01.9`, not `00:00:02.0`. The indicator should never run ahead of the clock.
- **A negative duration renders as zero** rather than counting backwards. Reachable if the system clock moves backwards mid-request; a status bar going negative looks like a bug in the query rather than in the clock.
- **The reset literal now goes through the formatter too** (`Set-SqlConnectionState.ps1`), so there is no hardcoded format left to fall out of step.

## Verification

```
./build/build.ps1 -Task TestBuildOnly   →  803 tests, 0 failed; PSScriptAnalyzer clean
./build/build.ps1 -Task E2E             →   54 tests, 0 failed
```

Part of #40.
