### PR TITLE
Hold a tab's messages until that tab is on screen

### DIFF
--- a/src/Lib/Events/MainForm.Elements.TabControlSessions.ps1
+++ b/src/Lib/Events/MainForm.Elements.TabControlSessions.ps1
@@ -66,6 +66,11 @@
                 # visibility from those would flicker the popup for tabs the user is not looking at.
                 Sync-ExecuteQueryPopupVisibility
 
+                # Anything that happened on this tab while it was off screen is reported now, in the
+                # context where it makes sense. Deliberately after Set-ActiveTabContext, so the tab is
+                # fully swapped in before a modal pumps the dispatcher.
+                Show-TabScopedMessage -TabSession $TabSession
+
                 if (![string]::IsNullOrWhiteSpace($OutgoingTabId) -and $OutgoingTabId -ne $TabSession.Id) {
                     $Script:PreviousActiveTabId = $OutgoingTabId
                 }

--- a/src/Lib/Functions/Private/Add-TabScopedMessage.ps1
+++ b/src/Lib/Functions/Private/Add-TabScopedMessage.ps1
@@ -1,0 +1,111 @@
+function Add-TabScopedMessage {
+    <#
+    .SYNOPSIS
+    Hold a tab-scoped warning or error until the tab it belongs to is on screen.
+
+    .DESCRIPTION
+    Since queries run in the background (issue #40) a failure can arrive for a tab the user is not
+    looking at. Showing it immediately puts a modal dialog in front of whatever they are doing on a
+    different tab, about a query they cannot see - and, because the dialog is modal, it stops them
+    working on the tab they ARE looking at until they dismiss something irrelevant to it.
+
+    So a tab-scoped message raised while its tab is off screen is held here and shown when the user
+    next opens that tab. Nothing is lost: it is already in the log by the time this is called, and the
+    interruption now happens in the context where it makes sense.
+
+    Only WARNING and ERROR reach this - they are the only levels that raise a dialog at all.
+
+    Application-wide failures do NOT come through here. Those are not about a tab and must be seen
+    wherever the user is; see the -TabScoped switch on Write-LogOutput for where that line is drawn.
+
+    .PARAMETER TabSession
+    The tab the message belongs to.
+
+    .PARAMETER Text
+    The message body, already formatted for the dialog.
+
+    .PARAMETER Title
+    The dialog title, already carrying the tab name.
+
+    .PARAMETER Icon
+    The MessageBoxIcon the dialog would have used.
+    #>
+    [CmdLetBinding()]
+    param(
+        $TabSession,
+        [string]$Text,
+        [string]$Title,
+        $Icon
+    )
+
+    try {
+        if ($null -eq $TabSession) {
+            return
+        }
+
+        if ($null -eq $TabSession.PendingMessages) {
+            $TabSession.PendingMessages = [System.Collections.Generic.List[object]]::new()
+        }
+
+        # Capped. A tab whose query fails repeatedly - a stale session retrying, say - must not build
+        # an unbounded backlog that then has to be read through when the tab is opened. The oldest go
+        # first: the most recent failure is the one that describes the current state.
+        while ($TabSession.PendingMessages.Count -ge 10) {
+            $TabSession.PendingMessages.RemoveAt(0)
+        }
+
+        $TabSession.PendingMessages.Add(@{
+                Text  = $Text
+                Title = $Title
+                Icon  = $Icon
+            })
+    }
+    catch {
+        # This is the path that reports failures; it has nowhere useful to report its own.
+    }
+}
+
+function Show-TabScopedMessage {
+    <#
+    .SYNOPSIS
+    Show whatever was held for a tab while it was off screen, as one dialog.
+
+    .DESCRIPTION
+    Called when a tab becomes the visible one. Coalesced into a single dialog on purpose: opening a
+    tab that failed four times should not mean dismissing four modals in a row.
+
+    The queue is cleared BEFORE the dialog is shown. A modal pumps the dispatcher, which lets the
+    completion poll timer run, which can enqueue another message for this same tab - and if the queue
+    were cleared afterwards that message would be discarded unseen.
+
+    .PARAMETER TabSession
+    The tab being opened. Defaults to the active tab.
+    #>
+    [CmdLetBinding()]
+    param(
+        $TabSession
+    )
+
+    try {
+        $Private:Target = if ($null -ne $TabSession) { $TabSession } else { Get-ActiveTabSession }
+        if ($null -eq $Private:Target -or $null -eq $Private:Target.PendingMessages -or $Private:Target.PendingMessages.Count -eq 0) {
+            return
+        }
+
+        $Private:Held = @($Private:Target.PendingMessages)
+        $Private:Target.PendingMessages.Clear()
+
+        $Private:Title = $Private:Held[-1].Title
+        $Private:Icon = $Private:Held[-1].Icon
+        $Private:Text = ($Private:Held | ForEach-Object { $_.Text }) -join "`r`n`r`n"
+
+        if ($Private:Held.Count -gt 1) {
+            $Private:Text = "{0} messages occurred on this tab while it was not open:`r`n`r`n{1}" -f $Private:Held.Count, $Private:Text
+        }
+
+        Show-LogMessageDialog -Text $Private:Text -Title $Private:Title -Icon $Private:Icon
+    }
+    catch {
+        "Could not show the messages held for this tab: {0}" -f $_.Exception.Message | Write-LogOutput -LogType DEBUG
+    }
+}

--- a/src/Lib/Functions/Private/Invoke-ExecuteQuery.ps1
+++ b/src/Lib/Functions/Private/Invoke-ExecuteQuery.ps1
@@ -134,7 +134,7 @@ function Invoke-ExecuteQuery {
                         $Private:TaskFailure = $Script:Task.Exception.GetBaseException().Message
                     }
 
-                    "Reading the editor's contents failed: {0}" -f $Private:TaskFailure | Write-ContainedErrorLog -ErrorObject $Script:Task.Exception
+                    "Reading the editor's contents failed: {0}" -f $Private:TaskFailure | Write-ContainedErrorLog -ErrorObject $Script:Task.Exception -TabScoped
                 }
                 else {
                     "Task result: {0}" -f $Script:Task.Status | Write-LogOutput -LogType DEBUG
@@ -146,14 +146,14 @@ function Invoke-ExecuteQuery {
                 # object for its whole lifetime and deletes it in its own finally, so this frame
                 # never holds one to leak.
                 Reset-ExecuteQueryUiState
-                $_.Exception.Message | Write-ContainedErrorLog -ErrorObject $_
+                $_.Exception.Message | Write-ContainedErrorLog -ErrorObject $_ -TabScoped
             }
         }
         Invoke-ExecuteScriptWithResultAsync -ScriptToExecute $ScriptToExecute -OnCompletedScriptBlock $OnCompletedScriptBlock
     }
     catch {
         Reset-ExecuteQueryUiState
-        $_.Exception.Message | Write-ContainedErrorLog -ErrorObject $_
+        $_.Exception.Message | Write-ContainedErrorLog -ErrorObject $_ -TabScoped
     }
 }
 
