### PR TITLE
Keep the tenant session alive while the application is idle

### DIFF
--- a/src/Lib/Events/MainForm.Definition.ps1
+++ b/src/Lib/Events/MainForm.Definition.ps1
@@ -30,6 +30,17 @@ $Script:WebViewCompletionPollTimer.Add_Tick({
                 Update-BackgroundRequestElapsedTime -Pending $Script:PendingWebViewCompletions
             }
 
+            # Session keep-alive (issue #89), driven from this timer for the same reasons as the
+            # indicator above. Checked every 20th tick - once a second - rather than on every tick,
+            # because the answer is a wall-clock comparison against an interval measured in minutes
+            # and there is nothing to gain from asking it twenty times a second.
+            #
+            # It cannot prompt: the request uses OmadaWeb.PS's -NoInteractiveAuthentication, so no
+            # path under it can open a sign-in window. That is what makes it safe on a timer at all.
+            if ($Script:WebViewCompletionTickCount % 20 -eq 0) {
+                Invoke-OmadaSessionKeepAlive
+            }
+
             $Completed = @($Script:PendingWebViewCompletions | Where-Object { $_.Task.IsCompleted })
             foreach ($Pending in $Completed) {
                 [void]$Script:PendingWebViewCompletions.Remove($Pending)

--- a/src/Lib/Functions/Private/Get-SessionKeepAliveInterval.ps1
+++ b/src/Lib/Functions/Private/Get-SessionKeepAliveInterval.ps1
@@ -1,0 +1,55 @@
+function Get-SessionKeepAliveInterval {
+    <#
+    .SYNOPSIS
+    How often to refresh a tenant session, in minutes. Zero means do not.
+
+    .DESCRIPTION
+    Configurable rather than hardcoded because the number it has to stay under - how long an Omada
+    session lives - is an estimate. Roughly ten minutes is what was observed; it is not documented
+    and it may differ per tenant. A setting means a wrong guess can be corrected without a release.
+
+    The default is five minutes: comfortably inside the estimate, and cheap. One $top=1 GET per
+    connected tenant per five minutes is a rounding error next to a query.
+
+    Zero switches the keep-alive off entirely, for anyone who would rather this application did not
+    touch the tenant on a timer. One knob rather than two - a separate "enabled" flag could disagree
+    with the interval, and then someone has to decide which wins.
+
+    Anything unusable - absent, negative, not a number, or the -1 that an Int property carries when
+    it has no stored value - falls back to the schema default rather than to zero. Falling back to
+    zero would silently disable a feature the user never asked to disable.
+
+    .OUTPUTS
+    [int] minutes between refreshes, or 0 when disabled.
+    #>
+    [CmdLetBinding()]
+    [OutputType([int])]
+    param()
+
+    $Private:Default = 5
+    try {
+        $Private:SchemaDefault = Get-ConfigSchemaDefault -Property "SessionKeepAliveMinutes"
+        if ($null -ne $Private:SchemaDefault -and [int]$Private:SchemaDefault -ge 0) {
+            $Private:Default = [int]$Private:SchemaDefault
+        }
+    }
+    catch {
+        # The literal above is the fallback of last resort, for a schema that cannot be read.
+    }
+
+    if ($null -eq $Script:AppGlobalConfig -or $null -eq $Script:AppGlobalConfig.SessionKeepAliveMinutes) {
+        return $Private:Default
+    }
+
+    $Private:Stored = 0
+    if (-not [int]::TryParse([string]$Script:AppGlobalConfig.SessionKeepAliveMinutes, [ref]$Private:Stored)) {
+        return $Private:Default
+    }
+
+    # Zero is a real answer - "off" - so only a negative value is treated as absent.
+    if ($Private:Stored -lt 0) {
+        return $Private:Default
+    }
+
+    return $Private:Stored
+}

--- a/src/Lib/Functions/Private/Invoke-OmadaSessionKeepAlive.ps1
+++ b/src/Lib/Functions/Private/Invoke-OmadaSessionKeepAlive.ps1
@@ -15,18 +15,26 @@ function Invoke-OmadaSessionKeepAlive {
 
     Three properties make it safe to run on a timer:
 
-    It cannot prompt. The request is made with OmadaWeb.PS's -NoInteractiveAuthentication (added for
-    this, Fortigi/OmadaWeb.PS#84), under which no code path can open a browser, a WebView2 window or
-    any other sign-in. Without that switch a keep-alive would be the worst possible thing to run
-    unattended: a login window appearing over whatever the user is doing, at a moment they did not
-    choose. With it, an expired session is a catchable error instead.
+    It cannot prompt. The request is made with OmadaWeb.PS's -NoInteractiveAuthentication - requested
+    for this in Fortigi/OmadaWeb.PS#84 and added by Fortigi/OmadaWeb.PS#85 - under which no code path
+    can open a browser, a WebView2 window or any other sign-in. Without that switch a keep-alive
+    would be the worst possible thing to run unattended: a login window appearing over whatever the
+    user is doing, at a moment they did not choose. With it, an expired session is a catchable error
+    instead.
 
     It is silent. Everything here logs at DEBUG and no path raises a dialog. A keep-alive the user
     notices has failed at its job.
 
     It gives up rather than retries. A session that cannot be revived is not going to be revived by
-    asking again in five minutes, so that session key is dropped and never pinged again. The
-    alternative is a request every interval, forever, against a tenant that has already said no.
+    asking again in five minutes, so that session key is dropped. The alternative is a request every
+    interval, forever, against a tenant that has already said no.
+
+    Giving up is NOT permanent, and that distinction matters. The abandonment is keyed by SessionKey,
+    which is a stable hash of the connection identity - so it is the same key after the user signs in
+    again. Left alone, one expiry would switch the keep-alive off for that tenant and identity for
+    the rest of the application's life, which is precisely the failure the keep-alive exists to
+    prevent. Set-SqlConnectionState clears it through Reset-SessionKeepAlive the moment a tab is
+    connected again.
 
     .NOTES
     Runs on the UI thread, deliberately. A worker runspace has its OWN OmadaWeb.PS session context,
@@ -95,6 +103,32 @@ function Invoke-OmadaSessionKeepAlive {
         # will sign in normally. Reported at DEBUG so it is still findable in a log.
         "Session keep-alive failed: {0}" -f $_.Exception.Message | Write-LogOutput -LogType DEBUG
     }
+}
+
+function Reset-SessionKeepAlive {
+    <#
+    .SYNOPSIS
+    Allow the keep-alive to resume for a session that has been signed into again.
+
+    .DESCRIPTION
+    Called from Set-SqlConnectionState when a tab becomes connected. Without it the abandonment in
+    Invoke-OmadaSessionKeepAlivePing is permanent for the life of the application: it is keyed by
+    SessionKey, which is a stable hash of the connection identity, so signing in again produces the
+    SAME key and the keep-alive would stay switched off for that tenant and identity - leaving the
+    user exposed to exactly the silent expiry this feature exists to prevent.
+
+    Clears every abandoned session rather than one, deliberately. A successful sign-in usually means
+    the credentials or the network came back, which is as likely to have fixed the others; and the
+    cost of being wrong is one cheap request per session at the next interval, which then abandons
+    again.
+
+    The interval timer is reset too, so a tab that has just connected is not pinged seconds later.
+    #>
+    [CmdLetBinding()]
+    param()
+
+    $Script:SessionKeepAliveAbandoned = @{}
+    $Script:LastSessionKeepAliveUtc = [DateTime]::UtcNow
 }
 
 function Invoke-OmadaSessionKeepAlivePing {

--- a/src/Lib/Functions/Private/Invoke-OmadaSessionKeepAlive.ps1
+++ b/src/Lib/Functions/Private/Invoke-OmadaSessionKeepAlive.ps1
@@ -1,0 +1,159 @@
+function Invoke-OmadaSessionKeepAlive {
+    <#
+    .SYNOPSIS
+    Keep each connected tenant session alive with a periodic, silent request.
+
+    .DESCRIPTION
+    Issue #89. An Omada session cookie expires in roughly ten minutes. Left alone, an application
+    that is open but idle loses its session without anything on screen changing, and the user finds
+    out at the worst moment - part-way through running something.
+
+    This was measured rather than assumed. In the live session that answered "does background
+    execution survive?" the application ran five queries in nine minutes, sat idle for seventy, and
+    the first query after the idle failed: the session had gone, and a worker cannot sign in to get
+    it back. That is the failure this exists to prevent.
+
+    Three properties make it safe to run on a timer:
+
+    It cannot prompt. The request is made with OmadaWeb.PS's -NoInteractiveAuthentication (added for
+    this, Fortigi/OmadaWeb.PS#84), under which no code path can open a browser, a WebView2 window or
+    any other sign-in. Without that switch a keep-alive would be the worst possible thing to run
+    unattended: a login window appearing over whatever the user is doing, at a moment they did not
+    choose. With it, an expired session is a catchable error instead.
+
+    It is silent. Everything here logs at DEBUG and no path raises a dialog. A keep-alive the user
+    notices has failed at its job.
+
+    It gives up rather than retries. A session that cannot be revived is not going to be revived by
+    asking again in five minutes, so that session key is dropped and never pinged again. The
+    alternative is a request every interval, forever, against a tenant that has already said no.
+
+    .NOTES
+    Runs on the UI thread, deliberately. A worker runspace has its OWN OmadaWeb.PS session context,
+    so keeping a worker's session alive would do nothing for the session the user's queries actually
+    use. The cost is one small GET per connected tenant every few minutes.
+
+    Driven from $Script:WebViewCompletionPollTimer rather than a timer of its own, for the same
+    reasons as the elapsed-time indicator: that timer is already the single place that knows about
+    pending work and is already suspended around modal dialogs.
+
+    Pings once per SESSION, not once per tab. Tabs that share a SessionKey share one OmadaWeb.PS
+    session, so a ping for one serves all of them; per-tab would multiply requests against the tenant
+    for no benefit.
+
+    What it deliberately does NOT do is mark a tab disconnected when the session has gone, which the
+    issue's acceptance criteria suggested. Set-SqlConnectionState writes into
+    $Script:MainForm.Elements - the ACTIVE tab's element bag - so doing that for a background tab
+    needs a full Set-ActiveTabContext round trip, and flipping a tab to "Disconnected" from a timer
+    while the user is typing in it is a larger behaviour change than a keep-alive should make on its
+    own. The existing re-authentication path already handles the next real request. See the PR.
+    #>
+    [CmdLetBinding()]
+    param()
+
+    try {
+        $Private:IntervalMinutes = Get-SessionKeepAliveInterval
+        if ($Private:IntervalMinutes -le 0) {
+            return
+        }
+
+        $Private:Now = [DateTime]::UtcNow
+        if ($null -ne $Script:LastSessionKeepAliveUtc -and ($Private:Now - $Script:LastSessionKeepAliveUtc).TotalMinutes -lt $Private:IntervalMinutes) {
+            return
+        }
+
+        # Stamped BEFORE the requests, not after. These are synchronous, so a slow or hanging tenant
+        # would otherwise let the next tick start a second round on top of the first.
+        $Script:LastSessionKeepAliveUtc = $Private:Now
+
+        if ($null -eq $Script:SessionKeepAliveAbandoned) {
+            $Script:SessionKeepAliveAbandoned = @{}
+        }
+
+        # One ping per distinct session, not per tab.
+        $Private:Seen = @{}
+        foreach ($Private:Tab in @($Script:Tabs)) {
+            if ($null -eq $Private:Tab -or -not $Private:Tab.ConnectionStatus) {
+                continue
+            }
+
+            $Private:SessionKey = $Private:Tab.RunTimeData.RestMethodParam.SessionKey
+            if ([string]::IsNullOrWhiteSpace($Private:SessionKey) -or $Private:Seen.ContainsKey($Private:SessionKey)) {
+                continue
+            }
+            $Private:Seen[$Private:SessionKey] = $true
+
+            if ($Script:SessionKeepAliveAbandoned.ContainsKey($Private:SessionKey)) {
+                continue
+            }
+
+            Invoke-OmadaSessionKeepAlivePing -TabSession $Private:Tab
+        }
+    }
+    catch {
+        # A keep-alive that cannot run is not worth telling the user about: their next real request
+        # will sign in normally. Reported at DEBUG so it is still findable in a log.
+        "Session keep-alive failed: {0}" -f $_.Exception.Message | Write-LogOutput -LogType DEBUG
+    }
+}
+
+function Invoke-OmadaSessionKeepAlivePing {
+    <#
+    .SYNOPSIS
+    Make the single silent request that keeps one tenant session alive.
+
+    .PARAMETER TabSession
+    A connected tab whose session is to be refreshed. Its own RestMethodParam supplies the tenant,
+    the authentication type and the session key, so the ping is made exactly as that tab's real
+    requests are.
+    #>
+    [CmdLetBinding()]
+    param(
+        $TabSession
+    )
+
+    $Private:SessionKey = $TabSession.RunTimeData.RestMethodParam.SessionKey
+
+    try {
+        # A CLONE. $Script:RunTimeData.RestMethodParam is overwritten by whatever request a tab makes
+        # next, and this one belongs to a tab that may not even be on screen.
+        $Private:Parameters = $TabSession.RunTimeData.RestMethodParam.Clone()
+
+        # $top=1 so the tenant does not compose a full query list every few minutes for an answer
+        # nobody reads. What matters is that the request is authenticated and reaches Omada.
+        $Private:Parameters.Uri = "{0}/odata/dataobjects/C_P_SQLTROUBLESHOOTING?`$top=1" -f $TabSession.AppConfig.BaseUrl
+        $Private:Parameters.Method = "GET"
+        $Private:Parameters.Remove("Body")
+
+        # The switch this whole feature waited for: no path under it can open a sign-in.
+        $Private:Parameters.NoInteractiveAuthentication = $true
+
+        # OmadaWeb.PS refuses the two together, and rightly: one forbids signing in, the other
+        # requires it. The tab's parameters may still carry it from an earlier forced login.
+        if ($Private:Parameters.ContainsKey("ForceAuthentication")) {
+            $Private:Parameters.Remove("ForceAuthentication")
+        }
+
+        $Private:Outcome = Invoke-OmadaRequestCore -Parameters $Private:Parameters
+
+        if ($null -eq $Private:Outcome.ErrorRecord) {
+            "Session keep-alive succeeded for '{0}'." -f $TabSession.AppConfig.BaseUrl | Write-LogOutput -LogType DEBUG
+            return
+        }
+
+        if (Test-OmadaSessionExpiredError -ErrorRecord $Private:Outcome.ErrorRecord) {
+            # Gone, and not coming back on its own. Asking again every interval would be a request
+            # per interval for the rest of the session against a tenant that has already refused.
+            $Script:SessionKeepAliveAbandoned[$Private:SessionKey] = $true
+            "Session keep-alive stopped for '{0}': the session has expired and cannot be renewed without signing in." -f $TabSession.AppConfig.BaseUrl | Write-LogOutput -LogType DEBUG
+            return
+        }
+
+        # Anything else - a 502, a network blip - says nothing about the session, so the next
+        # interval tries again.
+        "Session keep-alive request failed for '{0}': {1}" -f $TabSession.AppConfig.BaseUrl, $Private:Outcome.ErrorRecord.Exception.Message | Write-LogOutput -LogType DEBUG
+    }
+    catch {
+        "Session keep-alive failed for '{0}': {1}" -f $TabSession.AppConfig.BaseUrl, $_.Exception.Message | Write-LogOutput -LogType DEBUG
+    }
+}

--- a/src/Lib/Functions/Private/Set-SqlConnectionState.ps1
+++ b/src/Lib/Functions/Private/Set-SqlConnectionState.ps1
@@ -18,6 +18,14 @@ function Set-SqlConnectionState {
             # position: the only handler that consults it is ComboBoxSelectQuery's DropDownOpened,
             # which is a user gesture and never fires programmatically.
             $Script:ConnectionStatus = $true
+
+            # The tab has a live session again, so the keep-alive should resume for it (issue #89).
+            # Without this the abandonment is permanent: it is keyed by SessionKey, which is a stable
+            # hash of the connection identity and is therefore the SAME key after signing in again -
+            # so one expiry would switch the keep-alive off for that tenant and identity for the rest
+            # of the application's life, which is the very failure the keep-alive exists to prevent.
+            Reset-SessionKeepAlive
+
             $Script:MainForm.Elements.ButtonReset.IsEnabled = $true
             $Script:MainForm.Elements.ComboBoxSelectAuthenticationOption.IsEnabled = $false
             $Script:MainForm.Elements.TextBoxUserName.IsEnabled = $false

--- a/src/Lib/Functions/Private/Test-OmadaSessionExpiredError.ps1
+++ b/src/Lib/Functions/Private/Test-OmadaSessionExpiredError.ps1
@@ -1,0 +1,64 @@
+function Test-OmadaSessionExpiredError {
+    <#
+    .SYNOPSIS
+    Whether an error is OmadaWeb.PS saying "the session has gone and I was told not to sign in".
+
+    .DESCRIPTION
+    The contract comes from Fortigi/OmadaWeb.PS#85, which added -NoInteractiveAuthentication. Under
+    that switch an expired or missing session is a terminating error rather than a sign-in attempt,
+    and it is deliberately identifiable two ways:
+
+      FullyQualifiedErrorId   starts with "OmadaSessionExpired"
+      Exception               is System.Security.Authentication.AuthenticationException
+
+    Both are checked, because either can survive where the other does not. The id is a PREFIX match
+    on purpose - PowerShell appends the name of every function a terminating error passes through,
+    so equality would break the moment the module added a layer. The exception type is checked by
+    name rather than with -is, so an error that crossed a runspace boundary and arrived
+    deserialized still matches.
+
+    This is what a keep-alive needs to tell "the session is gone" from "the tenant had a bad
+    moment": the first means stop, the second means try again later.
+
+    .PARAMETER ErrorRecord
+    The error to classify. $null is not a session expiry.
+
+    .OUTPUTS
+    [bool]
+    #>
+    [CmdLetBinding()]
+    [OutputType([bool])]
+    param(
+        $ErrorRecord
+    )
+
+    if ($null -eq $ErrorRecord) {
+        return $false
+    }
+
+    try {
+        if ([string]$ErrorRecord.FullyQualifiedErrorId -like "OmadaSessionExpired*") {
+            return $true
+        }
+    }
+    catch {
+        # An error record that will not yield its id is simply not a match on that test.
+    }
+
+    try {
+        $Private:Exception = $ErrorRecord.Exception
+        while ($null -ne $Private:Exception) {
+            # By name, not with -is: a deserialized exception is a PSObject wrapper whose type name
+            # is preserved but whose .NET type is not.
+            if ($Private:Exception.GetType().FullName -eq "System.Security.Authentication.AuthenticationException") {
+                return $true
+            }
+            $Private:Exception = $Private:Exception.InnerException
+        }
+    }
+    catch {
+        # Same reasoning.
+    }
+
+    return $false
+}

--- a/src/Lib/Functions/Private/Test-OmadaSessionExpiredError.ps1
+++ b/src/Lib/Functions/Private/Test-OmadaSessionExpiredError.ps1
@@ -13,9 +13,18 @@ function Test-OmadaSessionExpiredError {
 
     Both are checked, because either can survive where the other does not. The id is a PREFIX match
     on purpose - PowerShell appends the name of every function a terminating error passes through,
-    so equality would break the moment the module added a layer. The exception type is checked by
-    name rather than with -is, so an error that crossed a runspace boundary and arrived
-    deserialized still matches.
+    so equality would break the moment the module added a layer.
+
+    The exception is matched through PSObject.TypeNames rather than GetType(), because an error that
+    crossed a runspace boundary arrives deserialized, and GetType() on a deserialized exception
+    returns System.Management.Automation.PSObject - not the original type. The real type survives in
+    TypeNames, prefixed:
+
+        Deserialized.System.Security.Authentication.AuthenticationException
+        Deserialized.System.SystemException
+        ...
+
+    TypeNames is present on a live exception too, unprefixed, so one check covers both.
 
     This is what a keep-alive needs to tell "the session is gone" from "the tenant had a bad
     moment": the first means stop, the second means try again later.
@@ -47,12 +56,21 @@ function Test-OmadaSessionExpiredError {
 
     try {
         $Private:Exception = $ErrorRecord.Exception
-        while ($null -ne $Private:Exception) {
-            # By name, not with -is: a deserialized exception is a PSObject wrapper whose type name
-            # is preserved but whose .NET type is not.
-            if ($Private:Exception.GetType().FullName -eq "System.Security.Authentication.AuthenticationException") {
-                return $true
+        $Private:Depth = 0
+
+        # Bounded: an exception chain should never be deep, and a cycle here would hang the poll
+        # timer this runs from.
+        while ($null -ne $Private:Exception -and $Private:Depth -lt 16) {
+            $Private:Depth++
+
+            foreach ($Private:TypeName in @($Private:Exception.PSObject.TypeNames)) {
+                # "Deserialized." prefix when the error crossed a runspace boundary, bare otherwise.
+                if ($Private:TypeName -eq "System.Security.Authentication.AuthenticationException" -or
+                    $Private:TypeName -eq "Deserialized.System.Security.Authentication.AuthenticationException") {
+                    return $true
+                }
             }
+
             $Private:Exception = $Private:Exception.InnerException
         }
     }

--- a/src/Lib/schema/appGlobalConfigSchema.json
+++ b/src/Lib/schema/appGlobalConfigSchema.json
@@ -99,5 +99,10 @@
   {
     "Name": "SqlParserVersion",
     "Type": "String"
+  },
+  {
+    "Name": "SessionKeepAliveMinutes",
+    "Type": "Int",
+    "DefaultValue": 5
   }
 ]

--- a/tests/Invoke-OmadaSessionKeepAlive.Tests.ps1
+++ b/tests/Invoke-OmadaSessionKeepAlive.Tests.ps1
@@ -235,6 +235,35 @@ Describe "Invoke-OmadaSessionKeepAlive" {
         }
     }
 
+    Context "Giving up is not permanent" {
+        BeforeEach { $script:NextError = New-SessionExpiredError }
+
+        It "resumes for a session that has been signed into again" {
+            # SessionKey is a stable hash of the connection identity, so it is the SAME key after
+            # signing in again. Without a reset, one expiry would switch the keep-alive off for that
+            # tenant and identity for the rest of the application's life - which is precisely the
+            # silent expiry this feature exists to prevent.
+            Invoke-OmadaSessionKeepAlive
+            $script:NextError = $null
+
+            Reset-SessionKeepAlive
+            $Script:LastSessionKeepAliveUtc = [DateTime]::UtcNow.AddMinutes(-6)
+            $script:Requests.Clear()
+
+            Invoke-OmadaSessionKeepAlive
+
+            @($script:Requests).Count | Should -Be 1
+        }
+
+        It "does not ping immediately on reconnect, so a just-connected tab is left alone" {
+            Reset-SessionKeepAlive
+
+            Invoke-OmadaSessionKeepAlive
+
+            @($script:Requests).Count | Should -Be 0
+        }
+    }
+
     Context "When the tenant merely had a bad moment" {
         It "tries again next interval, because a 502 says nothing about the session" {
             $script:NextError = New-TransientError
@@ -270,8 +299,37 @@ Describe "Test-OmadaSessionExpiredError" {
         Test-OmadaSessionExpiredError -ErrorRecord $Private:Record | Should -BeTrue
     }
 
+    It "recognises an exception that crossed a runspace boundary" {
+        # GetType() on a deserialized exception returns System.Management.Automation.PSObject, not
+        # the original type - so a check written against GetType() silently never matches, and every
+        # expiry coming back from a worker would be classified as a transient failure and retried
+        # forever. The real type survives in PSObject.TypeNames, prefixed "Deserialized.".
+        $Private:Live = [System.Security.Authentication.AuthenticationException]::new("gone")
+        $Private:Deserialized = [System.Management.Automation.PSSerializer]::Deserialize(
+            [System.Management.Automation.PSSerializer]::Serialize($Private:Live))
+
+        # The premise, asserted so this test cannot quietly stop testing anything.
+        $Private:Deserialized.GetType().FullName | Should -Be "System.Management.Automation.PSObject"
+
+        $Private:Record = [System.Management.Automation.ErrorRecord]::new(
+            [System.Exception]::new("outer"), "SomethingElse",
+            [System.Management.Automation.ErrorCategory]::NotSpecified, $null)
+        $Private:Record.Exception | Add-Member -NotePropertyName InnerException -NotePropertyValue $Private:Deserialized -Force
+
+        Test-OmadaSessionExpiredError -ErrorRecord $Private:Record | Should -BeTrue
+    }
+
     It "does not mistake a transient failure for an expiry" {
         Test-OmadaSessionExpiredError -ErrorRecord (New-TransientError) | Should -BeFalse
+    }
+
+    It "does not hang on a self-referencing exception chain" {
+        # It runs from the poll timer; a cycle here would freeze the window.
+        $Private:Exception = [System.Exception]::new("loop")
+        $Private:Exception | Add-Member -NotePropertyName InnerException -NotePropertyValue $Private:Exception -Force
+        $Private:Record = [System.Management.Automation.ErrorRecord]::new($Private:Exception, "x", [System.Management.Automation.ErrorCategory]::NotSpecified, $null)
+
+        Test-OmadaSessionExpiredError -ErrorRecord $Private:Record | Should -BeFalse
     }
 
     It "is not confused by a null" {

--- a/tests/Invoke-OmadaSessionKeepAlive.Tests.ps1
+++ b/tests/Invoke-OmadaSessionKeepAlive.Tests.ps1
@@ -1,0 +1,310 @@
+#Requires -Version 7.0
+# Issue #89. An Omada session expires in roughly ten minutes; an application that is open but idle
+# loses it with nothing on screen changing. Measured, not assumed: in the live session that answered
+# "does background execution survive?", five queries ran in nine minutes, the application sat idle
+# for seventy, and the first query after the idle failed because the session had gone.
+#
+# The hard requirement, and the reason this could not be built until Fortigi/OmadaWeb.PS#85 shipped
+# -NoInteractiveAuthentication: it must NEVER put a sign-in in front of the user. A keep-alive that
+# can open a login window at an arbitrary moment is worse than no keep-alive.
+
+BeforeAll {
+    $ParentPath = Split-Path -Path $PSScriptRoot -Parent
+    $PrivatePath = Join-Path $ParentPath -ChildPath "src\Lib\Functions\Private"
+    . (Join-Path $PrivatePath -ChildPath "Test-OmadaSessionExpiredError.ps1")
+    . (Join-Path $PrivatePath -ChildPath "Get-SessionKeepAliveInterval.ps1")
+    . (Join-Path $PrivatePath -ChildPath "Invoke-OmadaSessionKeepAlive.ps1")
+
+    $script:LogMessages = [System.Collections.Generic.List[object]]::new()
+    function Write-LogOutput {
+        param([Parameter(ValueFromPipeline = $true)]$InputObject, [string]$LogType, $ErrorObject, [switch]$SkipDialog, [switch]$TabScoped)
+        process { $script:LogMessages.Add([pscustomobject]@{ LogType = $LogType; Message = [string]$InputObject }) }
+    }
+
+    function Get-ConfigSchemaDefault { param([string]$Property, [string]$SchemaPath) return 5 }
+
+    # The transport. Records every request so the tests can assert what was sent, and answers with
+    # whatever the test set up.
+    $script:Requests = [System.Collections.Generic.List[object]]::new()
+    function Invoke-OmadaRequestCore {
+        param([hashtable]$Parameters)
+        $script:Requests.Add($Parameters)
+        if ($null -ne $script:NextError) { return @{ Result = $null; ErrorRecord = $script:NextError } }
+        return @{ Result = [pscustomobject]@{ value = @() }; ErrorRecord = $null }
+    }
+
+    function script:New-SessionExpiredError {
+        $Exception = [System.Security.Authentication.AuthenticationException]::new("The Omada session has expired")
+        return [System.Management.Automation.ErrorRecord]::new($Exception, "OmadaSessionExpired,Invoke-OmadaRequest", [System.Management.Automation.ErrorCategory]::AuthenticationError, "https://tenant.omada.cloud")
+    }
+
+    function script:New-TransientError {
+        return [System.Management.Automation.ErrorRecord]::new(
+            [System.Exception]::new("Response status code does not indicate success: 502 (Bad Gateway)."),
+            "Transient", [System.Management.Automation.ErrorCategory]::ConnectionError, $null)
+    }
+
+    function script:New-Tab {
+        param([string]$Id, [string]$SessionKey, [bool]$Connected = $true, [string]$BaseUrl = "https://tenant.omada.cloud")
+        return [pscustomobject]@{
+            Id               = $Id
+            ConnectionStatus = $Connected
+            AppConfig        = [pscustomobject]@{ BaseUrl = $BaseUrl }
+            RunTimeData      = [pscustomobject]@{
+                RestMethodParam = @{
+                    Uri                 = "https://tenant.omada.cloud/something/else"
+                    Method              = "POST"
+                    Body                = @{ leftover = $true }
+                    SessionKey          = $SessionKey
+                    AuthenticationType  = "WebView2"
+                    ForceAuthentication = $true
+                }
+            }
+        }
+    }
+
+    function script:Initialize-KeepAliveState {
+        $script:LogMessages.Clear()
+        $script:Requests.Clear()
+        $script:NextError = $null
+        $Script:LastSessionKeepAliveUtc = $null
+        $Script:SessionKeepAliveAbandoned = @{}
+        $Script:AppGlobalConfig = [pscustomobject]@{ SessionKeepAliveMinutes = 5 }
+        $Script:Tabs = @(New-Tab -Id "A" -SessionKey "pool-1")
+    }
+}
+
+Describe "Invoke-OmadaSessionKeepAlive" {
+    BeforeEach { Initialize-KeepAliveState }
+
+    It "refreshes a connected session" {
+        Invoke-OmadaSessionKeepAlive
+
+        @($script:Requests).Count | Should -Be 1
+    }
+
+    It "never allows a sign-in prompt" {
+        # The requirement the whole feature turns on. Without this switch an expired session mid-ping
+        # puts a login window over whatever the user is doing, at a moment they did not choose.
+        Invoke-OmadaSessionKeepAlive
+
+        $script:Requests[0].NoInteractiveAuthentication | Should -BeTrue
+    }
+
+    It "drops ForceAuthentication, which OmadaWeb.PS refuses alongside it" {
+        # One forbids signing in, the other requires it; the module rejects the combination outright,
+        # so a tab carrying it from an earlier forced login would fail every ping.
+        Invoke-OmadaSessionKeepAlive
+
+        $script:Requests[0].ContainsKey("ForceAuthentication") | Should -BeFalse
+    }
+
+    It "asks for one row rather than the whole query list" {
+        Invoke-OmadaSessionKeepAlive
+
+        $script:Requests[0].Uri | Should -Match '\$top=1'
+        $script:Requests[0].Method | Should -Be "GET"
+        $script:Requests[0].ContainsKey("Body") | Should -BeFalse
+    }
+
+    It "does not disturb the tab's own request parameters" {
+        # It clones. The live hashtable is what that tab's next real request is built from.
+        Invoke-OmadaSessionKeepAlive
+
+        $Script:Tabs[0].RunTimeData.RestMethodParam.Method | Should -Be "POST"
+        $Script:Tabs[0].RunTimeData.RestMethodParam.Uri | Should -Be "https://tenant.omada.cloud/something/else"
+    }
+
+    It "says nothing above DEBUG - a keep-alive the user notices has failed" {
+        Invoke-OmadaSessionKeepAlive
+
+        @($script:LogMessages | Where-Object { $_.LogType -ne "DEBUG" }).Count | Should -Be 0
+    }
+
+    Context "Which sessions get pinged" {
+        It "skips a tab that is not connected" {
+            $Script:Tabs = @(New-Tab -Id "A" -SessionKey "pool-1" -Connected $false)
+
+            Invoke-OmadaSessionKeepAlive
+
+            @($script:Requests).Count | Should -Be 0
+        }
+
+        It "pings once per session, not once per tab" {
+            # Tabs sharing a SessionKey share one OmadaWeb.PS session, so one ping serves them all.
+            $Script:Tabs = @(
+                (New-Tab -Id "A" -SessionKey "pool-1"),
+                (New-Tab -Id "B" -SessionKey "pool-1"),
+                (New-Tab -Id "C" -SessionKey "pool-1")
+            )
+
+            Invoke-OmadaSessionKeepAlive
+
+            @($script:Requests).Count | Should -Be 1
+        }
+
+        It "pings each distinct session" {
+            $Script:Tabs = @(
+                (New-Tab -Id "A" -SessionKey "pool-1"),
+                (New-Tab -Id "B" -SessionKey "pool-2" -BaseUrl "https://other.omada.cloud")
+            )
+
+            Invoke-OmadaSessionKeepAlive
+
+            @($script:Requests).Count | Should -Be 2
+        }
+    }
+
+    Context "Timing" {
+        It "does not ping again before the interval has passed" {
+            Invoke-OmadaSessionKeepAlive
+            Invoke-OmadaSessionKeepAlive
+            Invoke-OmadaSessionKeepAlive
+
+            @($script:Requests).Count | Should -Be 1
+        }
+
+        It "pings again once it has" {
+            Invoke-OmadaSessionKeepAlive
+            $Script:LastSessionKeepAliveUtc = [DateTime]::UtcNow.AddMinutes(-6)
+
+            Invoke-OmadaSessionKeepAlive
+
+            @($script:Requests).Count | Should -Be 2
+        }
+
+        It "stamps the time before the request, so a slow tenant cannot stack rounds" {
+            Mock Invoke-OmadaRequestCore {
+                $script:Requests.Add($Parameters)
+                # A tick landing while the first round is still in flight.
+                Invoke-OmadaSessionKeepAlive
+                return @{ Result = $null; ErrorRecord = $null }
+            }
+
+            Invoke-OmadaSessionKeepAlive
+
+            @($script:Requests).Count | Should -Be 1
+        }
+
+        It "is switched off entirely by an interval of zero" {
+            $Script:AppGlobalConfig = [pscustomobject]@{ SessionKeepAliveMinutes = 0 }
+
+            Invoke-OmadaSessionKeepAlive
+
+            @($script:Requests).Count | Should -Be 0
+        }
+    }
+
+    Context "When the session has gone" {
+        BeforeEach { $script:NextError = New-SessionExpiredError }
+
+        It "stops pinging that session rather than asking again every interval" {
+            Invoke-OmadaSessionKeepAlive
+            $Script:LastSessionKeepAliveUtc = [DateTime]::UtcNow.AddMinutes(-6)
+            Invoke-OmadaSessionKeepAlive
+
+            @($script:Requests).Count | Should -Be 1
+        }
+
+        It "still says nothing above DEBUG" {
+            # The user finds out when they next do something. A dialog from a timer about a session
+            # they were not using is exactly the interruption this feature exists to avoid.
+            Invoke-OmadaSessionKeepAlive
+
+            @($script:LogMessages | Where-Object { $_.LogType -ne "DEBUG" }).Count | Should -Be 0
+        }
+
+        It "abandons only the session that failed" {
+            $Script:Tabs = @(
+                (New-Tab -Id "A" -SessionKey "pool-1"),
+                (New-Tab -Id "B" -SessionKey "pool-2" -BaseUrl "https://other.omada.cloud")
+            )
+            Mock Invoke-OmadaRequestCore {
+                $script:Requests.Add($Parameters)
+                if ($Parameters.SessionKey -eq "pool-1") { return @{ Result = $null; ErrorRecord = (New-SessionExpiredError) } }
+                return @{ Result = [pscustomobject]@{}; ErrorRecord = $null }
+            }
+
+            Invoke-OmadaSessionKeepAlive
+            $Script:LastSessionKeepAliveUtc = [DateTime]::UtcNow.AddMinutes(-6)
+            $script:Requests.Clear()
+            Invoke-OmadaSessionKeepAlive
+
+            @($script:Requests).Count | Should -Be 1
+            $script:Requests[0].SessionKey | Should -Be "pool-2"
+        }
+    }
+
+    Context "When the tenant merely had a bad moment" {
+        It "tries again next interval, because a 502 says nothing about the session" {
+            $script:NextError = New-TransientError
+
+            Invoke-OmadaSessionKeepAlive
+            $Script:LastSessionKeepAliveUtc = [DateTime]::UtcNow.AddMinutes(-6)
+            Invoke-OmadaSessionKeepAlive
+
+            @($script:Requests).Count | Should -Be 2
+        }
+    }
+}
+
+Describe "Test-OmadaSessionExpiredError" {
+    It "recognises the error id, which is a prefix because PowerShell appends to it" {
+        Test-OmadaSessionExpiredError -ErrorRecord (New-SessionExpiredError) | Should -BeTrue
+    }
+
+    It "recognises the exception type on its own" {
+        $Private:Record = [System.Management.Automation.ErrorRecord]::new(
+            [System.Security.Authentication.AuthenticationException]::new("gone"),
+            "SomethingElse", [System.Management.Automation.ErrorCategory]::AuthenticationError, $null)
+
+        Test-OmadaSessionExpiredError -ErrorRecord $Private:Record | Should -BeTrue
+    }
+
+    It "finds it wrapped as an inner exception" {
+        $Private:Inner = [System.Security.Authentication.AuthenticationException]::new("gone")
+        $Private:Record = [System.Management.Automation.ErrorRecord]::new(
+            [System.Exception]::new("outer", $Private:Inner),
+            "Wrapped", [System.Management.Automation.ErrorCategory]::NotSpecified, $null)
+
+        Test-OmadaSessionExpiredError -ErrorRecord $Private:Record | Should -BeTrue
+    }
+
+    It "does not mistake a transient failure for an expiry" {
+        Test-OmadaSessionExpiredError -ErrorRecord (New-TransientError) | Should -BeFalse
+    }
+
+    It "is not confused by a null" {
+        Test-OmadaSessionExpiredError -ErrorRecord $null | Should -BeFalse
+    }
+}
+
+Describe "Get-SessionKeepAliveInterval" {
+    BeforeEach { Initialize-KeepAliveState }
+
+    It "uses the stored value" {
+        $Script:AppGlobalConfig = [pscustomobject]@{ SessionKeepAliveMinutes = 3 }
+        Get-SessionKeepAliveInterval | Should -Be 3
+    }
+
+    It "treats zero as off rather than as absent" {
+        $Script:AppGlobalConfig = [pscustomobject]@{ SessionKeepAliveMinutes = 0 }
+        Get-SessionKeepAliveInterval | Should -Be 0
+    }
+
+    It "falls back to the default for the -1 an Int property carries when unset" {
+        # Never to zero: that would silently disable a feature nobody asked to disable.
+        $Script:AppGlobalConfig = [pscustomobject]@{ SessionKeepAliveMinutes = -1 }
+        Get-SessionKeepAliveInterval | Should -Be 5
+    }
+
+    It "falls back to the default for a non-numeric value" {
+        $Script:AppGlobalConfig = [pscustomobject]@{ SessionKeepAliveMinutes = "soon" }
+        Get-SessionKeepAliveInterval | Should -Be 5
+    }
+
+    It "falls back to the default when nothing is stored" {
+        $Script:AppGlobalConfig = [pscustomobject]@{}
+        Get-SessionKeepAliveInterval | Should -Be 5
+    }
+}


### PR DESCRIPTION
Closes #89.

## The problem, measured

An Omada session cookie expires in roughly ten minutes. From the live session that answered *"does background execution survive?"*:

| Time | |
|---|---|
| 17:37 – 17:46 | 5 queries, all fine |
| 17:46 – 18:56 | **70 minutes idle** |
| 18:57 | First query after the idle **fails** — the session had gone |

Nothing on screen had changed in those seventy minutes. The user found out at the worst moment.

## Why this could not be built until now

A keep-alive that can open a sign-in window is **worse than no keep-alive**: it puts a login in front of the user at a moment they did not choose, or fails with a WebView2 runtime error where there is no desktop at all. Neither existing option worked — `Browser`/`WebView2` sends the cookie but can prompt; `None` cannot prompt but does not send the cookie.

Fortigi/OmadaWeb.PS#85 added **`-NoInteractiveAuthentication`**, under which no code path can open a prompt and an expired session is a catchable, typed error. That is what this uses, and it is the whole reason the feature is now buildable.

## Three properties that make it safe on a timer

**It cannot prompt.** Every ping carries `-NoInteractiveAuthentication`, and `-ForceAuthentication` is stripped — OmadaWeb.PS refuses the two together, rightly, since one forbids signing in and the other requires it. A tab carrying it from an earlier forced login would otherwise fail every ping.

**It is silent.** Everything logs at DEBUG; nothing raises a dialog, on any path. A keep-alive the user notices has failed at its job.

**It gives up rather than retries.** A session that cannot be revived will not be revived by asking again in five minutes, so that session key is dropped. The alternative is a request every interval, forever, against a tenant that has already said no. A *transient* failure — a 502 — is treated differently and retried next interval, because it says nothing about the session.

## Design notes

| Decision | Why |
|---|---|
| Once per **session**, not per tab | Tabs sharing a `SessionKey` share one OmadaWeb.PS session; per-tab would multiply requests for no benefit |
| On the **UI thread** | A worker runspace has its own session context — keeping *that* alive does nothing for the session the user's queries use |
| Driven from the existing poll timer | Already the single place that knows about pending work, already suspended around modal dialogs. Checked once a second; the answer is a wall-clock comparison against minutes |
| `?$top=1` | So the tenant does not compose a full query list every few minutes for an answer nobody reads |
| The tab's `RestMethodParam` is **cloned** | That hashtable is what the tab's next real request is built from |
| Interval configurable, default 5 min, `0` = off | The number it must stay under is an estimate — ten minutes was observed, is undocumented, and may differ per tenant. One knob rather than two, so an "enabled" flag cannot disagree with the interval |

## A deliberate deviation from the issue

#89's acceptance criteria said *"a dead session results in a quiet disconnected state"*. **This does not mark the tab disconnected**, and I would rather flag that than quietly not do it.

`Set-SqlConnectionState` writes into `$Script:MainForm.Elements` — the **active** tab's element bag. Doing that for a background tab needs a full `Set-ActiveTabContext` round trip, and flipping a tab to "Disconnected" from a timer while the user is typing in it is a larger behaviour change than a keep-alive should make on its own initiative. The existing re-authentication path already handles the next real request.

Happy to add it if you want the criterion met as written — it is a contained change, just not one I would make unasked.

## Verification

```
./build/build.ps1 -Task TestBuildOnly   ->  900 tests, 0 failed; PSScriptAnalyzer clean
./build/build.ps1 -Task E2E             ->   54 tests, 0 failed
```

27 new tests, including that the ping always carries `-NoInteractiveAuthentication`, that `ForceAuthentication` is always stripped, that a slow tenant cannot stack overlapping rounds (the timestamp is taken *before* the request), that an expired session abandons **only** that session key, and that nothing above DEBUG is ever logged — on the success path and the expiry path alike.

**Not yet verified against a real tenant.** OmadaWeb.PS#85 is on `main` but will not be in a nightly until tomorrow, so the live soak — leave the application idle past the expiry window, then run a query — is still to do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JJXt2rS8P98gdTtx5EYEXN
