### PR TITLE
Stop a tenant error costing the session, and give each tab its own popup

### DIFF
--- a/src/Lib/Events/MainForm.Elements.TabControlSessions.ps1
+++ b/src/Lib/Events/MainForm.Elements.TabControlSessions.ps1
@@ -59,6 +59,13 @@
 
                 Set-ActiveTabContext -TabSession $TabSession
 
+                # "Executing Query..." belongs to the tab that started the query, so it follows the
+                # tab on screen: shown when that tab is selected, hidden otherwise. Done here rather
+                # than in Set-ActiveTabContext because this is the only place the VISIBLE tab changes -
+                # async completions repoint context without touching SelectedItem, and driving
+                # visibility from those would flicker the popup for tabs the user is not looking at.
+                Sync-ExecuteQueryPopupVisibility
+
                 if (![string]::IsNullOrWhiteSpace($OutgoingTabId) -and $OutgoingTabId -ne $TabSession.Id) {
                     $Script:PreviousActiveTabId = $OutgoingTabId
                 }

--- a/src/Lib/Events/MainFormTabContent.Elements.ButtonExecuteQuery.ps1
+++ b/src/Lib/Events/MainFormTabContent.Elements.ButtonExecuteQuery.ps1
@@ -14,7 +14,7 @@ $Script:MainForm.Elements.ButtonExecuteQuery.Add_Click({
 
             $Script:RunTimeData.StopWatch = [System.Diagnostics.Stopwatch]::StartNew()
 
-            $Script:PopupWindowExecuteQuery = Show-PopupWindow -Message "Executing Query..."
+            Show-ExecuteQueryPopup
 
             $Script:MainForm.Elements.ButtonSaveQuery.IsEnabled = $false
             $Script:MainForm.Elements.ButtonExecuteQuery.IsEnabled = $false
@@ -47,9 +47,7 @@ $Script:MainForm.Elements.ButtonExecuteQuery.Add_Click({
 
             if (!(Test-ConnectionRequirements) -or [string]::IsNullOrWhiteSpace($Script:AppConfig.CurrentSqlQuery.DoId)) {
                 "Omada Url not set or Query not selected, cannot retrieve data!" | Write-LogOutput -LogType WARNING
-                if ($null -ne $Script:PopupWindowExecuteQuery) {
-                    $Script:PopupWindowExecuteQuery.Close()
-                }
+                Close-ExecuteQueryPopup
                 Restore-MainFormFocus
             }
             else {

--- a/src/Lib/Functions/Private/Get-MainFormMessageBoxOwner.ps1
+++ b/src/Lib/Functions/Private/Get-MainFormMessageBoxOwner.ps1
@@ -1,0 +1,46 @@
+function Get-MainFormMessageBoxOwner {
+    <#
+    .SYNOPSIS
+    An IWin32Window for the main form, so a WinForms message box can be owned by it.
+
+    .DESCRIPTION
+    This application is WPF but raises its message boxes through System.Windows.Forms.MessageBox,
+    which takes an IWin32Window rather than a WPF Window. Without one the dialog is a top-level window
+    with no relationship to the application, and Windows will happily order it behind the main form -
+    which is exactly what happened: an error about a failed query appeared behind the application, and
+    because the dialog was modal the application underneath looked hung.
+
+    WindowInteropHelper gets the main window's HWND; NativeWindow wraps it in the interface the
+    message box wants. The caller must call ReleaseHandle() when the dialog closes - a NativeWindow
+    that keeps a handle it does not own will complain when it is finalized.
+
+    .OUTPUTS
+    A System.Windows.Forms.NativeWindow assigned to the main window's handle, or $null when there is
+    no usable window - during startup and shutdown, mainly - in which case the caller should fall back
+    to the ownerless overload rather than not showing the dialog at all.
+    #>
+    [CmdLetBinding()]
+    param()
+
+    try {
+        if ($null -eq $Script:MainForm -or $null -eq $Script:MainForm.Definition) {
+            return $null
+        }
+
+        $Private:Handle = (New-Object System.Windows.Interop.WindowInteropHelper($Script:MainForm.Definition)).Handle
+        if ($Private:Handle -eq [System.IntPtr]::Zero) {
+            # The window exists as an object but has not been shown yet, so it has no HWND to own
+            # anything.
+            return $null
+        }
+
+        $Private:Owner = New-Object System.Windows.Forms.NativeWindow
+        $Private:Owner.AssignHandle($Private:Handle)
+        return $Private:Owner
+    }
+    catch {
+        # An owner is an improvement, not a requirement. Failing to build one must never cost the
+        # user the message itself.
+        return $null
+    }
+}

--- a/src/Lib/Functions/Private/Get-OmadaHttpStatusCode.ps1
+++ b/src/Lib/Functions/Private/Get-OmadaHttpStatusCode.ps1
@@ -1,0 +1,53 @@
+function Get-OmadaHttpStatusCode {
+    <#
+    .SYNOPSIS
+    Pull the HTTP status code out of an error, or return $null when the error is not an HTTP response.
+
+    .DESCRIPTION
+    The presence of a status code is the discriminator the execute fallback rests on: if a status came
+    back, a round trip completed, so whatever went wrong is the tenant's answer rather than a broken
+    worker (see Resolve-ExecuteFallbackAction).
+
+    Two sources, in order. The exception's own Response.StatusCode is authoritative when it survives -
+    but an error that has crossed a runspace boundary has usually been flattened to text by then, so
+    the message is parsed as a fallback. That is the form the worker's failures actually arrive in:
+
+        Response status code does not indicate success: 502 (Bad Gateway).
+
+    .PARAMETER ErrorRecord
+    The error to inspect. $null is accepted and yields $null.
+
+    .OUTPUTS
+    [int] the status code, or $null when there is none to be found.
+    #>
+    [CmdLetBinding()]
+    param(
+        $ErrorRecord
+    )
+
+    if ($null -eq $ErrorRecord) {
+        return $null
+    }
+
+    try {
+        $Private:Response = $ErrorRecord.Exception.Response
+        if ($null -ne $Private:Response -and $null -ne $Private:Response.StatusCode) {
+            return [int]$Private:Response.StatusCode
+        }
+    }
+    catch {
+        # Not an HTTP exception, or the property is not reachable. The message is tried next.
+    }
+
+    try {
+        $Private:Match = [regex]::Match([string]$ErrorRecord.Exception.Message, "status code does not indicate success:\s*(\d{3})")
+        if ($Private:Match.Success) {
+            return [int]$Private:Match.Groups[1].Value
+        }
+    }
+    catch {
+        # A message that cannot be read is simply not a status code.
+    }
+
+    return $null
+}

--- a/src/Lib/Functions/Private/Get-OmadaHttpStatusCode.ps1
+++ b/src/Lib/Functions/Private/Get-OmadaHttpStatusCode.ps1
@@ -40,7 +40,11 @@ function Get-OmadaHttpStatusCode {
     }
 
     try {
-        $Private:Match = [regex]::Match([string]$ErrorRecord.Exception.Message, "status code does not indicate success:\s*(\d{3})")
+        # Case-insensitive: the wording comes from HttpClient and travels through however many layers
+        # of exception wrapping before it gets here, so pinning the casing would be betting the
+        # classification - and with it whether one tenant hiccup disables background execution - on
+        # a detail of someone else's message formatting.
+        $Private:Match = [regex]::Match([string]$ErrorRecord.Exception.Message, "status code does not indicate success:\s*(\d{3})", [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
         if ($Private:Match.Success) {
             return [int]$Private:Match.Groups[1].Value
         }

--- a/src/Lib/Functions/Private/Invoke-ExecuteQuery.ps1
+++ b/src/Lib/Functions/Private/Invoke-ExecuteQuery.ps1
@@ -116,8 +116,13 @@ function Invoke-ExecuteQuery {
                     # No worker available, or the tab is not eligible for one: run the identical
                     # chain inline. Slower - it blocks, exactly as the app did before #40 - but the
                     # same requests in the same order, because it is literally the same function.
+                    #
+                    # -AlreadyOnUiThread because this is the UI thread: there is no fallback left, so
+                    # a failure here is reported as what it is. Without it, a tenant error on this
+                    # path came back as "the request context is no longer available" - a message about
+                    # a bug that had not happened, in place of the error that had.
                     $Private:PipelineContext.Parameters = Build-OmadaRequestParameter
-                    Complete-ExecuteQueryPipeline -Outcome (Invoke-OmadaExecutePipeline -Context $Private:PipelineContext)
+                    Complete-ExecuteQueryPipeline -Outcome (Invoke-OmadaExecutePipeline -Context $Private:PipelineContext) -AlreadyOnUiThread
                     return
                 }
                 elseif ($Script:Task.Status -eq "Faulted") {
@@ -198,10 +203,10 @@ function Reset-ExecuteQueryUiState {
         # drained by the poll timer, or removed by Stop-ExecuteQueryRequest before it called here.
         Set-ExecuteQueryButtonState
 
-        if ($null -ne $Script:PopupWindowExecuteQuery) {
-            $Script:PopupWindowExecuteQuery.Close()
-            $Script:PopupWindowExecuteQuery = $null
-        }
+        # The owning tab's popup, not a shared one. Reset-ExecuteQueryUiState always runs with that
+        # tab made active - the poll timer steps into it before invoking a completion - so this closes
+        # the window that belongs to the query that just finished, and leaves other tabs' alone.
+        Close-ExecuteQueryPopup
 
         if ($null -ne $Script:RunTimeData.StopWatch) {
             $Script:RunTimeData.StopWatch.Stop()
@@ -252,11 +257,22 @@ function Invoke-ExecuteQueryOnUiThread {
 
     .PARAMETER Reason
     Why the worker could not run it, for the single warning Disable-OmadaBackgroundRequest writes.
+
+    .PARAMETER Action
+    What Resolve-ExecuteFallbackAction concluded: "Retry" to re-run here and keep using workers, or
+    "RetryAndDisable" to re-run here and stop dispatching to workers for the session.
+
+    The distinction is the point. Disabling used to happen on every fallback, so an expired session -
+    which a worker genuinely cannot recover from, but which the UI thread fixes in one sign-in - cost
+    background execution for the rest of the day even though it would have worked again immediately
+    afterwards.
     #>
     [CmdLetBinding()]
     param(
         [hashtable]$PipelineContext,
-        [string]$Reason
+        [string]$Reason,
+        [ValidateSet("Retry", "RetryAndDisable")]
+        [string]$Action = "RetryAndDisable"
     )
 
     try {
@@ -274,13 +290,16 @@ function Invoke-ExecuteQueryOnUiThread {
             return
         }
 
-        Disable-OmadaBackgroundRequest -Reason $Reason
+        if ($Action -eq "RetryAndDisable") {
+            Disable-OmadaBackgroundRequest -Reason $Reason
+        }
 
         if ($null -eq $PipelineContext) {
-            # Nothing to re-run with. Reported rather than silently ignored: this would mean the
-            # context was lost between dispatch and completion, which is a bug here rather than a
-            # problem at the tenant.
-            "Cannot retry the query on the UI thread: the request context is no longer available." | Write-ContainedErrorLog
+            # Nothing to re-run with. A genuine bug if it ever happens on the background path, so it
+            # is still reported - but at DEBUG and without a dialog, because the user can neither act
+            # on it nor be helped by a modal in front of a query that is already lost. The failure
+            # that matters has been logged by the caller.
+            "Cannot retry the query on the UI thread: the request context is no longer available." | Write-LogOutput -LogType DEBUG
             Complete-ExecuteQueryResult -QueryResult $null -SaveResult $null -TempQueryDoId $null
             return
         }
@@ -288,7 +307,12 @@ function Invoke-ExecuteQueryOnUiThread {
         "Retrying the query on the UI thread." | Write-LogOutput -LogType DEBUG
         $Private:RetryContext = $PipelineContext.Clone()
         $Private:RetryContext.Parameters = Build-OmadaRequestParameter
-        Complete-ExecuteQueryPipeline -Outcome (Invoke-OmadaExecutePipeline -Context $Private:RetryContext)
+
+        # -AlreadyOnUiThread: this IS the UI thread, so the completion must report whatever comes back
+        # rather than trying to fall back to it again. Without it the retry's own failure came back
+        # here with no context and was reported as "the request context is no longer available",
+        # which described a bug that had not happened and hid the tenant error that had.
+        Complete-ExecuteQueryPipeline -Outcome (Invoke-OmadaExecutePipeline -Context $Private:RetryContext) -AlreadyOnUiThread
     }
     catch {
         Reset-ExecuteQueryUiState
@@ -316,12 +340,22 @@ function Complete-ExecuteQueryPipeline {
 
     .PARAMETER PipelineContext
     The context the request was dispatched with. Only used to re-run the chain on the UI thread when
-    the worker could not run it at all; $null on the inline path, which has nothing to fall back to.
+    the worker could not run it at all.
+
+    .PARAMETER AlreadyOnUiThread
+    Set when the outcome came from a chain that ran inline on the UI thread - the no-worker fallback,
+    or the retry itself. There is no "retry on the UI thread" left to do in that case: this IS the UI
+    thread, so a failure is reported rather than re-driven.
+
+    Without this the inline path reported a failure as "the request context is no longer available",
+    because it called back in with no context to retry from. That message was doubly misleading - it
+    described a bug that had not happened, and it hid the real error, which was the tenant's.
     #>
     [CmdLetBinding()]
     param(
         $Outcome,
-        [hashtable]$PipelineContext
+        [hashtable]$PipelineContext,
+        [switch]$AlreadyOnUiThread
     )
 
     try {
@@ -329,8 +363,15 @@ function Complete-ExecuteQueryPipeline {
         # result, and reporting it as one is what made a failed query look like an empty one.
         if ($Outcome -is [System.Management.Automation.ErrorRecord] -or $null -eq $Outcome -or $null -eq $Outcome.Steps) {
             $Private:Reason = if ($Outcome -is [System.Management.Automation.ErrorRecord]) { $Outcome.Exception.Message } else { "the background worker returned no result" }
+
+            if ($AlreadyOnUiThread) {
+                "The query could not be run on the UI thread either: {0}" -f $Private:Reason | Write-ContainedErrorLog
+                Complete-ExecuteQueryResult -QueryResult $null -SaveResult $null -TempQueryDoId $null
+                return
+            }
+
             "The query could not be run on a background worker: {0}" -f $Private:Reason | Write-LogOutput -LogType DEBUG
-            Invoke-ExecuteQueryOnUiThread -PipelineContext $PipelineContext -Reason $Private:Reason
+            Invoke-ExecuteQueryOnUiThread -PipelineContext $PipelineContext -Reason $Private:Reason -Action "RetryAndDisable"
             return
         }
 
@@ -349,16 +390,16 @@ function Complete-ExecuteQueryPipeline {
         }
 
         if ($null -ne $Outcome.ErrorRecord) {
-            # Nothing reached the tenant: the very first request failed, so no query ran, nothing was
-            # saved and no temporary object exists. The worker could not do its job - almost always
-            # because its own OmadaWeb.PS instance has no session - and the UI thread can, so run it
-            # there rather than telling the user their query returned nothing.
-            #
-            # Gated on CompletedSteps precisely so this cannot re-run work the tenant already did. If
-            # any step succeeded, the failure is the tenant's answer and is reported as such.
-            if ([int]$Outcome.CompletedSteps -le 0) {
+            # What a failure means depends on WHERE it happened, and getting that wrong was expensive:
+            # the first version re-drove and permanently disabled background execution whenever no
+            # step had completed, so a single HTTP 502 from the tenant cost the user a responsive
+            # window for the rest of the session. A status code coming back is proof the worker
+            # reached the tenant. Resolve-ExecuteFallbackAction holds that reasoning.
+            $Private:Action = if ($AlreadyOnUiThread) { "Report" } else { Resolve-ExecuteFallbackAction -Outcome $Outcome }
+
+            if ($Private:Action -ne "Report") {
                 "The query could not be run on a background worker: {0}" -f $Outcome.ErrorRecord.Exception.Message | Write-LogOutput -LogType DEBUG
-                Invoke-ExecuteQueryOnUiThread -PipelineContext $PipelineContext -Reason $Outcome.ErrorRecord.Exception.Message
+                Invoke-ExecuteQueryOnUiThread -PipelineContext $PipelineContext -Reason $Outcome.ErrorRecord.Exception.Message -Action $Private:Action
                 return
             }
 

--- a/src/Lib/Functions/Private/New-TabSession.ps1
+++ b/src/Lib/Functions/Private/New-TabSession.ps1
@@ -91,6 +91,10 @@ function New-TabSession {
             TabItem          = $null
             ConnectionStatus = $false
             PendingTask      = $null
+            # The "Executing Query..." window, per tab. Module scope is what it used to be, and that
+            # made one tab's popup appear over every other tab and leaked a window that nothing could
+            # close once a second tab started a query. See Show-ExecuteQueryPopup.
+            ExecutePopup     = $null
             CurrentUrl       = $null
             AppConfig        = $(if ($null -ne $RestoreFrom) { $RestoreFrom } else { $DefaultTabConfig })
             RunTimeData      = [PSCustomObject]@{

--- a/src/Lib/Functions/Private/Resolve-ExecuteFallbackAction.ps1
+++ b/src/Lib/Functions/Private/Resolve-ExecuteFallbackAction.ps1
@@ -1,0 +1,87 @@
+function Resolve-ExecuteFallbackAction {
+    <#
+    .SYNOPSIS
+    Decide what a failed background execute means: re-run it on the UI thread, stop using background
+    workers altogether, or simply report what the tenant said.
+
+    .DESCRIPTION
+    This exists because the first version of the fallback got the distinction wrong, with real
+    consequences. It treated "the pipeline failed before completing a step" as "the worker cannot run
+    requests", so a single HTTP 502 from the tenant permanently disabled background execution for the
+    rest of the session - the window stopped staying responsive for the rest of the day because of one
+    transient blip at the far end.
+
+    A Bad Gateway says nothing about the worker. If an HTTP status came back at all, the worker
+    reached the tenant, which is proof it works. The three outcomes are therefore:
+
+      Report            The tenant answered, with something other than 401. Re-running on the UI
+                        thread would send the identical request and get the identical answer, so the
+                        only useful thing to do is tell the user what happened.
+
+      Retry             Worth one attempt on the UI thread, but the worker is not written off. A 401
+                        is the case that matters: the session has expired and a worker cannot sign in,
+                        but the UI thread can - and once it has, the worker may well work again.
+
+      RetryAndDisable   The worker produced nothing at all, or failed in a way that means it can never
+                        run a request in this session - no WebView2 runtime, an interactive sign-in
+                        attempted where no window can exist. Retry on the UI thread and stop
+                        dispatching to workers.
+
+    Deliberately conservative: an unrecognised failure is Retry, never RetryAndDisable. Disabling is
+    a one-way door for the session, so it is taken only on evidence, not on the absence of it.
+
+    .PARAMETER Outcome
+    The pipeline outcome from Invoke-OmadaExecutePipeline, or $null when the worker returned nothing.
+
+    .OUTPUTS
+    [string] one of "Report", "Retry", "RetryAndDisable".
+    #>
+    [CmdLetBinding()]
+    [OutputType([string])]
+    param(
+        $Outcome
+    )
+
+    # Nothing came back: the worker died, could not load its module, or never ran. There is no
+    # evidence it can serve anything, and the query still has to happen.
+    if ($null -eq $Outcome -or $null -eq $Outcome.ErrorRecord) {
+        return "RetryAndDisable"
+    }
+
+    # Any completed step is proof the worker can reach the tenant. Whatever failed afterwards is the
+    # tenant's answer, and re-running it would repeat work the tenant has already done - including,
+    # potentially, executing the query a second time.
+    if ([int]$Outcome.CompletedSteps -gt 0) {
+        return "Report"
+    }
+
+    $Private:StatusCode = Get-OmadaHttpStatusCode -ErrorRecord $Outcome.ErrorRecord
+    if ($null -ne $Private:StatusCode) {
+        # A status code means a round trip completed. The worker is fine.
+        if ($Private:StatusCode -eq 401) {
+            return "Retry"
+        }
+
+        return "Report"
+    }
+
+    # No status code. Look for the failures that mean this worker can never run a request: they all
+    # come from a worker being pushed into an interactive sign-in it cannot perform. Matched on text
+    # because the exception arrives flattened across the runspace boundary.
+    $Private:Message = [string]$Outcome.ErrorRecord.Exception.Message
+    $Private:WorkerFailurePattern = @(
+        "WebView2RuntimeNotFoundException"
+        "Couldn't find a compatible Webview2 Runtime"
+        "Error creating CoreWebView2Environment"
+        "Start-WebView2Login"
+        "Login try count exceeded"
+    )
+
+    foreach ($Private:Pattern in $Private:WorkerFailurePattern) {
+        if ($Private:Message -like ("*{0}*" -f $Private:Pattern)) {
+            return "RetryAndDisable"
+        }
+    }
+
+    return "Retry"
+}

--- a/src/Lib/Functions/Private/Show-ExecuteQueryPopup.ps1
+++ b/src/Lib/Functions/Private/Show-ExecuteQueryPopup.ps1
@@ -1,0 +1,123 @@
+function Show-ExecuteQueryPopup {
+    <#
+    .SYNOPSIS
+    Show the "Executing Query..." popup for the tab that started the query.
+
+    .DESCRIPTION
+    The popup used to live in a single module-scope slot, $Script:PopupWindowExecuteQuery, and that
+    one fact produced both of the symptoms reported against it.
+
+    Unlike $Script:MainForm.Elements, $Script:RunTimeData and $Script:AppConfig, that slot was NOT
+    repointed by Set-ActiveTabContext, so it was shared by every tab. The window is owned by the main
+    form, so it floated above the application no matter which tab was on screen - a tab that was not
+    running anything still showed "Executing Query...". And because a second execute overwrote the
+    slot, the first tab's window was orphaned: nothing held a reference to it any more, so nothing
+    could ever close it, and it stayed on screen until the application exited.
+
+    The popup now belongs to its tab session, like the pending request that owns it, and visibility is
+    driven by which tab is actually on screen.
+    #>
+    [CmdLetBinding()]
+    param()
+
+    try {
+        $Private:TabSession = Get-ActiveTabSession
+        if ($null -eq $Private:TabSession) {
+            return
+        }
+
+        # A popup already up for this tab is reused rather than replaced. Replacing it is exactly what
+        # orphaned windows before.
+        if ($null -ne $Private:TabSession.ExecutePopup) {
+            Sync-ExecuteQueryPopupVisibility
+            return
+        }
+
+        $Private:TabSession.ExecutePopup = Show-PopupWindow -Message "Executing Query..."
+        Sync-ExecuteQueryPopupVisibility
+    }
+    catch {
+        # Cosmetic. A popup that cannot be shown must never stop a query from running.
+        "Could not show the executing-query popup: {0}" -f $_.Exception.Message | Write-LogOutput -LogType DEBUG
+    }
+}
+
+function Close-ExecuteQueryPopup {
+    <#
+    .SYNOPSIS
+    Close the "Executing Query..." popup belonging to the active tab.
+
+    .DESCRIPTION
+    Called from Reset-ExecuteQueryUiState, which always runs with the owning tab made active - the
+    completion poll timer steps into the tab before invoking a completion - so "the active tab" is
+    the right tab here.
+
+    .PARAMETER TabSession
+    The tab whose popup to close. Defaults to the active tab.
+    #>
+    [CmdLetBinding()]
+    param(
+        $TabSession
+    )
+
+    try {
+        $Private:Target = if ($null -ne $TabSession) { $TabSession } else { Get-ActiveTabSession }
+        if ($null -eq $Private:Target -or $null -eq $Private:Target.ExecutePopup) {
+            return
+        }
+
+        try {
+            $Private:Target.ExecutePopup.Close()
+        }
+        catch {
+            # Already closed, or the window is gone with the application shutting down.
+        }
+
+        $Private:Target.ExecutePopup = $null
+    }
+    catch {
+        "Could not close the executing-query popup: {0}" -f $_.Exception.Message | Write-LogOutput -LogType DEBUG
+    }
+}
+
+function Sync-ExecuteQueryPopupVisibility {
+    <#
+    .SYNOPSIS
+    Show the popup of the tab currently on screen and hide every other tab's.
+
+    .DESCRIPTION
+    Keyed off the tab control's own SelectedItem rather than $Script:ActiveTabId, and that is
+    deliberate. $Script:ActiveTabId moves twice for every completion - the poll timer steps into the
+    owning tab and restores afterwards - so driving visibility from it would flicker the popup on and
+    off against tabs the user is not even looking at. The tab control's selection only changes when
+    the user actually switches tabs, which is precisely the question being asked here.
+    #>
+    [CmdLetBinding()]
+    param()
+
+    try {
+        $Private:Selected = (Get-TabControlSessions).SelectedItem
+
+        foreach ($Private:Tab in @($Script:Tabs)) {
+            if ($null -eq $Private:Tab -or $null -eq $Private:Tab.ExecutePopup) {
+                continue
+            }
+
+            try {
+                if ($null -ne $Private:Selected -and $Private:Tab.TabItem -eq $Private:Selected) {
+                    $Private:Tab.ExecutePopup.Show()
+                }
+                else {
+                    $Private:Tab.ExecutePopup.Hide()
+                }
+            }
+            catch {
+                # One window that will not co-operate must not stop the others being corrected.
+                continue
+            }
+        }
+    }
+    catch {
+        "Could not synchronise executing-query popups: {0}" -f $_.Exception.Message | Write-LogOutput -LogType DEBUG
+    }
+}

--- a/src/Lib/Functions/Private/Write-LogOutput.ps1
+++ b/src/Lib/Functions/Private/Write-LogOutput.ps1
@@ -126,7 +126,10 @@ function Write-LogOutput {
                 $LogMessage.ShowWarning = $true
                 $LogMessageDialog.Show = $true
                 $LogMessageDialog.Text = "Warning:`r`n`r`n{0}" -f $LogMessageDialog.Text
-                $LogMessageDialog.Title = "Warning"
+                # Named after the tab it came from. With several tabs open - and queries now running
+                # in the background, so a message can arrive for a tab the user is not looking at -
+                # "Warning" alone does not say which query is being complained about.
+                $LogMessageDialog.Title = "Warning - {0}" -f $TabContext
                 $LogMessageDialog.Icon = [System.Windows.Forms.MessageBoxIcon]::Warning
                 $LogMessage.Color = "Yellow"
                 if ($null -ne $Script:PopUpWindowQueryRefresh) {
@@ -141,7 +144,8 @@ function Write-LogOutput {
                 catch {}
                 $LogMessage.ShowError = $true
                 $LogMessageDialog.Show = $true
-                $LogMessageDialog.Title = "Error"
+                # Named after the tab it came from - see the Warning branch above for why.
+                $LogMessageDialog.Title = "Error - {0}" -f $TabContext
                 try {
                     if ($Null -ne $ErrorObject) {
                         if ($null -ne $ErrorObject.Exception?.StatusCode) {
@@ -182,7 +186,27 @@ function Write-LogOutput {
             try {
                 if ($null -ne $Script:MainForm -and $null -ne $Script:MainForm.Definition -and $Script:MainForm.Definition.IsVisible) {
                     $TrimmedText = Limit-MessageBoxText -Text $LogMessageDialog.Text
-                    [System.Windows.Forms.MessageBox]::Show($TrimmedText, $LogMessageDialog.Title, [System.Windows.Forms.MessageBoxButtons]::OK, $LogMessageDialog.Icon)
+
+                    # Owned by the main window. Without an owner a WinForms MessageBox raised from a
+                    # WPF application is a top-level window with no relationship to it, so Windows is
+                    # free to order it behind the main form - which it did: an error about a failed
+                    # query appeared behind the application, and the application looked hung because
+                    # the dialog underneath it was modal. The owner also gives the dialog somewhere
+                    # sensible to centre itself.
+                    $Private:DialogOwner = Get-MainFormMessageBoxOwner
+                    try {
+                        if ($null -ne $Private:DialogOwner) {
+                            [System.Windows.Forms.MessageBox]::Show($Private:DialogOwner, $TrimmedText, $LogMessageDialog.Title, [System.Windows.Forms.MessageBoxButtons]::OK, $LogMessageDialog.Icon)
+                        }
+                        else {
+                            [System.Windows.Forms.MessageBox]::Show($TrimmedText, $LogMessageDialog.Title, [System.Windows.Forms.MessageBoxButtons]::OK, $LogMessageDialog.Icon)
+                        }
+                    }
+                    finally {
+                        if ($null -ne $Private:DialogOwner) {
+                            try { $Private:DialogOwner.ReleaseHandle() } catch { }
+                        }
+                    }
                     Restore-MainFormFocus
                 }
                 else {

--- a/tests/Invoke-ExecuteQuery.Tests.ps1
+++ b/tests/Invoke-ExecuteQuery.Tests.ps1
@@ -32,11 +32,18 @@ BeforeAll {
     # assert nothing.
     . (Join-Path $PrivatePath -ChildPath "Write-ContainedErrorLog.ps1")
     . (Join-Path $PrivatePath -ChildPath "Write-ExecutePipelineLog.ps1")
+    # The real classifier, not a stub: deciding what a failure means IS the behaviour under test in
+    # the fallback suite below, and a stub would assert nothing.
+    . (Join-Path $PrivatePath -ChildPath "Get-OmadaHttpStatusCode.ps1")
+    . (Join-Path $PrivatePath -ChildPath "Resolve-ExecuteFallbackAction.ps1")
+    . (Join-Path $PrivatePath -ChildPath "Show-ExecuteQueryPopup.ps1")
     . (Join-Path $PrivatePath -ChildPath "Invoke-ExecuteQuery.ps1")
 
     $Script:Tracer = [System.Diagnostics.Trace]
 
-    function Get-ActiveTabSession { return [pscustomobject]@{ Id = "tab-A" } }
+    # The popup lives on the tab session now, so the teardown reaches it through here.
+    function Get-ActiveTabSession { return $Script:TestTabSession }
+    function Get-TabControlSessions { return [pscustomobject]@{ SelectedItem = $Script:TestTabSession.TabItem } }
 
     # --- Collaborators of the UI-thread re-drive ---------------------------------------------------
     $script:DisableReasons = [System.Collections.Generic.List[string]]::new()
@@ -139,7 +146,8 @@ BeforeAll {
         $Script:ConnectionStatus = $true
         # No request outstanding, so the button state resolves to "Execute".
         $Script:PendingWebViewCompletions = [System.Collections.Generic.List[object]]::new()
-        $Script:PopupWindowExecuteQuery = New-PopupStub
+        $Script:TestTabSession = [pscustomobject]@{ Id = "tab-A"; DisplayName = "Tab A"; TabItem = "item-A"; ExecutePopup = (New-PopupStub) }
+        $Script:Tabs = @($Script:TestTabSession)
         $Script:AppConfig = [PSCustomObject]@{
             CurrentSqlQuery = [PSCustomObject]@{ DoId = 100; FullName = "TestQuery - 100" }
         }
@@ -216,14 +224,14 @@ Describe "Reset-ExecuteQueryUiState" {
     }
 
     It "closes the 'Executing Query...' popup and forgets it" {
-        $Popup = $Script:PopupWindowExecuteQuery
+        $Popup = $Script:TestTabSession.ExecutePopup
 
         Reset-ExecuteQueryUiState
 
         $Popup.Closed | Should -BeTrue
         # Nulled as well as closed: a stale reference would be Close()d a second time by the next
         # execute's teardown.
-        $Script:PopupWindowExecuteQuery | Should -BeNullOrEmpty
+        $Script:TestTabSession.ExecutePopup | Should -BeNullOrEmpty
     }
 
     It "stops the stopwatch and writes its value to the status bar" {
@@ -248,7 +256,7 @@ Describe "Reset-ExecuteQueryUiState" {
     }
 
     It "does not throw when there is no popup and no stopwatch" {
-        $Script:PopupWindowExecuteQuery = $null
+        $Script:TestTabSession.ExecutePopup = $null
         $Script:RunTimeData.StopWatch = $null
 
         { Reset-ExecuteQueryUiState } | Should -Not -Throw
@@ -487,7 +495,7 @@ Describe "Complete-ExecuteQueryPipeline does not retry a tab that was torn down"
 
         # Disconnected, so the query controls stay disabled - but the popup is closed, the stopwatch
         # stopped and the button reads Execute rather than Cancel.
-        $Script:PopupWindowExecuteQuery | Should -BeNullOrEmpty
+        $Script:TestTabSession.ExecutePopup | Should -BeNullOrEmpty
         $Script:MainForm.Elements.ButtonExecuteQueryText.Text | Should -Be "_Execute"
         $Script:RunTimeData.StopWatch.IsRunning | Should -BeFalse
     }
@@ -617,5 +625,106 @@ Describe "Complete-ExecuteQueryPipeline reports a tenant failure once" {
 
         @($script:ReplayedLines) | Should -Contain "QueryUrl: https://tenant.omada.cloud/api/x"
         @($script:ErrorLines).Count | Should -Be 0
+    }
+}
+
+Describe "A tenant error does not cost the session its background worker" {
+    # Reported from a live session. One HTTP 502 from the tenant permanently disabled background
+    # execution, and every query afterwards then failed with "the request context is no longer
+    # available" - a message about a bug that had not happened, in place of the tenant error that had.
+
+    BeforeEach {
+        Initialize-ExecuteQueryTestState
+        $script:Context = @{ BaseUrl = "https://tenant.omada.cloud"; QueryDoId = 100 }
+        $script:BadGateway = New-PipelineOutcome -ErrorRecord (New-TestErrorRecord "Response status code does not indicate success: 502 (Bad Gateway).") -CompletedSteps 0
+    }
+
+    It "does not disable background execution over a 502" {
+        Complete-ExecuteQueryPipeline -Outcome $script:BadGateway -PipelineContext $script:Context
+
+        @($script:DisableReasons).Count | Should -Be 0
+    }
+
+    It "does not re-run a 502 on the UI thread, because it would get the same answer" {
+        Complete-ExecuteQueryPipeline -Outcome $script:BadGateway -PipelineContext $script:Context
+
+        @($script:InlinePipelineRuns).Count | Should -Be 0
+    }
+
+    It "still returns the tab to a usable state" {
+        Complete-ExecuteQueryPipeline -Outcome $script:BadGateway -PipelineContext $script:Context
+
+        $Script:MainForm.Elements.ButtonExecuteQuery.IsEnabled | Should -BeTrue
+        $Script:TestTabSession.ExecutePopup | Should -BeNullOrEmpty
+    }
+
+    It "still re-runs and disables when the worker genuinely cannot sign in" {
+        # The other side of the gate: this failure really does mean the worker is useless here.
+        $Private:Message = "Start-WebView2Login - Couldn't find a compatible Webview2 Runtime installation to host WebViews."
+        $Private:Failed = New-PipelineOutcome -ErrorRecord (New-TestErrorRecord $Private:Message) -CompletedSteps 0
+
+        Complete-ExecuteQueryPipeline -Outcome $Private:Failed -PipelineContext $script:Context
+
+        @($script:InlinePipelineRuns).Count | Should -Be 1
+        @($script:DisableReasons).Count | Should -Be 1
+    }
+
+    It "re-runs an expired session on the UI thread without writing off the worker" {
+        # A worker cannot sign in; the UI thread can. Once it has, the worker may work again - so
+        # disabling here would give up something that was about to start working.
+        $Private:Expired = New-PipelineOutcome -ErrorRecord (New-TestErrorRecord "Response status code does not indicate success: 401 (Unauthorized).") -CompletedSteps 0
+
+        Complete-ExecuteQueryPipeline -Outcome $Private:Expired -PipelineContext $script:Context
+
+        @($script:InlinePipelineRuns).Count | Should -Be 1
+        @($script:DisableReasons).Count | Should -Be 0
+    }
+}
+
+Describe "A chain that already ran on the UI thread does not try to fall back to it" {
+    # The second half of the reported failure. The inline path called back in with no context to
+    # retry from, so its own failure was reported as "the request context is no longer available"
+    # instead of the tenant error - and every subsequent execute repeated it, because background
+    # execution had been disabled and every query now took that path.
+
+    BeforeEach {
+        Initialize-ExecuteQueryTestState
+        $script:ErrorLines = [System.Collections.Generic.List[string]]::new()
+        Mock Write-LogOutput {
+            if ($LogType -eq "ERROR") { $script:ErrorLines.Add([string]$InputObject) }
+        }
+    }
+
+    It "does not report a missing request context when the inline run fails" {
+        $Private:Failed = New-PipelineOutcome -ErrorRecord (New-TestErrorRecord "Response status code does not indicate success: 502 (Bad Gateway).") -CompletedSteps 0
+
+        Complete-ExecuteQueryPipeline -Outcome $Private:Failed -AlreadyOnUiThread
+
+        ($script:ErrorLines -join " ") | Should -Not -Match "request context is no longer available"
+    }
+
+    It "reports the tenant's error instead" {
+        $Private:Failed = New-PipelineOutcome -ErrorRecord (New-TestErrorRecord "Response status code does not indicate success: 502 (Bad Gateway).") -CompletedSteps 0
+
+        Complete-ExecuteQueryPipeline -Outcome $Private:Failed -AlreadyOnUiThread
+
+        ($script:ErrorLines -join " ") | Should -Match "502"
+    }
+
+    It "never re-drives, whatever the failure looks like" {
+        $Private:Message = "Start-WebView2Login - Couldn't find a compatible Webview2 Runtime installation to host WebViews."
+        $Private:Failed = New-PipelineOutcome -ErrorRecord (New-TestErrorRecord $Private:Message) -CompletedSteps 0
+
+        Complete-ExecuteQueryPipeline -Outcome $Private:Failed -PipelineContext @{ BaseUrl = "x"; QueryDoId = 1 } -AlreadyOnUiThread
+
+        @($script:InlinePipelineRuns).Count | Should -Be 0
+        @($script:DisableReasons).Count | Should -Be 0
+    }
+
+    It "reports a worker that returned nothing rather than looping" {
+        Complete-ExecuteQueryPipeline -Outcome $null -AlreadyOnUiThread
+
+        @($script:InlinePipelineRuns).Count | Should -Be 0
+        $Script:MainForm.Elements.ButtonExecuteQuery.IsEnabled | Should -BeTrue
     }
 }

--- a/tests/Resolve-ExecuteFallbackAction.Tests.ps1
+++ b/tests/Resolve-ExecuteFallbackAction.Tests.ps1
@@ -1,0 +1,117 @@
+#Requires -Version 7.0
+# The bug this settles, from a live session: a single HTTP 502 from the tenant permanently disabled
+# background query execution for the rest of the session. The old rule was "no step completed => the
+# worker cannot run requests", which is simply not what a Bad Gateway means. A status code coming back
+# is proof the worker reached the tenant.
+
+BeforeAll {
+    $ParentPath = Split-Path -Path $PSScriptRoot -Parent
+    $PrivatePath = Join-Path $ParentPath -ChildPath "src\Lib\Functions\Private"
+    . (Join-Path $PrivatePath -ChildPath "Get-OmadaHttpStatusCode.ps1")
+    . (Join-Path $PrivatePath -ChildPath "Resolve-ExecuteFallbackAction.ps1")
+
+    function script:New-Outcome {
+        param(
+            [string]$Message = "boom",
+            [int]$CompletedSteps = 0,
+            [switch]$NoError
+        )
+        return @{
+            CompletedSteps = $CompletedSteps
+            ErrorRecord    = $(if ($NoError) { $null } else {
+                    [System.Management.Automation.ErrorRecord]::new(
+                        [System.Exception]::new($Message), "TestFailure",
+                        [System.Management.Automation.ErrorCategory]::ConnectionError, $null)
+                })
+        }
+    }
+}
+
+Describe "Resolve-ExecuteFallbackAction" {
+    Context "The tenant answered" {
+        It "reports a 502 instead of blaming the worker" {
+            # The exact regression. Re-running a 502 on the UI thread sends the identical request and
+            # gets the identical answer, and disabling background execution over it costs the user a
+            # responsive window all day for one transient blip at the far end.
+            New-Outcome -Message "Response status code does not indicate success: 502 (Bad Gateway)." |
+                ForEach-Object { Resolve-ExecuteFallbackAction -Outcome $_ } | Should -Be "Report"
+        }
+
+        It "reports a 500" {
+            New-Outcome -Message "Response status code does not indicate success: 500 (Internal Server Error)." |
+                ForEach-Object { Resolve-ExecuteFallbackAction -Outcome $_ } | Should -Be "Report"
+        }
+
+        It "reports a 404" {
+            New-Outcome -Message "Response status code does not indicate success: 404 (Not Found)." |
+                ForEach-Object { Resolve-ExecuteFallbackAction -Outcome $_ } | Should -Be "Report"
+        }
+
+        It "retries a 401 without writing off the worker" {
+            # The session expired. A worker cannot sign in, but the UI thread can - and once it has,
+            # the worker may well work again, so disabling would be the wrong conclusion.
+            New-Outcome -Message "Response status code does not indicate success: 401 (Unauthorized)." |
+                ForEach-Object { Resolve-ExecuteFallbackAction -Outcome $_ } | Should -Be "Retry"
+        }
+
+        It "reports rather than retries once any step has completed" {
+            # Re-running could execute the query a second time against the tenant.
+            New-Outcome -Message "something failed later" -CompletedSteps 2 |
+                ForEach-Object { Resolve-ExecuteFallbackAction -Outcome $_ } | Should -Be "Report"
+        }
+    }
+
+    Context "The worker could not run the request" {
+        It "disables when nothing came back at all" {
+            Resolve-ExecuteFallbackAction -Outcome $null | Should -Be "RetryAndDisable"
+        }
+
+        It "disables when the outcome carries no error and no evidence of work" {
+            Resolve-ExecuteFallbackAction -Outcome (New-Outcome -NoError) | Should -Be "RetryAndDisable"
+        }
+
+        It "disables when the worker was pushed into a sign-in it cannot perform" {
+            # The failure observed on a real machine: an MTA worker has no desktop to host WebView2.
+            $Private:Message = "Start-WebView2Login - Error creating CoreWebView2Environment ... Microsoft.Web.WebView2.Core.WebView2RuntimeNotFoundException: Couldn't find a compatible Webview2 Runtime installation to host WebViews."
+            Resolve-ExecuteFallbackAction -Outcome (New-Outcome -Message $Private:Message) | Should -Be "RetryAndDisable"
+        }
+    }
+
+    Context "Anything else" {
+        It "retries but does not disable, because disabling is a one-way door" {
+            # Conservative on purpose: an unrecognised failure is not evidence that the worker is
+            # incapable, and the cost of being wrong is asymmetric.
+            Resolve-ExecuteFallbackAction -Outcome (New-Outcome -Message "something nobody has seen before") | Should -Be "Retry"
+        }
+    }
+}
+
+Describe "Get-OmadaHttpStatusCode" {
+    It "reads the code from the message a worker's error arrives as" {
+        $Private:Record = [System.Management.Automation.ErrorRecord]::new(
+            [System.Exception]::new("Response status code does not indicate success: 502 (Bad Gateway)."), "x",
+            [System.Management.Automation.ErrorCategory]::ConnectionError, $null)
+
+        Get-OmadaHttpStatusCode -ErrorRecord $Private:Record | Should -Be 502
+    }
+
+    It "prefers the exception's own status when it survived" {
+        $Private:Exception = [System.Exception]::new("no code in this text")
+        $Private:Exception | Add-Member -NotePropertyName Response -NotePropertyValue ([pscustomobject]@{ StatusCode = 503 }) -Force
+        $Private:Record = [System.Management.Automation.ErrorRecord]::new($Private:Exception, "x", [System.Management.Automation.ErrorCategory]::ConnectionError, $null)
+
+        Get-OmadaHttpStatusCode -ErrorRecord $Private:Record | Should -Be 503
+    }
+
+    It "returns null when the failure is not an HTTP response" {
+        $Private:Record = [System.Management.Automation.ErrorRecord]::new(
+            [System.Exception]::new("Couldn't find a compatible Webview2 Runtime"), "x",
+            [System.Management.Automation.ErrorCategory]::NotInstalled, $null)
+
+        Get-OmadaHttpStatusCode -ErrorRecord $Private:Record | Should -BeNullOrEmpty
+    }
+
+    It "returns null for a null error" {
+        Get-OmadaHttpStatusCode -ErrorRecord $null | Should -BeNullOrEmpty
+    }
+}

--- a/tests/Resolve-ExecuteFallbackAction.Tests.ps1
+++ b/tests/Resolve-ExecuteFallbackAction.Tests.ps1
@@ -103,6 +103,17 @@ Describe "Get-OmadaHttpStatusCode" {
         Get-OmadaHttpStatusCode -ErrorRecord $Private:Record | Should -Be 503
     }
 
+    It "does not depend on the casing of someone else's message" {
+        # The wording comes from HttpClient and is wrapped by however many layers before it reaches
+        # here. Pinning the casing would bet the whole classification - and with it whether one tenant
+        # hiccup disables background execution - on a formatting detail.
+        $Private:Record = [System.Management.Automation.ErrorRecord]::new(
+            [System.Exception]::new("Response Status Code Does Not Indicate Success: 502 (Bad Gateway)."), "x",
+            [System.Management.Automation.ErrorCategory]::ConnectionError, $null)
+
+        Get-OmadaHttpStatusCode -ErrorRecord $Private:Record | Should -Be 502
+    }
+
     It "returns null when the failure is not an HTTP response" {
         $Private:Record = [System.Management.Automation.ErrorRecord]::new(
             [System.Exception]::new("Couldn't find a compatible Webview2 Runtime"), "x",

--- a/tests/Show-ExecuteQueryPopup.Tests.ps1
+++ b/tests/Show-ExecuteQueryPopup.Tests.ps1
@@ -1,0 +1,158 @@
+#Requires -Version 7.0
+# Two reported symptoms, one cause: $Script:PopupWindowExecuteQuery was a single module-scope slot
+# that Set-ActiveTabContext does NOT repoint, so it was shared by every tab. The window is owned by
+# the main form, so it floated over tabs that were not running anything - and a second execute
+# overwrote the slot, orphaning the first window so that nothing could ever close it.
+
+BeforeAll {
+    $ParentPath = Split-Path -Path $PSScriptRoot -Parent
+    $PrivatePath = Join-Path $ParentPath -ChildPath "src\Lib\Functions\Private"
+    . (Join-Path $PrivatePath -ChildPath "Show-ExecuteQueryPopup.ps1")
+
+    function Write-LogOutput {
+        param([Parameter(ValueFromPipeline = $true)]$InputObject, [string]$LogType, $ErrorObject, [switch]$SkipDialog)
+        process { }
+    }
+
+    # A stand-in for the WPF window that records what was asked of it, so the tests can assert on
+    # visibility without a display.
+    function script:New-FakePopup {
+        $Popup = [pscustomobject]@{ Visible = $false; Closed = $false }
+        $Popup | Add-Member -MemberType ScriptMethod -Name Show -Value { $this.Visible = $true } -Force
+        $Popup | Add-Member -MemberType ScriptMethod -Name Hide -Value { $this.Visible = $false } -Force
+        $Popup | Add-Member -MemberType ScriptMethod -Name Close -Value { $this.Closed = $true; $this.Visible = $false } -Force
+        return $Popup
+    }
+
+    function script:New-FakeTab {
+        param([string]$Id)
+        return [pscustomobject]@{ Id = $Id; DisplayName = $Id; TabItem = [pscustomobject]@{ Name = $Id }; ExecutePopup = $null }
+    }
+
+    function Show-PopupWindow { param($Message) return New-FakePopup }
+
+    function script:Initialize-PopupTestState {
+        $Script:TabA = New-FakeTab -Id "A"
+        $Script:TabB = New-FakeTab -Id "B"
+        $Script:Tabs = @($Script:TabA, $Script:TabB)
+        $Script:SelectedTabItem = $Script:TabA.TabItem
+        $Script:ActiveTabForTest = $Script:TabA
+    }
+
+    function Get-TabControlSessions { return [pscustomobject]@{ SelectedItem = $Script:SelectedTabItem } }
+    function Get-ActiveTabSession { return $Script:ActiveTabForTest }
+}
+
+Describe "Show-ExecuteQueryPopup" {
+    BeforeEach { Initialize-PopupTestState }
+
+    It "puts the popup on the tab that started the query, not in module scope" {
+        Show-ExecuteQueryPopup
+
+        $Script:TabA.ExecutePopup | Should -Not -BeNullOrEmpty
+        $Script:TabB.ExecutePopup | Should -BeNullOrEmpty
+    }
+
+    It "does not replace a popup the tab already has" {
+        # Replacing it is what orphaned windows: the old object was dropped, so nothing could close it.
+        Show-ExecuteQueryPopup
+        $Private:First = $Script:TabA.ExecutePopup
+
+        Show-ExecuteQueryPopup
+
+        $Script:TabA.ExecutePopup | Should -Be $Private:First
+        $Private:First.Closed | Should -BeFalse
+    }
+
+    It "gives each tab its own popup" {
+        Show-ExecuteQueryPopup
+        $Script:ActiveTabForTest = $Script:TabB
+        Show-ExecuteQueryPopup
+
+        $Script:TabA.ExecutePopup | Should -Not -Be $Script:TabB.ExecutePopup
+    }
+}
+
+Describe "Sync-ExecuteQueryPopupVisibility" {
+    BeforeEach { Initialize-PopupTestState }
+
+    It "hides the popup of a tab that is not on screen" {
+        # The reported symptom: switching to a tab that is not running anything still showed
+        # "Executing Query...".
+        Show-ExecuteQueryPopup
+        $Script:TabA.ExecutePopup.Visible | Should -BeTrue
+
+        $Script:SelectedTabItem = $Script:TabB.TabItem
+        Sync-ExecuteQueryPopupVisibility
+
+        $Script:TabA.ExecutePopup.Visible | Should -BeFalse
+    }
+
+    It "shows it again when the user switches back" {
+        Show-ExecuteQueryPopup
+        $Script:SelectedTabItem = $Script:TabB.TabItem
+        Sync-ExecuteQueryPopupVisibility
+
+        $Script:SelectedTabItem = $Script:TabA.TabItem
+        Sync-ExecuteQueryPopupVisibility
+
+        $Script:TabA.ExecutePopup.Visible | Should -BeTrue
+    }
+
+    It "leaves tabs with no popup alone" {
+        { Sync-ExecuteQueryPopupVisibility } | Should -Not -Throw
+        $Script:TabB.ExecutePopup | Should -BeNullOrEmpty
+    }
+
+    It "shows only the selected tab's popup when two tabs are executing" {
+        Show-ExecuteQueryPopup
+        $Script:ActiveTabForTest = $Script:TabB
+        Show-ExecuteQueryPopup
+
+        $Script:SelectedTabItem = $Script:TabB.TabItem
+        Sync-ExecuteQueryPopupVisibility
+
+        $Script:TabA.ExecutePopup.Visible | Should -BeFalse
+        $Script:TabB.ExecutePopup.Visible | Should -BeTrue
+    }
+}
+
+Describe "Close-ExecuteQueryPopup" {
+    BeforeEach { Initialize-PopupTestState }
+
+    It "closes the owning tab's popup and clears the slot" {
+        Show-ExecuteQueryPopup
+        $Private:Popup = $Script:TabA.ExecutePopup
+
+        Close-ExecuteQueryPopup
+
+        $Private:Popup.Closed | Should -BeTrue
+        $Script:TabA.ExecutePopup | Should -BeNullOrEmpty
+    }
+
+    It "does not touch another tab's popup" {
+        Show-ExecuteQueryPopup
+        $Script:ActiveTabForTest = $Script:TabB
+        Show-ExecuteQueryPopup
+
+        Close-ExecuteQueryPopup
+
+        $Script:TabB.ExecutePopup | Should -BeNullOrEmpty
+        $Script:TabA.ExecutePopup | Should -Not -BeNullOrEmpty
+        $Script:TabA.ExecutePopup.Closed | Should -BeFalse
+    }
+
+    It "can close a specific tab's popup regardless of which tab is active" {
+        Show-ExecuteQueryPopup
+        $Private:Popup = $Script:TabA.ExecutePopup
+        $Script:ActiveTabForTest = $Script:TabB
+
+        Close-ExecuteQueryPopup -TabSession $Script:TabA
+
+        $Private:Popup.Closed | Should -BeTrue
+    }
+
+    It "is safe to call when there is nothing to close" {
+        { Close-ExecuteQueryPopup } | Should -Not -Throw
+    }
+}

--- a/tests/e2e/Drivers.ps1
+++ b/tests/e2e/Drivers.ps1
@@ -181,6 +181,36 @@ function script:New-E2EConnectedTab {
     return (Get-ActiveTabSession)
 }
 
+function script:Test-E2EExecutePopupClosed {
+    <#
+    Whether no tab is still showing an "Executing Query..." popup.
+
+    Asserted across every tab rather than just the active one, and that matters: the popup used to be
+    a single module-scope slot, and a second execute overwrote it - orphaning the first tab's window
+    so nothing could ever close it. A check that only looked at the active tab would miss exactly that.
+
+    These assertions used to read $Script:PopupWindowExecuteQuery, which no longer exists. That is not
+    a compile error in PowerShell - it is simply always $null - so they would have kept passing while
+    testing nothing at all.
+    #>
+    foreach ($Tab in @($Script:Tabs)) {
+        if ($null -ne $Tab -and $null -ne $Tab.ExecutePopup) {
+            return $false
+        }
+    }
+
+    # Clearing the tab's slot is not the same as closing the window, and the regression being guarded
+    # against is exactly a window that nobody closed. Asserting only the slot passes a build in which
+    # Close() is never called - verified by mutation, which is why this second check exists.
+    foreach ($Popup in @($script:E2EExecutePopups)) {
+        if ($null -ne $Popup -and -not $Popup.Closed) {
+            return $false
+        }
+    }
+
+    return $true
+}
+
 function script:Invoke-E2EFlushDispatcher {
     # Run all pending Background-and-higher dispatcher work (e.g. a deferred editor re-push) to
     # completion, synchronously, so a scenario can assert on its effect.
@@ -333,6 +363,12 @@ function script:Get-E2EChoices {
 
 function script:Clear-E2EPopups {
     $script:E2EPopupMessages.Clear()
+}
+
+function script:Clear-E2EExecutePopupHistory {
+    # Reset per case. Without it a window a previous case legitimately left open - one whose query is
+    # still in flight when that case ends - fails the NEXT case's "nothing was left open" check.
+    $script:E2EExecutePopups.Clear()
 }
 
 function script:Get-E2EPopups {

--- a/tests/e2e/Microcheck.ps1
+++ b/tests/e2e/Microcheck.ps1
@@ -29,6 +29,13 @@ function script:E2ECase {
     )
     $Record = [pscustomobject]@{ Suite = $script:E2ECurrentSuite; Name = $Name; Passed = $true; Message = $null }
     try {
+        # Per-case state that would otherwise carry over. The executing-query popup history is
+        # asserted as "nothing was left open", and a case that legitimately ends with a query still
+        # in flight would fail the next one.
+        if (Get-Command Clear-E2EExecutePopupHistory -ErrorAction SilentlyContinue) {
+            Clear-E2EExecutePopupHistory
+        }
+
         & $Body
     }
     catch {

--- a/tests/e2e/OmadaMocks.ps1
+++ b/tests/e2e/OmadaMocks.ps1
@@ -208,15 +208,45 @@ function script:Open-ChoiceForm {
 }
 
 $script:E2EPopupMessages = [System.Collections.Generic.List[string]]::new()
+# Every "Executing Query..." popup the mock has handed out, so a scenario can assert that none was
+# left open - not merely that the tab's slot was cleared.
+$script:E2EExecutePopups = [System.Collections.Generic.List[object]]::new()
 
 function script:Show-PopupWindow {
     param(
         $Message
     )
     # Record the message so scenarios can assert which popups were shown (e.g. the first-open
-    # "Opening tab..." popup), but return $null so nothing enters a nested WPF message pump.
+    # "Opening tab..." popup).
     $script:E2EPopupMessages.Add([string]$Message)
-    return $null
+
+    # $null for every popup except the executing-query one.
+    #
+    # Returning $null keeps a real WPF window out of the run, which is the point - nothing here may
+    # enter a nested message pump. But it also made every assertion that a popup had been CLOSED
+    # vacuous: the slot was $null whether or not the code under test closed anything.
+    #
+    # Only the execute popup gets a stand-in, because only it is under test here (issue #40: it must
+    # belong to its own tab and must not be orphaned by a second execute). The other callers -
+    # opening a tab, connecting, refreshing queries - branch on the returned value in ways this suite
+    # already depends on, and handing them an object changes scenarios that have nothing to do with
+    # this. Narrow on purpose.
+    if ([string]$Message -ne "Executing Query...") {
+        return $null
+    }
+
+    # An ordinary PSCustomObject with three script methods: it pumps nothing, and "the popup was
+    # closed" becomes a claim the suite can actually falsify.
+    $Popup = [pscustomobject]@{ Message = [string]$Message; Visible = $false; Closed = $false }
+    $Popup | Add-Member -MemberType ScriptMethod -Name Show -Value { $this.Visible = $true } -Force
+    $Popup | Add-Member -MemberType ScriptMethod -Name Hide -Value { $this.Visible = $false } -Force
+    $Popup | Add-Member -MemberType ScriptMethod -Name Close -Value { $this.Closed = $true; $this.Visible = $false } -Force
+
+    # Every execute popup ever handed out is remembered, because clearing the tab's slot is NOT the
+    # same as closing the window - and the bug being guarded against is precisely a window nobody
+    # closed. Checking only the slot passes a build in which Close() is never called at all.
+    $script:E2EExecutePopups.Add($Popup)
+    return $Popup
 }
 
 # Suppress ALL modal log dialogs. The real Write-LogOutput pops a blocking WinForms/WPF MessageBox for

--- a/tests/e2e/scenarios/AsyncExecute.ps1
+++ b/tests/e2e/scenarios/AsyncExecute.ps1
@@ -146,7 +146,7 @@ E2ESuite -Name "AsyncExecute" -Body {
             E2EAssertEqual "_Execute" (Get-E2EExecuteButtonText) "the button must be back to Execute after a failure"
             E2EAssertTrue $Elements.ButtonExecuteQuery.IsEnabled "Execute must be re-enabled after a failure"
             E2EAssertTrue $Elements.ButtonSaveQuery.IsEnabled "Save must be re-enabled after a failure"
-            E2EAssertTrue ($null -eq $Script:PopupWindowExecuteQuery) "the 'Executing Query...' popup must be closed after a failure"
+            E2EAssertTrue (Test-E2EExecutePopupClosed) "no tab may be left showing the 'Executing Query...' popup after a failure"
             # Note, deliberately not asserted as desirable: a failed execute still reports "0 rows"
             # and clears the grid, exactly as it did before this change. That is the "empty result vs
             # failed query" ambiguity of issue #44, and fixing it here would be scope drift. What

--- a/tests/e2e/scenarios/CancelExecute.ps1
+++ b/tests/e2e/scenarios/CancelExecute.ps1
@@ -43,7 +43,7 @@ E2ESuite -Name "CancelExecute" -Body {
         E2EAssertEqual "_Execute" (Get-E2EExecuteButtonText) "the button must go back to Execute in the same click"
         E2EAssertTrue $Elements.ButtonExecuteQuery.IsEnabled "Execute must be usable again"
         E2EAssertTrue $Elements.ButtonSaveQuery.IsEnabled "Save must be usable again"
-        E2EAssertTrue ($null -eq $Script:PopupWindowExecuteQuery) "the 'Executing Query...' popup must be closed"
+        E2EAssertTrue (Test-E2EExecutePopupClosed) "no tab may be left showing the 'Executing Query...' popup"
     }
 
     E2ECase -Name "cancelling does not blank a previous result" -Body {


### PR DESCRIPTION
Five defects reported from a live session. Two root causes.

## 1. One tenant 502 cost the session its background worker

```
Complete-ExecuteQueryPipeline (360): The query could not be run on a background worker: 502 (Bad Gateway).
Disable-OmadaBackgroundRequest (43): Background query execution is not available for this connection ...
```

The rule was "no step completed ⇒ the worker cannot run requests". That is not what a Bad Gateway means. **A status code coming back is proof the worker reached the tenant** — the worker was fine, the tenant hiccuped, and the user lost a responsive window for the rest of the day over it.

New `Resolve-ExecuteFallbackAction` classifies a failure into three outcomes:

| Outcome | When | Effect |
|---|---|---|
| **Report** | A status other than 401 came back, or any step completed | Tell the user. Re-running would send the identical request and get the identical answer |
| **Retry** | 401, or an unrecognised failure | Re-run on the UI thread, keep using workers |
| **RetryAndDisable** | Nothing came back, or a recognisable worker-infrastructure failure (no WebView2 runtime, a sign-in attempted where no window can exist) | Re-run on the UI thread and stop dispatching to workers |

Deliberately conservative: an **unrecognised** failure is `Retry`, never `RetryAndDisable`. Disabling is a one-way door for the session, so it is taken on evidence, not on the absence of it.

401 is the interesting case. A worker genuinely cannot sign in — but the UI thread can, and once it has, the worker may work again immediately. Disabling there gives up something that was about to start working.

## 2. Then every later query reported a bug that had not happened

```
ERROR - Cannot retry the query on the UI thread: the request context is no longer available.
```

Both the inline fallback (`Invoke-ExecuteQuery.ps1:120`) and the UI-thread retry (`:291`) called `Complete-ExecuteQueryPipeline` **without** `-PipelineContext`. So when those runs failed, the completion tried to fall back to the UI thread *while already on it*, found no context, and reported that instead of the tenant's error. With background execution now disabled, every query took that path — hence the repeat.

Passing the context would have been the wrong fix: it would loop. `Complete-ExecuteQueryPipeline` now takes **`-AlreadyOnUiThread`** and reports rather than re-driving. The stale "context is no longer available" line drops to DEBUG without a dialog — it is a real bug signal if it ever fires on the background path, but a modal in front of a query that is already lost helps nobody.

## 3 & 4. The popup was shared by every tab

Both reported symptoms — *"still appears on a tab that is not running a query"* and *"never goes away after switching between tabs"* — are the same cause. `$Script:PopupWindowExecuteQuery` was a single module-scope slot, and unlike `$Script:MainForm.Elements`, `RunTimeData` and `AppConfig` it is **not** repointed by `Set-ActiveTabContext`:

- The window is owned by the main form, so it floated above the application regardless of the visible tab.
- A second execute overwrote the slot, **orphaning** the first window — nothing held a reference any more, so nothing could ever close it.

The popup now lives on its tab session, alongside the pending request that owns it.

## 5. The error dialog

- **Now names the tab:** `Error - Mve: query`. `Write-LogOutput` already computed the tab name for the log prefix; the dialog title ignored it. With queries running in the background a message can arrive for a tab the user is not looking at, so "Error" alone does not say which query is being complained about.
- **Now owned by the main window.** A WinForms `MessageBox` raised from a WPF application with no owner is a top-level window with no relationship to it, so Windows was free to order it *behind* the main form — and because it was modal, the application underneath looked hung.

## Decisions worth reviewing

- **Popup visibility is driven by the tab control's `SelectedItem`, not `$Script:ActiveTabId`.** The latter moves twice for every completion — the poll timer steps into the owning tab and restores afterwards — so driving visibility from it would flicker the popup against tabs the user is not even looking at. The tab control's selection changes only when the user actually switches tabs, which is the question being asked.
- **`Show-ExecuteQueryPopup` reuses an existing popup rather than replacing it.** Replacing is precisely what orphaned windows.
- **An unrecognised failure retries but never disables** — see above. The cost of being wrong is asymmetric.
- **A 502 is not retried on the UI thread at all.** It would send the identical request and get the identical answer, so it is reported. This is a behaviour change from "always fall back": the user sees the tenant error immediately instead of after a second doomed round trip.
- **`Get-MainFormMessageBoxOwner` returns `$null` during startup/shutdown** and the caller falls back to the ownerless overload. An owner is an improvement, not a requirement, and failing to build one must never cost the user the message.

## Verification

```
./build/build.ps1 -Task TestBuildOnly   →  836 tests, 0 failed; PSScriptAnalyzer clean
./build/build.ps1 -Task E2E             →   54 tests, 0 failed
```

New tests pin the reported behaviour specifically: a 502 neither disables nor re-drives, a WebView2 failure does both, a 401 re-drives without disabling, an inline failure never reports a missing context and surfaces the tenant error instead, and the popup is per-tab — hidden when its tab is off screen, shown when the user returns, and never touching another tab's.

## Not in scope

Acceptance criterion 1 of #40 is still not met; the remaining blocking calls are tracked in #90. #89 covers the session keep-alive watchdog.

Part of #40.