@@ -217,7 +217,7 @@ function Reset-ExecuteQueryUiState {
         }
     }
     catch {
-        $_.Exception.Message | Write-ContainedErrorLog -ErrorObject $_
+        $_.Exception.Message | Write-ContainedErrorLog -ErrorObject $_ -TabScoped
     }
 }
 
@@ -316,7 +316,7 @@ function Invoke-ExecuteQueryOnUiThread {
     }
     catch {
         Reset-ExecuteQueryUiState
-        $_.Exception.Message | Write-ContainedErrorLog -ErrorObject $_
+        $_.Exception.Message | Write-ContainedErrorLog -ErrorObject $_ -TabScoped
     }
 }
 
@@ -365,7 +365,7 @@ function Complete-ExecuteQueryPipeline {
             $Private:Reason = if ($Outcome -is [System.Management.Automation.ErrorRecord]) { $Outcome.Exception.Message } else { "the background worker returned no result" }
 
             if ($AlreadyOnUiThread) {
-                "The query could not be run on the UI thread either: {0}" -f $Private:Reason | Write-ContainedErrorLog
+                "The query could not be run on the UI thread either: {0}" -f $Private:Reason | Write-ContainedErrorLog -TabScoped
                 Complete-ExecuteQueryResult -QueryResult $null -SaveResult $null -TempQueryDoId $null
                 return
             }
@@ -403,7 +403,7 @@ function Complete-ExecuteQueryPipeline {
                 return
             }
 
-            "The query pipeline failed at step '{0}': {1}" -f $Outcome.FailedStep, $Outcome.ErrorRecord.Exception.Message | Write-ContainedErrorLog -ErrorObject $Outcome.ErrorRecord
+            "The query pipeline failed at step '{0}': {1}" -f $Outcome.FailedStep, $Outcome.ErrorRecord.Exception.Message | Write-ContainedErrorLog -ErrorObject $Outcome.ErrorRecord -TabScoped
             Complete-ExecuteQueryResult -QueryResult $Outcome.ErrorRecord -SaveResult $Outcome.SaveResult -TempQueryDoId $null
             return
         }
@@ -414,7 +414,7 @@ function Complete-ExecuteQueryPipeline {
     }
     catch {
         Reset-ExecuteQueryUiState
-        $_.Exception.Message | Write-ContainedErrorLog -ErrorObject $_
+        $_.Exception.Message | Write-ContainedErrorLog -ErrorObject $_ -TabScoped
     }
 }
 
@@ -464,7 +464,7 @@ function Complete-ExecuteQueryResult {
         # not exist. Null became far more reachable once a request could fail or be abandoned in a
         # worker, so it is now treated as what it is - no rows.
         if ($null -eq $Script:RunTimeData.QueryResult -or ($Script:RunTimeData.QueryResult.d.Rows | Measure-Object).Count -le 0) {
-            "Query did not return any results!" | Write-LogOutput -LogType WARNING
+            "Query did not return any results!" | Write-LogOutput -LogType WARNING -TabScoped
             $Script:MainForm.Elements.TextBlockStatusBarRows | Set-TextBlockText -Text "0 rows"
             $Script:MainForm.Elements.DataGridQueryResult.ItemsSource = $null
         }
@@ -514,6 +514,6 @@ function Complete-ExecuteQueryResult {
         # The temporary object is already gone by here - it is deleted before anything that can throw
         # - so this only has to put the UI back.
         Reset-ExecuteQueryUiState
-        $_.Exception.Message | Write-ContainedErrorLog -ErrorObject $_
+        $_.Exception.Message | Write-ContainedErrorLog -ErrorObject $_ -TabScoped
     }
 }

