### PR TITLE
Let background execution recover, and unclip the log window's checkbox row

### DIFF
--- a/src/Lib/Functions/Private/Disable-OmadaBackgroundRequest.ps1
+++ b/src/Lib/Functions/Private/Disable-OmadaBackgroundRequest.ps1
@@ -43,11 +43,26 @@ function Disable-OmadaBackgroundRequest {
 
     $Script:OmadaBackgroundRequestsDisabled = $true
 
-    # WARNING, once, and not a dialog: nothing is broken from the user's point of view - the query
-    # they asked for is about to run on the UI thread and succeed. What they lose is the window
-    # staying responsive while it does, and that is worth one line in the log rather than a popup
-    # interrupting them.
-    "Background query execution is not available for this connection; falling back to running queries on the UI thread for the rest of this session. The window will not stay responsive during a query. Reason: {0}" -f $Reason | Write-LogOutput -LogType WARNING -SkipDialog
+    # Not a dialog: nothing is broken from the user's point of view - the query they asked for is
+    # about to run on the UI thread and succeed. What they lose is the window staying responsive
+    # while it does, and that is worth a line in the log rather than a popup interrupting them.
+    #
+    # WARNING only the first time. The disable is recoverable now, so this function can be reached
+    # several times in a session; repeating the same warning on each fallback would be noise about a
+    # condition the user has already been told about and cannot act on. Later falls back at DEBUG.
+    #
+    # The text deliberately does NOT promise "for the rest of this session" any more, because that is
+    # no longer true - Enable-OmadaBackgroundRequest turns it back on once a query has succeeded on
+    # the UI thread.
+    $Private:Message = "Background query execution is not available at the moment; falling back to running queries on the UI thread, so the window will not stay responsive during a query. It will be offered again once a query has succeeded. Reason: {0}" -f $Reason
+
+    if ($Script:OmadaBackgroundRequestWarned) {
+        $Private:Message | Write-LogOutput -LogType DEBUG
+    }
+    else {
+        $Script:OmadaBackgroundRequestWarned = $true
+        $Private:Message | Write-LogOutput -LogType WARNING -SkipDialog
+    }
 
     # The pool's workers are of no further use, and they are real threads. Initialize-OmadaRequestPool
     # rebuilds one on demand, so closing it here does not stand in the way of re-enabling later.

--- a/src/Lib/Functions/Private/Disable-OmadaBackgroundRequest.ps1
+++ b/src/Lib/Functions/Private/Disable-OmadaBackgroundRequest.ps1
@@ -17,10 +17,17 @@ function Disable-OmadaBackgroundRequest {
     request goes straight down the synchronous path that has always worked, with no doomed round-trip
     in front of it.
 
-    Deliberately session-scoped and one-way. Whether a worker can authenticate is a property of the
-    tenant and the authentication option, not of the moment, so re-probing it per query would cost a
-    failed request every time for an answer that will not have changed. Restarting the application
-    re-probes.
+    This used to be one-way for the session, on the reasoning that whether a worker can authenticate
+    is a property of the tenant and the authentication option rather than of the moment. A live
+    session disproved that. Background execution ran for nine minutes, the application then sat idle
+    for seventy, and the first query after the idle failed because the session had expired - which a
+    worker cannot recover from, since it has no way to sign in. The UI thread re-authenticated
+    seconds later and everything worked again, but background execution stayed off for the rest of
+    the session for no reason.
+
+    So it is now recoverable: Enable-OmadaBackgroundRequest turns it back on when a request has
+    demonstrably succeeded on the UI thread, because that proves a session exists again for a worker
+    to inherit. See there for how flapping is bounded.
 
     .PARAMETER Reason
     What went wrong, included in the single warning this writes.
@@ -42,6 +49,58 @@ function Disable-OmadaBackgroundRequest {
     # interrupting them.
     "Background query execution is not available for this connection; falling back to running queries on the UI thread for the rest of this session. The window will not stay responsive during a query. Reason: {0}" -f $Reason | Write-LogOutput -LogType WARNING -SkipDialog
 
-    # The pool's workers are of no further use, and they are real threads.
+    # The pool's workers are of no further use, and they are real threads. Initialize-OmadaRequestPool
+    # rebuilds one on demand, so closing it here does not stand in the way of re-enabling later.
     Close-OmadaRequestPool
+}
+
+function Enable-OmadaBackgroundRequest {
+    <#
+    .SYNOPSIS
+    Allow background execution again after a request has succeeded on the UI thread.
+
+    .DESCRIPTION
+    The disable exists to stop paying a doomed round-trip before every query. But the commonest
+    reason for it is an expired session, which is a property of the moment and not of the tenant: a
+    worker cannot sign in, so it fails; the UI thread signs in seconds later; and from then on there
+    is a live session for a worker to inherit through the cookie cache.
+
+    A request that has just succeeded on the UI thread is the proof that such a session exists, which
+    is why that is the trigger. Nothing probes speculatively.
+
+    Bounded, because the disable might instead be a worker that genuinely cannot ever run here - no
+    WebView2 runtime, say - and re-enabling that costs one failed request each time. After
+    $Script:OmadaBackgroundRequestReenableLimit attempts the session settles into disabled and stops
+    trying. Three is enough to ride out a few session expiries in a working setup, and cheap enough
+    in a broken one: three wasted round-trips across a whole session, not one per query.
+
+    Restarting the application resets the count, as it always did.
+    #>
+    [CmdletBinding()]
+    param()
+
+    if (-not $Script:OmadaBackgroundRequestsDisabled) {
+        return
+    }
+
+    if ($null -eq $Script:OmadaBackgroundRequestReenableLimit) {
+        $Script:OmadaBackgroundRequestReenableLimit = 3
+    }
+
+    if ([int]$Script:OmadaBackgroundRequestReenableCount -ge $Script:OmadaBackgroundRequestReenableLimit) {
+        # Said once, at DEBUG: the user was already told when it was disabled, and this is the
+        # detail of a decision they cannot act on.
+        if (-not $Script:OmadaBackgroundRequestReenableExhausted) {
+            $Script:OmadaBackgroundRequestReenableExhausted = $true
+            "Background query execution has failed {0} times after re-enabling; leaving it off for the rest of this session." -f $Script:OmadaBackgroundRequestReenableCount | Write-LogOutput -LogType DEBUG
+        }
+        return
+    }
+
+    $Script:OmadaBackgroundRequestReenableCount = [int]$Script:OmadaBackgroundRequestReenableCount + 1
+    $Script:OmadaBackgroundRequestsDisabled = $false
+
+    # INFO rather than a dialog: it is good news about something the user was told had gone away, so
+    # it belongs in the log where the warning was - but it interrupts nothing.
+    "A query succeeded on the UI thread, so background execution is available again. The window will stay responsive during a query." | Write-LogOutput -LogType INFO -SkipDialog
 }

--- a/src/Lib/Functions/Private/Invoke-ExecuteQuery.ps1
+++ b/src/Lib/Functions/Private/Invoke-ExecuteQuery.ps1
@@ -408,6 +408,16 @@ function Complete-ExecuteQueryPipeline {
             return
         }
 
+        # The chain succeeded. If background execution had been switched off - almost always because
+        # a worker met an expired session, which it cannot sign in to recover from - this is the
+        # evidence that a session exists again, so it is worth offering a worker the next query
+        # rather than staying on the UI thread for the rest of the session out of one stale
+        # conclusion. Enable-OmadaBackgroundRequest is a no-op when nothing was disabled, and bounds
+        # how often it will keep trying.
+        if ($AlreadyOnUiThread) {
+            Enable-OmadaBackgroundRequest
+        }
+
         # TempQueryDoId is passed as $null on purpose: the pipeline already deleted the temporary
         # object in its own finally, whatever the outcome. Passing it would delete it twice.
         Complete-ExecuteQueryResult -QueryResult $Outcome.QueryResult -SaveResult $Outcome.SaveResult -TempQueryDoId $null

--- a/src/Lib/ui/LogForm.xaml
+++ b/src/Lib/ui/LogForm.xaml
@@ -132,8 +132,13 @@
                     Grid.Column="1"
                     VerticalAlignment="Center">
             <Grid>
+                <!-- Log Level joins the buttons on this row. All five controls used to share the row
+                     below, which needs roughly 520px against a 450px window, so "Show request body"
+                     was clipped at the default size. -->
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="20"/>
                     <ColumnDefinition Width="Auto"/>
                     <ColumnDefinition Width="20"/>
                     <ColumnDefinition Width="Auto"/>
@@ -187,32 +192,37 @@
                                     IsHitTestVisible="False"/>
                     </Grid>
                 </Button>
+                <StackPanel Grid.Column="5"
+                            Orientation="Horizontal"
+                            VerticalAlignment="Center">
+                    <Label x:Name="LabelSelectLogLevel"
+                           Content="Log Level:"
+                           ToolTip="Select log level"
+                           VerticalAlignment="Center"
+                           Width="Auto"/>
+                    <Separator Width="10"/>
+                    <ComboBox x:Name="ComboBoxSelectLogLevel"
+                              ToolTip="Select log level"
+                              VerticalAlignment="Center"
+                              Width="80">
+                        <ComboBoxItem Content="LOG"/>
+                        <ComboBoxItem Content="INFO"/>
+                        <ComboBoxItem Content="WARNING"/>
+                        <ComboBoxItem Content="ERROR"/>
+                        <ComboBoxItem Content="FATAL"/>
+                        <ComboBoxItem Content="DEBUG"/>
+                        <ComboBoxItem Content="VERBOSE"/>
+                        <ComboBoxItem Content="VERBOSE2"/>
+                    </ComboBox>
+                </StackPanel>
             </Grid>
         </StackPanel>
         <StackPanel Orientation="Vertical"
                     Grid.Row="3"
                     Grid.Column="1"
                     VerticalAlignment="Center">
-            <StackPanel Orientation="Horizontal">
-                <Label x:Name="LabelSelectLogLevel"
-                       Content="Log Level:"
-                       ToolTip="Select log level"
-                       HorizontalAlignment="Left"
-                       Width="Auto"/>
-                <Separator Width="10"/>
-                <ComboBox x:Name="ComboBoxSelectLogLevel"
-                          ToolTip="Select log level"
-                          Width="80">
-                    <ComboBoxItem Content="LOG"/>
-                    <ComboBoxItem Content="INFO"/>
-                    <ComboBoxItem Content="WARNING"/>
-                    <ComboBoxItem Content="ERROR"/>
-                    <ComboBoxItem Content="FATAL"/>
-                    <ComboBoxItem Content="DEBUG"/>
-                    <ComboBoxItem Content="VERBOSE"/>
-                    <ComboBoxItem Content="VERBOSE2"/>
-                </ComboBox>
-                <Separator Width="20"/>
+            <StackPanel Orientation="Horizontal"
+                        HorizontalAlignment="Center">
                 <CheckBox x:Name="CheckboxWordWrap"
                           Content="Word wrap"
                           VerticalAlignment="Center"

--- a/tests/Disable-OmadaBackgroundRequest.Tests.ps1
+++ b/tests/Disable-OmadaBackgroundRequest.Tests.ps1
@@ -33,6 +33,7 @@ BeforeAll {
         $script:LogMessages.Clear()
         $script:PoolClosures = 0
         $Script:OmadaBackgroundRequestsDisabled = $false
+        $Script:OmadaBackgroundRequestWarned = $false
         $Script:ConnectionStatus = $true
     }
 }

--- a/tests/Enable-OmadaBackgroundRequest.Tests.ps1
+++ b/tests/Enable-OmadaBackgroundRequest.Tests.ps1
@@ -1,0 +1,124 @@
+#Requires -Version 7.0
+# From a live session (issue #40 test 1): background execution ran for nine minutes, the application
+# sat idle for seventy, and the first query after the idle failed because the session had expired -
+# which a worker cannot recover from, having no way to sign in. The UI thread re-authenticated
+# seconds later and every subsequent query worked, but background execution stayed off for the rest
+# of the session, so the remaining four minutes blocked the window for no reason.
+#
+# The disable was written as one-way on the reasoning that a worker's ability to authenticate is a
+# property of the tenant rather than of the moment. The log disproved that: the commonest cause is an
+# expired session, which is entirely of the moment.
+
+BeforeAll {
+    $ParentPath = Split-Path -Path $PSScriptRoot -Parent
+    $PrivatePath = Join-Path $ParentPath -ChildPath "src\Lib\Functions\Private"
+    . (Join-Path $PrivatePath -ChildPath "Disable-OmadaBackgroundRequest.ps1")
+    . (Join-Path $PrivatePath -ChildPath "Test-OmadaBackgroundRequestEligible.ps1")
+
+    $script:LogMessages = [System.Collections.Generic.List[object]]::new()
+    function Write-LogOutput {
+        param([Parameter(ValueFromPipeline = $true)]$InputObject, [string]$LogType, $ErrorObject, [switch]$SkipDialog, [switch]$TabScoped)
+        process { $script:LogMessages.Add([pscustomobject]@{ LogType = $LogType; Message = [string]$InputObject }) }
+    }
+
+    $script:PoolClosures = 0
+    function Close-OmadaRequestPool { $script:PoolClosures++ }
+
+    function script:Initialize-ReenableTestState {
+        $script:LogMessages.Clear()
+        $script:PoolClosures = 0
+        $Script:OmadaBackgroundRequestsDisabled = $false
+        $Script:OmadaBackgroundRequestReenableCount = 0
+        $Script:OmadaBackgroundRequestReenableLimit = 3
+        $Script:OmadaBackgroundRequestReenableExhausted = $false
+        $Script:ConnectionStatus = $true
+    }
+
+    function script:Test-Eligible { return Test-OmadaBackgroundRequestEligible -Parameters @{ ForceAuthentication = $false } }
+}
+
+Describe "Enable-OmadaBackgroundRequest" {
+    BeforeEach { Initialize-ReenableTestState }
+
+    It "offers a worker the next query once one has succeeded on the UI thread" {
+        # The whole point. An expired session is not a permanent property of the tenant.
+        Disable-OmadaBackgroundRequest -Reason "worker could not sign in"
+        Test-Eligible | Should -BeFalse
+
+        Enable-OmadaBackgroundRequest
+
+        Test-Eligible | Should -BeTrue
+    }
+
+    It "says so in the log, where the warning was, without a dialog" {
+        Disable-OmadaBackgroundRequest -Reason "worker could not sign in"
+        $script:LogMessages.Clear()
+
+        Enable-OmadaBackgroundRequest
+
+        $Private:Info = @($script:LogMessages | Where-Object { $_.LogType -eq "INFO" })
+        $Private:Info.Count | Should -Be 1
+        $Private:Info[0].Message | Should -Match "available again"
+    }
+
+    It "does nothing when background execution was never switched off" {
+        Enable-OmadaBackgroundRequest
+
+        @($script:LogMessages).Count | Should -Be 0
+        Test-Eligible | Should -BeTrue
+    }
+
+    It "stops trying after the limit, so a genuinely broken worker settles down" {
+        # The other half of the trade. If the worker can never run here - no WebView2 runtime - each
+        # re-enable costs one failed request. Three across a whole session is acceptable; one per
+        # query is not.
+        1..4 | ForEach-Object {
+            Disable-OmadaBackgroundRequest -Reason "worker cannot run here"
+            Enable-OmadaBackgroundRequest
+        }
+
+        Test-Eligible | Should -BeFalse
+        $Script:OmadaBackgroundRequestReenableCount | Should -Be 3
+    }
+
+    It "explains the give-up once, at DEBUG" {
+        1..5 | ForEach-Object {
+            Disable-OmadaBackgroundRequest -Reason "worker cannot run here"
+            Enable-OmadaBackgroundRequest
+        }
+
+        $Private:GiveUp = @($script:LogMessages | Where-Object { $_.LogType -eq "DEBUG" -and $_.Message -match "leaving it off" })
+        $Private:GiveUp.Count | Should -Be 1
+    }
+
+    It "lets the pool be rebuilt, because disabling closed it" {
+        # Close-OmadaRequestPool nulls the pool and Initialize-OmadaRequestPool recreates one on
+        # demand, so re-enabling needs nothing beyond clearing the flag - but if that ever changes,
+        # this is where it shows up.
+        Disable-OmadaBackgroundRequest -Reason "worker could not sign in"
+        $script:PoolClosures | Should -Be 1
+
+        Enable-OmadaBackgroundRequest
+
+        Test-Eligible | Should -BeTrue
+    }
+
+    It "still refuses while the tab is disconnected" {
+        # Re-enabling is about the worker, not about the tab. A disconnected tab has nothing to run.
+        Disable-OmadaBackgroundRequest -Reason "worker could not sign in"
+        Enable-OmadaBackgroundRequest
+        $Script:ConnectionStatus = $false
+
+        Test-Eligible | Should -BeFalse
+    }
+}
+
+Describe "The re-enable is driven by a UI-thread success" {
+    It "is called only on the already-on-the-UI-thread success path" {
+        # A background success cannot be evidence that the UI thread has a session - and background
+        # is disabled at that point anyway, so there is nothing to re-enable.
+        $Private:Source = Get-Content -Path (Join-Path (Join-Path (Split-Path -Path $PSScriptRoot -Parent) "src\Lib\Functions\Private") "Invoke-ExecuteQuery.ps1") -Raw
+
+        $Private:Source | Should -Match '(?s)if \(\$AlreadyOnUiThread\) \{\s*Enable-OmadaBackgroundRequest'
+    }
+}

--- a/tests/Enable-OmadaBackgroundRequest.Tests.ps1
+++ b/tests/Enable-OmadaBackgroundRequest.Tests.ps1
@@ -28,6 +28,7 @@ BeforeAll {
         $script:LogMessages.Clear()
         $script:PoolClosures = 0
         $Script:OmadaBackgroundRequestsDisabled = $false
+        $Script:OmadaBackgroundRequestWarned = $false
         $Script:OmadaBackgroundRequestReenableCount = 0
         $Script:OmadaBackgroundRequestReenableLimit = 3
         $Script:OmadaBackgroundRequestReenableExhausted = $false
@@ -110,6 +111,48 @@ Describe "Enable-OmadaBackgroundRequest" {
         $Script:ConnectionStatus = $false
 
         Test-Eligible | Should -BeFalse
+    }
+}
+
+Describe "The fallback warning matches what actually happens" {
+    BeforeEach { Initialize-ReenableTestState }
+
+    It "does not promise that background execution is gone for the session" {
+        # It used to say "for the rest of this session", which stopped being true the moment the
+        # disable became recoverable - and a message that overstates the damage is worse than none.
+        Disable-OmadaBackgroundRequest -Reason "worker could not sign in"
+
+        $Private:Warning = @($script:LogMessages | Where-Object { $_.LogType -eq "WARNING" })[0]
+        $Private:Warning.Message | Should -Not -Match "rest of this session"
+        $Private:Warning.Message | Should -Match "offered again"
+    }
+
+    It "still says what the user actually loses, and why" {
+        Disable-OmadaBackgroundRequest -Reason "worker could not sign in"
+
+        $Private:Warning = @($script:LogMessages | Where-Object { $_.LogType -eq "WARNING" })[0]
+        $Private:Warning.Message | Should -Match "will not stay responsive"
+        $Private:Warning.Message | Should -Match "worker could not sign in"
+    }
+
+    It "warns once per session, not once per fallback" {
+        # Recoverable means this can be reached several times. Repeating the same warning each time
+        # would be noise about a condition the user has been told about and cannot act on.
+        Disable-OmadaBackgroundRequest -Reason "first"
+        Enable-OmadaBackgroundRequest
+        Disable-OmadaBackgroundRequest -Reason "second"
+        Enable-OmadaBackgroundRequest
+        Disable-OmadaBackgroundRequest -Reason "third"
+
+        @($script:LogMessages | Where-Object { $_.LogType -eq "WARNING" }).Count | Should -Be 1
+    }
+
+    It "still records the later fallbacks, at DEBUG" {
+        Disable-OmadaBackgroundRequest -Reason "first"
+        Enable-OmadaBackgroundRequest
+        Disable-OmadaBackgroundRequest -Reason "second"
+
+        @($script:LogMessages | Where-Object { $_.LogType -eq "DEBUG" -and $_.Message -match "second" }).Count | Should -Be 1
     }
 }
 

--- a/tests/Invoke-ExecuteQuery.Tests.ps1
+++ b/tests/Invoke-ExecuteQuery.Tests.ps1
@@ -52,6 +52,12 @@ BeforeAll {
         $script:DisableReasons.Add([string]$Reason)
     }
 
+    # A UI-thread success re-offers background execution for the next query - an expired session is
+    # of the moment, not a property of the tenant. Recorded rather than exercised here; the decision
+    # itself is asserted in Enable-OmadaBackgroundRequest.Tests.ps1.
+    $script:ReenableCalls = 0
+    function Enable-OmadaBackgroundRequest { $script:ReenableCalls++ }
+
     function Build-OmadaRequestParameter { return @{ SessionKey = "pool" } }
 
     # Records what the inline retry was asked to run, and answers with whatever the test set up.


### PR DESCRIPTION
Two independent fixes, both from the live session that answered *"does background execution survive?"*.

## 1. The disable was too pessimistic

From the log:

| Time | |
|---|---|
| 17:37 – 17:46 | 5 background executes, all successful |
| 17:46 – 18:56 | **70 minutes idle** |
| 18:57:02 | First query after the idle — worker cannot sign in → **background disabled for the session** |
| 18:57:53 | UI thread re-authenticates; query succeeds — and every one after it |
| 18:57 – 19:02 | Ran on the UI thread anyway, blocking the window, for nothing |

`Disable-OmadaBackgroundRequest` was written one-way, on this reasoning:

> Whether a worker can authenticate is a property of the tenant and the authentication option, not of the moment, so re-probing it per query would cost a failed request every time for an answer that will not have changed.

**The log disproves that.** The commonest cause is an expired session, which is entirely of the moment — a worker cannot sign in, so it fails; the UI thread signs in seconds later; and from then on there is a live session for a worker to inherit through the cookie cache.

`Enable-OmadaBackgroundRequest` turns it back on when a query has **succeeded on the UI thread**. That success is the evidence a session exists, and it was going to happen anyway — nothing probes speculatively.

## 2. "Show request body" was clipped

All five controls shared one row: `Log Level:` + combo + three checkboxes ≈ 500px against a 450px window. Log Level moves up to join Save and Clear, leaving the checkboxes a row of their own — the layout in the mockup.

Measured after the change, by loading the XAML and measuring desired widths:

| Row | Needs | Available |
|---|---|---|
| Save · Clear · Log Level | 388px | ~430px |
| Word wrap · Console Log · Show request body | 326px | ~430px |

## Decisions worth reviewing

- **Bounded at three re-enables per session.** The disable might instead be a worker that genuinely can never run here — no WebView2 runtime — and re-enabling that costs one failed request each time. Three rides out several session expiries in a working setup and stays cheap in a broken one: three wasted round-trips across a whole session, not one per query. After that it settles into disabled and says so once, at DEBUG.
- **The trigger is a UI-thread success, not a reconnect.** In the observed session there was no explicit reconnect — the user simply ran the query again and it worked. Hooking `Set-SqlConnectionState` would have missed it entirely.
- **Gated on `-AlreadyOnUiThread`.** A background success cannot be evidence that the UI thread has a session, and background is disabled at that point anyway, so there would be nothing to re-enable. Pinned by a test.
- **INFO, not a dialog.** It is good news about something the user was told had gone away, so it belongs in the log where the warning was — but it interrupts nothing.
- **Both rows centred** in the log window, following the existing design (the buttons were already centred by `*` columns). If you would rather have them left-aligned to match the mockup exactly, that is a one-line change.

## Verification

```
./build/build.ps1 -Task TestBuildOnly   ->  881 tests, 0 failed; PSScriptAnalyzer clean
./build/build.ps1 -Task E2E             ->   54 tests, 0 failed
```

The XAML is loaded and its named controls resolved in a test, so a rename or a broken layout fails the build rather than only showing up when someone opens the window.

## Not fixed here

The underlying cause — the session expiring while the application sits idle — is #89, which still needs Fortigi/OmadaWeb.PS#84. This makes the symptom recoverable rather than removing it.

Part of #40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JJXt2rS8P98gdTtx5EYEXN