--- a/src/Lib/Functions/Private/New-TabSession.ps1
+++ b/src/Lib/Functions/Private/New-TabSession.ps1
@@ -95,6 +95,10 @@ function New-TabSession {
             # made one tab's popup appear over every other tab and leaked a window that nothing could
             # close once a second tab started a query. See Show-ExecuteQueryPopup.
             ExecutePopup     = $null
+            # Warnings and errors that belong to this tab and were raised while it was off screen.
+            # Shown when the tab is next opened, so a background query's failure does not interrupt
+            # whatever the user is doing on a different tab. See Add-TabScopedMessage.
+            PendingMessages  = [System.Collections.Generic.List[object]]::new()
             CurrentUrl       = $null
             AppConfig        = $(if ($null -ne $RestoreFrom) { $RestoreFrom } else { $DefaultTabConfig })
             RunTimeData      = [PSCustomObject]@{

--- a/src/Lib/Functions/Private/Show-LogMessageDialog.ps1
+++ b/src/Lib/Functions/Private/Show-LogMessageDialog.ps1
@@ -1,0 +1,57 @@
+function Show-LogMessageDialog {
+    <#
+    .SYNOPSIS
+    Show a warning or error dialog, owned by the main window.
+
+    .DESCRIPTION
+    Extracted from Write-LogOutput so that a message shown immediately and a message held for a tab
+    that was off screen go through exactly one implementation. They previously could not have drifted
+    apart, because only one of them existed; now that there are two callers, one function is what
+    stops them drifting.
+
+    Owned by the main window: without an owner a WinForms message box raised from a WPF application
+    is a top-level window with no relationship to it, so Windows is free to order it behind the main
+    form - which it did, and because the dialog is modal the application underneath looked hung.
+
+    .PARAMETER Text
+    The message body.
+
+    .PARAMETER Title
+    The dialog title.
+
+    .PARAMETER Icon
+    The MessageBoxIcon to show.
+    #>
+    [CmdLetBinding()]
+    param(
+        [string]$Text,
+        [string]$Title,
+        $Icon
+    )
+
+    # A blocking dialog pumps this thread's messages while it is up, which can let the completion
+    # poll timer's Tick fire reentrantly nested inside it - suspend it for the duration so that
+    # cannot happen (see Suspend-WebViewCompletionPolling.ps1 for why).
+    Suspend-WebViewCompletionPolling
+    try {
+        $Private:DialogOwner = Get-MainFormMessageBoxOwner
+        try {
+            if ($null -ne $Private:DialogOwner) {
+                [System.Windows.Forms.MessageBox]::Show($Private:DialogOwner, (Limit-MessageBoxText -Text $Text), $Title, [System.Windows.Forms.MessageBoxButtons]::OK, $Icon)
+            }
+            else {
+                [System.Windows.Forms.MessageBox]::Show((Limit-MessageBoxText -Text $Text), $Title, [System.Windows.Forms.MessageBoxButtons]::OK, $Icon)
+            }
+        }
+        finally {
+            if ($null -ne $Private:DialogOwner) {
+                try { $Private:DialogOwner.ReleaseHandle() } catch { }
+            }
+        }
+
+        Restore-MainFormFocus
+    }
+    finally {
+        Resume-WebViewCompletionPolling
+    }
+}

--- a/src/Lib/Functions/Private/Stop-ExecuteQueryRequest.ps1
+++ b/src/Lib/Functions/Private/Stop-ExecuteQueryRequest.ps1
@@ -79,6 +79,6 @@ function Stop-ExecuteQueryRequest {
         # Whatever went wrong, the tab must not be left in the executing state - that would leave the
         # user with a Cancel button that cancels nothing and no way back to Execute.
         Reset-ExecuteQueryUiState
-        $_.Exception.Message | Write-ContainedErrorLog -ErrorObject $_
+        $_.Exception.Message | Write-ContainedErrorLog -ErrorObject $_ -TabScoped
     }
 }

--- a/src/Lib/Functions/Private/Test-ActiveTabIsOnScreen.ps1
+++ b/src/Lib/Functions/Private/Test-ActiveTabIsOnScreen.ps1
@@ -1,0 +1,48 @@
+function Test-ActiveTabIsOnScreen {
+    <#
+    .SYNOPSIS
+    Whether the tab the current work belongs to is the one the user is actually looking at.
+
+    .DESCRIPTION
+    Two different notions of "current tab" exist, and the difference is the whole point of this
+    function.
+
+    $Script:ActiveTabId is the tab the code is currently acting FOR. The completion poll timer steps
+    into the owning tab before invoking a completion and restores afterwards, so during a background
+    query's completion it names that query's tab - which is what makes log lines and dialog titles
+    attribute correctly.
+
+    The tab control's SelectedItem is the tab on SCREEN. It changes only when the user switches tabs.
+
+    When a background query fails, the first says "tab A" while the second may well say "tab B". That
+    is exactly when a modal must not appear: it would interrupt work on tab B to report something
+    about tab A that the user cannot even see.
+
+    .OUTPUTS
+    [bool] $true when the acting tab is the visible one, or when the question cannot be answered - a
+    message is better shown once too often than swallowed.
+    #>
+    [CmdLetBinding()]
+    [OutputType([bool])]
+    param()
+
+    try {
+        $Private:Active = Get-ActiveTabSession
+        if ($null -eq $Private:Active) {
+            # No tab context at all: not a tab-scoped situation, so nothing to defer.
+            return $true
+        }
+
+        $Private:Selected = (Get-TabControlSessions).SelectedItem
+        if ($null -eq $Private:Selected) {
+            return $true
+        }
+
+        return ($Private:Active.TabItem -eq $Private:Selected)
+    }
+    catch {
+        # Deliberately fails towards showing the message. Holding one back because this check threw
+        # would lose it until the user happened to switch tabs, which is the worse failure.
+        return $true
+    }
+}

--- a/src/Lib/Functions/Private/Write-ContainedErrorLog.ps1
+++ b/src/Lib/Functions/Private/Write-ContainedErrorLog.ps1
@@ -27,18 +27,25 @@ function Write-ContainedErrorLog {
 
     .PARAMETER ErrorObject
     The originating error, passed through for the call stack Write-LogOutput records.
+
+    .PARAMETER TabScoped
+    The error belongs to one tab rather than to the application, so it is held until that tab is on
+    screen instead of interrupting whatever the user is doing elsewhere. Passed straight through to
+    Write-LogOutput, where the reasoning lives.
     #>
     [CmdLetBinding()]
     param(
         [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
         [string]$Message,
 
-        $ErrorObject
+        $ErrorObject,
+
+        [switch]$TabScoped
     )
 
     process {
         try {
-            $Message | Write-LogOutput -LogType ERROR -ErrorObject $ErrorObject
+            $Message | Write-LogOutput -LogType ERROR -ErrorObject $ErrorObject -TabScoped:$TabScoped
         }
         catch {
             # Expected, and the entire point: Write-LogOutput has already written the line and shown

--- a/src/Lib/Functions/Private/Write-LogOutput.ps1
+++ b/src/Lib/Functions/Private/Write-LogOutput.ps1
@@ -6,7 +6,16 @@ function Write-LogOutput {
         $ErrorObject,
         [ValidateSet("DEBUG", "INFO", "ERROR", "VERBOSE", "WARNING", "FATAL", "LOG", "VERBOSE2")]
         [string]$LogType = "INFO",
-        [switch]$SkipDialog
+        [switch]$SkipDialog,
+        # The message belongs to one tab - a query result, a failed execute - rather than to the
+        # application. Since queries run in the background (issue #40) such a message can arrive for a
+        # tab the user is not looking at, and a modal about an invisible query interrupts whatever
+        # they are doing on the tab they ARE looking at. A tab-scoped message raised while its tab is
+        # off screen is therefore held and shown when that tab is next opened.
+        #
+        # Opt-in, so everything that has not been considered keeps today's behaviour: an application
+        # failure is not about a tab and must be seen wherever the user is.
+        [switch]$TabScoped
     )
 
     try {
@@ -178,38 +187,28 @@ function Write-LogOutput {
             $LogMessage.Text | Write-Verbose
         }
         if ($LogMessageDialog.Show -and !$SkipDialog) {
-            # A blocking dialog pumps this thread's messages while it's up, which can let
-            # $Script:WebViewCompletionPollTimer's Tick fire reentrantly nested inside it -
-            # suspend it for the duration so that can't happen (see
-            # Suspend-WebViewCompletionPolling.ps1 for why).
-            Suspend-WebViewCompletionPolling
-            try {
-                if ($null -ne $Script:MainForm -and $null -ne $Script:MainForm.Definition -and $Script:MainForm.Definition.IsVisible) {
-                    $TrimmedText = Limit-MessageBoxText -Text $LogMessageDialog.Text
-
-                    # Owned by the main window. Without an owner a WinForms MessageBox raised from a
-                    # WPF application is a top-level window with no relationship to it, so Windows is
-                    # free to order it behind the main form - which it did: an error about a failed
-                    # query appeared behind the application, and the application looked hung because
-                    # the dialog underneath it was modal. The owner also gives the dialog somewhere
-                    # sensible to centre itself.
-                    $Private:DialogOwner = Get-MainFormMessageBoxOwner
-                    try {
-                        if ($null -ne $Private:DialogOwner) {
-                            [System.Windows.Forms.MessageBox]::Show($Private:DialogOwner, $TrimmedText, $LogMessageDialog.Title, [System.Windows.Forms.MessageBoxButtons]::OK, $LogMessageDialog.Icon)
-                        }
-                        else {
-                            [System.Windows.Forms.MessageBox]::Show($TrimmedText, $LogMessageDialog.Title, [System.Windows.Forms.MessageBoxButtons]::OK, $LogMessageDialog.Icon)
-                        }
-                    }
-                    finally {
-                        if ($null -ne $Private:DialogOwner) {
-                            try { $Private:DialogOwner.ReleaseHandle() } catch { }
-                        }
-                    }
-                    Restore-MainFormFocus
+            if ($null -ne $Script:MainForm -and $null -ne $Script:MainForm.Definition -and $Script:MainForm.Definition.IsVisible) {
+                # A message that belongs to a tab the user is not looking at is held rather than
+                # shown. Interrupting work on the visible tab with a modal about an invisible query is
+                # what this avoids; it is shown when that tab is next opened, and it is in the log
+                # either way. An application-level failure is not tab-scoped and always shows.
+                if ($TabScoped -and -not (Test-ActiveTabIsOnScreen)) {
+                    Add-TabScopedMessage -TabSession (Get-ActiveTabSession) -Text $LogMessageDialog.Text -Title $LogMessageDialog.Title -Icon $LogMessageDialog.Icon
                 }
                 else {
+                    Show-LogMessageDialog -Text $LogMessageDialog.Text -Title $LogMessageDialog.Title -Icon $LogMessageDialog.Icon
+                }
+            }
+            else {
+                # No main window yet - startup, shutdown, or a console host. Nothing is tab-scoped
+                # here because there are no tabs to scope to, so this path is unchanged.
+                #
+                # A blocking dialog pumps this thread's messages while it's up, which can let
+                # $Script:WebViewCompletionPollTimer's Tick fire reentrantly nested inside it -
+                # suspend it for the duration so that can't happen (see
+                # Suspend-WebViewCompletionPolling.ps1 for why).
+                Suspend-WebViewCompletionPolling
+                try {
                     $MessageBoxImage = [System.Windows.MessageBoxImage]::Information
                     if ($LogMessage.ShowWarning) {
                         $LogMessage.Text | Write-Warning
@@ -224,9 +223,9 @@ function Write-LogOutput {
                     }
                     [System.Windows.MessageBox]::Show((Limit-MessageBoxText -Text $LogMessageDialog.Text), $LogMessageDialog.Title, [System.Windows.MessageBoxButton]::OK, $MessageBoxImage) | Out-Null
                 }
-            }
-            finally {
-                Resume-WebViewCompletionPolling
+                finally {
+                    Resume-WebViewCompletionPolling
+                }
             }
         }
         if ($LogMessage.ShowError) {

--- a/tests/Add-TabScopedMessage.Tests.ps1
+++ b/tests/Add-TabScopedMessage.Tests.ps1
@@ -1,0 +1,168 @@
+#Requires -Version 7.0
+# Since queries run in the background (issue #40) a failure can arrive for a tab the user is not
+# looking at. A modal about an invisible query interrupts work on the tab they ARE looking at, and
+# because it is modal they cannot carry on until they dismiss something irrelevant to them. So a
+# tab-scoped message raised off screen is held and shown when that tab is next opened.
+
+BeforeAll {
+    $ParentPath = Split-Path -Path $PSScriptRoot -Parent
+    $PrivatePath = Join-Path $ParentPath -ChildPath "src\Lib\Functions\Private"
+    . (Join-Path $PrivatePath -ChildPath "Add-TabScopedMessage.ps1")
+    . (Join-Path $PrivatePath -ChildPath "Test-ActiveTabIsOnScreen.ps1")
+
+    function Write-LogOutput {
+        param([Parameter(ValueFromPipeline = $true)]$InputObject, [string]$LogType, $ErrorObject, [switch]$SkipDialog)
+        process { }
+    }
+
+    $script:ShownDialogs = [System.Collections.Generic.List[object]]::new()
+    function Show-LogMessageDialog {
+        param([string]$Text, [string]$Title, $Icon)
+        $script:ShownDialogs.Add([pscustomobject]@{ Text = $Text; Title = $Title; Icon = $Icon })
+    }
+
+    function script:New-FakeTab {
+        param([string]$Id)
+        return [pscustomobject]@{
+            Id              = $Id
+            DisplayName     = $Id
+            TabItem         = "item-$Id"
+            PendingMessages = [System.Collections.Generic.List[object]]::new()
+        }
+    }
+
+    function script:Initialize-MessageTestState {
+        $script:ShownDialogs.Clear()
+        $Script:TabA = New-FakeTab -Id "A"
+        $Script:TabB = New-FakeTab -Id "B"
+        $Script:ActiveTabForTest = $Script:TabA
+        $Script:SelectedTabItem = $Script:TabA.TabItem
+    }
+
+    function Get-ActiveTabSession { return $Script:ActiveTabForTest }
+    function Get-TabControlSessions { return [pscustomobject]@{ SelectedItem = $Script:SelectedTabItem } }
+}
+
+Describe "Test-ActiveTabIsOnScreen" {
+    BeforeEach { Initialize-MessageTestState }
+
+    It "is true when the acting tab is the one being looked at" {
+        Test-ActiveTabIsOnScreen | Should -BeTrue
+    }
+
+    It "is false when a completion is acting for a tab that is off screen" {
+        # The poll timer steps into the owning tab to run its completion, so the acting tab and the
+        # visible tab genuinely differ - which is precisely when a modal must not appear.
+        $Script:SelectedTabItem = $Script:TabB.TabItem
+
+        Test-ActiveTabIsOnScreen | Should -BeFalse
+    }
+
+    It "is true when there is no tab context at all" {
+        $Script:ActiveTabForTest = $null
+
+        Test-ActiveTabIsOnScreen | Should -BeTrue
+    }
+
+    It "fails towards showing the message when the question cannot be answered" {
+        # Holding a message back because this check threw would lose it until the user happened to
+        # switch tabs. Showing it once too often is the better failure.
+        Mock Get-TabControlSessions { throw "no tab control" }
+
+        Test-ActiveTabIsOnScreen | Should -BeTrue
+    }
+}
+
+Describe "Add-TabScopedMessage" {
+    BeforeEach { Initialize-MessageTestState }
+
+    It "holds the message on the tab it belongs to" {
+        Add-TabScopedMessage -TabSession $Script:TabA -Text "boom" -Title "Error - A" -Icon "Error"
+
+        @($Script:TabA.PendingMessages).Count | Should -Be 1
+        @($Script:TabB.PendingMessages).Count | Should -Be 0
+    }
+
+    It "shows nothing at the time it is held" {
+        Add-TabScopedMessage -TabSession $Script:TabA -Text "boom" -Title "Error - A" -Icon "Error"
+
+        @($script:ShownDialogs).Count | Should -Be 0
+    }
+
+    It "caps the backlog so a repeatedly failing tab cannot pile up" {
+        1..15 | ForEach-Object { Add-TabScopedMessage -TabSession $Script:TabA -Text "boom $_" -Title "Error - A" -Icon "Error" }
+
+        @($Script:TabA.PendingMessages).Count | Should -Be 10
+        # Oldest dropped: the most recent failure describes the current state.
+        $Script:TabA.PendingMessages[-1].Text | Should -Be "boom 15"
+    }
+
+    It "is safe with no tab" {
+        { Add-TabScopedMessage -TabSession $null -Text "boom" -Title "t" -Icon "Error" } | Should -Not -Throw
+    }
+}
+
+Describe "Show-TabScopedMessage" {
+    BeforeEach { Initialize-MessageTestState }
+
+    It "shows what was held when the tab is opened" {
+        Add-TabScopedMessage -TabSession $Script:TabA -Text "boom" -Title "Error - A" -Icon "Error"
+
+        Show-TabScopedMessage -TabSession $Script:TabA
+
+        @($script:ShownDialogs).Count | Should -Be 1
+        $script:ShownDialogs[0].Text | Should -Match "boom"
+        $script:ShownDialogs[0].Title | Should -Be "Error - A"
+    }
+
+    It "coalesces several into one dialog" {
+        # Opening a tab that failed four times must not mean dismissing four modals in a row.
+        1..4 | ForEach-Object { Add-TabScopedMessage -TabSession $Script:TabA -Text "boom $_" -Title "Error - A" -Icon "Error" }
+
+        Show-TabScopedMessage -TabSession $Script:TabA
+
+        @($script:ShownDialogs).Count | Should -Be 1
+        $script:ShownDialogs[0].Text | Should -Match "4 messages occurred"
+        $script:ShownDialogs[0].Text | Should -Match "boom 1"
+        $script:ShownDialogs[0].Text | Should -Match "boom 4"
+    }
+
+    It "empties the queue, so re-opening the tab does not show it again" {
+        Add-TabScopedMessage -TabSession $Script:TabA -Text "boom" -Title "Error - A" -Icon "Error"
+
+        Show-TabScopedMessage -TabSession $Script:TabA
+        Show-TabScopedMessage -TabSession $Script:TabA
+
+        @($script:ShownDialogs).Count | Should -Be 1
+    }
+
+    It "clears the queue before showing, so a message enqueued by the modal's own pump survives" {
+        # A modal pumps the dispatcher, which lets the completion poll timer run, which can enqueue
+        # another message for this same tab. Clearing afterwards would discard it unseen.
+        Add-TabScopedMessage -TabSession $Script:TabA -Text "first" -Title "Error - A" -Icon "Error"
+        Mock Show-LogMessageDialog {
+            $script:ShownDialogs.Add([pscustomobject]@{ Text = $Text; Title = $Title; Icon = $Icon })
+            Add-TabScopedMessage -TabSession $Script:TabA -Text "arrived during the modal" -Title "Error - A" -Icon "Error"
+        }
+
+        Show-TabScopedMessage -TabSession $Script:TabA
+
+        @($Script:TabA.PendingMessages).Count | Should -Be 1
+        $Script:TabA.PendingMessages[0].Text | Should -Be "arrived during the modal"
+    }
+
+    It "does nothing when there is nothing held" {
+        Show-TabScopedMessage -TabSession $Script:TabA
+
+        @($script:ShownDialogs).Count | Should -Be 0
+    }
+
+    It "does not show another tab's messages" {
+        Add-TabScopedMessage -TabSession $Script:TabB -Text "B failed" -Title "Error - B" -Icon "Error"
+
+        Show-TabScopedMessage -TabSession $Script:TabA
+
+        @($script:ShownDialogs).Count | Should -Be 0
+        @($Script:TabB.PendingMessages).Count | Should -Be 1
+    }
+}

--- a/tests/Disable-OmadaBackgroundRequest.Tests.ps1
+++ b/tests/Disable-OmadaBackgroundRequest.Tests.ps1
@@ -20,7 +20,8 @@ BeforeAll {
             [Parameter(ValueFromPipeline = $true)]$InputObject,
             [string]$LogType,
             $ErrorObject,
-            [switch]$SkipDialog
+            [switch]$SkipDialog,
+            [switch]$TabScoped
         )
         process { $script:LogMessages.Add([pscustomobject]@{ LogType = $LogType; Message = [string]$InputObject }) }
     }

--- a/tests/Get-ConfigSchemaDefault.Tests.ps1
+++ b/tests/Get-ConfigSchemaDefault.Tests.ps1
@@ -16,7 +16,8 @@ BeforeAll {
             [string]$Message,
             $ErrorObject,
             [string]$LogType = "INFO",
-            [switch]$SkipDialog
+            [switch]$SkipDialog,
+            [switch]$TabScoped
         )
     }
 }

--- a/tests/Get-SqlSchema.Tests.ps1
+++ b/tests/Get-SqlSchema.Tests.ps1
@@ -45,7 +45,8 @@ BeforeAll {
             [Parameter(ValueFromPipeline = $true)]$InputObject,
             [string]$LogType,
             $ErrorObject,
-            [switch]$SkipDialog
+            [switch]$SkipDialog,
+            [switch]$TabScoped
         )
         process {
             $script:LoggedMessages.Add([pscustomobject]@{

--- a/tests/Get-SqlSyntaxDiagnostic.Tests.ps1
+++ b/tests/Get-SqlSyntaxDiagnostic.Tests.ps1
@@ -28,7 +28,8 @@ BeforeAll {
             [Parameter(ValueFromPipeline = $true)]$Message,
             [string]$LogType = "INFO",
             $ErrorObject,
-            [switch]$SkipDialog
+            [switch]$SkipDialog,
+            [switch]$TabScoped
         )
         process {
             $script:LoggedMessage.Add([PSCustomObject]@{ Message = [string]$Message; LogType = $LogType })

--- a/tests/Get-SqlValidationSetting.Tests.ps1
+++ b/tests/Get-SqlValidationSetting.Tests.ps1
@@ -16,7 +16,8 @@ BeforeAll {
             [Parameter(ValueFromPipeline = $true)]$Message,
             [string]$LogType = "INFO",
             $ErrorObject,
-            [switch]$SkipDialog
+            [switch]$SkipDialog,
+            [switch]$TabScoped
         )
         process { }
     }

--- a/tests/Initialize-GlobalConfigSettings.Tests.ps1
+++ b/tests/Initialize-GlobalConfigSettings.Tests.ps1
@@ -20,7 +20,8 @@ BeforeAll {
             [string]$Message,
             $ErrorObject,
             [string]$LogType = "INFO",
-            [switch]$SkipDialog
+            [switch]$SkipDialog,
+            [switch]$TabScoped
         )
     }
 

--- a/tests/Invoke-ExecuteQuery.Tests.ps1
+++ b/tests/Invoke-ExecuteQuery.Tests.ps1
@@ -95,7 +95,8 @@ BeforeAll {
             [Parameter(ValueFromPipeline = $true)]$InputObject,
             [string]$LogType,
             $ErrorObject,
-            [switch]$SkipDialog
+            [switch]$SkipDialog,
+            [switch]$TabScoped
         )
         process { }
     }

--- a/tests/Invoke-OmadaPSWebRequestWrapper.Tests.ps1
+++ b/tests/Invoke-OmadaPSWebRequestWrapper.Tests.ps1
@@ -36,7 +36,8 @@ BeforeAll {
             [Parameter(ValueFromPipeline = $true)]$InputObject,
             [string]$LogType,
             $ErrorObject,
-            [switch]$SkipDialog
+            [switch]$SkipDialog,
+            [switch]$TabScoped
         )
         process { }
     }

--- a/tests/Invoke-OmadaPSWebRequestWrapperAsync.Tests.ps1
+++ b/tests/Invoke-OmadaPSWebRequestWrapperAsync.Tests.ps1
@@ -24,7 +24,8 @@ BeforeAll {
             [Parameter(ValueFromPipeline = $true)]$InputObject,
             [string]$LogType,
             $ErrorObject,
-            [switch]$SkipDialog
+            [switch]$SkipDialog,
+            [switch]$TabScoped
         )
         process { }
     }

--- a/tests/Remove-PendingBackgroundRequest.Tests.ps1
+++ b/tests/Remove-PendingBackgroundRequest.Tests.ps1
@@ -19,7 +19,8 @@ BeforeAll {
             [Parameter(ValueFromPipeline = $true)]$InputObject,
             [string]$LogType,
             $ErrorObject,
-            [switch]$SkipDialog
+            [switch]$SkipDialog,
+            [switch]$TabScoped
         )
         process { }
     }

--- a/tests/Set-BodyRedactionState.Tests.ps1
+++ b/tests/Set-BodyRedactionState.Tests.ps1
@@ -15,7 +15,8 @@ BeforeAll {
             [string]$Message,
             $ErrorObject,
             [string]$LogType = "INFO",
-            [switch]$SkipDialog
+            [switch]$SkipDialog,
+            [switch]$TabScoped
         )
         process {
             $Script:LogLines.Add([PSCustomObject]@{ LogType = $LogType; Message = $Message; SkipDialog = $SkipDialog.IsPresent })

--- a/tests/Set-ExecuteQueryButtonState.Tests.ps1
+++ b/tests/Set-ExecuteQueryButtonState.Tests.ps1
@@ -19,7 +19,8 @@ BeforeAll {
             [Parameter(ValueFromPipeline = $true)]$InputObject,
             [string]$LogType,
             $ErrorObject,
-            [switch]$SkipDialog
+            [switch]$SkipDialog,
+            [switch]$TabScoped
         )
         process { }
     }

--- a/tests/Start-OmadaBackgroundRequest.Tests.ps1
+++ b/tests/Start-OmadaBackgroundRequest.Tests.ps1
@@ -22,7 +22,8 @@ BeforeAll {
             [Parameter(ValueFromPipeline = $true)]$InputObject,
             [string]$LogType,
             $ErrorObject,
-            [switch]$SkipDialog
+            [switch]$SkipDialog,
+            [switch]$TabScoped
         )
         process { }
     }

--- a/tests/Stop-ExecuteQueryRequest.Tests.ps1
+++ b/tests/Stop-ExecuteQueryRequest.Tests.ps1
@@ -26,7 +26,8 @@ BeforeAll {
             [Parameter(ValueFromPipeline = $true)]$InputObject,
             [string]$LogType,
             $ErrorObject,
-            [switch]$SkipDialog
+            [switch]$SkipDialog,
+            [switch]$TabScoped
         )
         process { $script:LogMessages.Add([pscustomobject]@{ LogType = $LogType; Message = [string]$InputObject }) }
     }

--- a/tests/Update-QueryList.Tests.ps1
+++ b/tests/Update-QueryList.Tests.ps1
@@ -49,7 +49,8 @@ BeforeAll {
             [Parameter(ValueFromPipeline = $true)]$InputObject,
             [string]$LogType,
             $ErrorObject,
-            [switch]$SkipDialog
+            [switch]$SkipDialog,
+            [switch]$TabScoped
         )
         process { }
     }

--- a/tests/Update-SqlSchemaTreeFilter.Tests.ps1
+++ b/tests/Update-SqlSchemaTreeFilter.Tests.ps1
@@ -15,7 +15,8 @@ BeforeAll {
             [Parameter(ValueFromPipeline = $true)]$InputObject,
             [string]$LogType,
             $ErrorObject,
-            [switch]$SkipDialog
+            [switch]$SkipDialog,
+            [switch]$TabScoped
         )
         process { }
     }

--- a/tests/Write-ContainedErrorLog.Tests.ps1
+++ b/tests/Write-ContainedErrorLog.Tests.ps1
@@ -19,7 +19,8 @@ BeforeAll {
             [Parameter(ValueFromPipeline = $true)]$InputObject,
             [string]$LogType,
             $ErrorObject,
-            [switch]$SkipDialog
+            [switch]$SkipDialog,
+            [switch]$TabScoped
         )
         process {
             $script:LogMessages.Add([pscustomobject]@{ LogType = $LogType; Message = [string]$InputObject; ErrorObject = $ErrorObject })

--- a/tests/Write-ExecutePipelineLog.Tests.ps1
+++ b/tests/Write-ExecutePipelineLog.Tests.ps1
@@ -15,7 +15,8 @@ BeforeAll {
             [Parameter(ValueFromPipeline = $true)]$InputObject,
             [string]$LogType,
             $ErrorObject,
-            [switch]$SkipDialog
+            [switch]$SkipDialog,
+            [switch]$TabScoped
         )
         process { $script:LogMessages.Add([pscustomobject]@{ LogType = $LogType; Message = [string]$InputObject; SkipDialog = [bool]$SkipDialog }) }
     }

--- a/tests/Write-LoadedComponentLog.Tests.ps1
+++ b/tests/Write-LoadedComponentLog.Tests.ps1
@@ -17,7 +17,8 @@ BeforeAll {
             [Parameter(ValueFromPipeline = $true)]$InputObject,
             [string]$LogType,
             $ErrorObject,
-            [switch]$SkipDialog
+            [switch]$SkipDialog,
+            [switch]$TabScoped
         )
         process { $script:LogMessages.Add([pscustomobject]@{ LogType = $LogType; Message = [string]$InputObject }) }
     }


### PR DESCRIPTION
> **Stacked on #91.** Based on `bugfix/execute-fallback-and-tab-scoped-popup` and targeted at it, so the diff shows only this change. Retarget to `feature/async-query-execution` once #91 merges.

Query errors and warnings now belong to their tab. Application errors still show wherever the user is.

## The problem

Since queries run in the background (#40) a failure can arrive for a tab the user is not looking at. The modal then appears over whatever they are doing on a *different* tab, describing a query they cannot see — and because it is modal, they cannot carry on until they dismiss something irrelevant to them.

## The distinction it rests on

There are two different notions of "current tab", and conflating them is what made this wrong. `Test-ActiveTabIsOnScreen` makes it explicit:

| | What it means | When it changes |
|---|---|---|
| `$Script:ActiveTabId` | The tab being acted **for** | The poll timer steps into a completion's owning tab and restores afterwards |
| Tab control `SelectedItem` | The tab on **screen** | Only when the user switches tabs |

During a background query's completion these genuinely differ — and that is exactly the moment a modal must not appear.

## What changed

`Write-LogOutput` gains **`-TabScoped`**. A message marked with it that is raised while its tab is off screen is held on the tab session and shown when that tab is next opened.

**Opt-in, not opt-out.** Anything not marked keeps today's behaviour, because an application-level failure — configuration, WebView2 startup, module loading — is not about a tab and must be seen wherever the user is. Marked as tab-scoped: the dialog-raising sites in `Invoke-ExecuteQuery` and `Stop-ExecuteQueryRequest`.

| New | Does |
|---|---|
| `Test-ActiveTabIsOnScreen` | Is the tab being acted for the one on screen? |
| `Add-TabScopedMessage` | Hold a message on its tab |
| `Show-TabScopedMessage` | Show what was held, as one dialog, when the tab opens |
| `Show-LogMessageDialog` | The dialog itself, extracted so the immediate and deferred paths cannot drift |

## Decisions worth reviewing

- **Held, not suppressed.** The alternative — log it and show nothing — loses the interruption entirely, which is too quiet for a failure. It is already in the log either way; this just moves *when* the user is interrupted to a point where the message makes sense. Issue #93 is where this properly goes: a Messages pane beside the results, no modal at all.
- **Coalesced into one dialog.** Opening a tab that failed four times must not mean dismissing four modals in a row.
- **The queue is cleared BEFORE the dialog is shown, not after.** A modal pumps the dispatcher, which lets the completion poll timer run, which can enqueue another message for this same tab. Clearing afterwards would discard it unseen. There is a test for exactly this.
- **Capped at ten, oldest dropped.** A tab whose query fails repeatedly must not build a backlog that has to be read through when it is opened; the most recent failure describes the current state.
- **`Test-ActiveTabIsOnScreen` fails towards showing.** If the check throws, the message shows. Holding one back because the check failed would lose it until the user happened to switch tabs — the worse failure.
- **The console/no-window path is untouched.** No main window means no tabs to scope to.

## Verification

```
./build/build.ps1 -Task TestBuildOnly   →  851 tests, 0 failed; PSScriptAnalyzer clean
./build/build.ps1 -Task E2E             →   54 tests, 0 failed
```

14 new tests cover the acting-vs-visible distinction, holding, coalescing, the cap, the clear-before-show ordering, and that one tab's messages never surface on another.

A note on the test suite: `-TabScoped` had to be added to 19 `Write-LogOutput` stubs. Without it those calls fail to bind and are swallowed by the surrounding `catch`, which surfaced as unrelated assertions failing — worth knowing if a future parameter is added here.

## Follow-up

**#93** — the proper fix: a Messages pane beside the results grid, so query errors stop being modal at all. This PR is the interim step and sets up the tab-scoped/application-scoped split that #93 builds on.
