### PR TITLE
Stop the worker ever trying to sign in

### DIFF
--- a/src/Lib/Functions/Private/Add-OmadaNonInteractiveAuthentication.ps1
+++ b/src/Lib/Functions/Private/Add-OmadaNonInteractiveAuthentication.ps1
@@ -48,26 +48,36 @@ function Add-OmadaNonInteractiveAuthentication {
 
     $Private:Result = $Parameters.Clone()
 
+    # Assume not supported until the probe says otherwise, so that every way of NOT getting an answer
+    # - a false, or a throw - lands on the same safe behaviour. Deciding this in two places is how the
+    # catch below came to leave a pre-existing key in place, which is the one outcome that actually
+    # breaks a request rather than merely failing to improve it.
+    $Private:Supported = $false
+
     try {
-        if (-not (Test-OmadaRestMethodParameter -Name "NoInteractiveAuthentication")) {
-            # Older module. Leave the splat alone rather than send a parameter it will reject.
-            if ($Private:Result.ContainsKey("NoInteractiveAuthentication")) {
-                $Private:Result.Remove("NoInteractiveAuthentication")
-            }
-
-            return $Private:Result
-        }
-
-        $Private:Result.NoInteractiveAuthentication = $true
-
-        if ($Private:Result.ContainsKey("ForceAuthentication")) {
-            $Private:Result.Remove("ForceAuthentication")
-        }
+        $Private:Supported = Test-OmadaRestMethodParameter -Name "NoInteractiveAuthentication"
     }
     catch {
         # A capability check that cannot run must not stop the query. The worst case is the behaviour
         # this function was written to improve, which the fallback classification already handles.
         "Could not determine whether OmadaWeb.PS supports -NoInteractiveAuthentication: {0}" -f $_.Exception.Message | Write-LogOutput -LogType DEBUG
+    }
+
+    if (-not $Private:Supported) {
+        # Older module, or an unanswerable question. Strip the key rather than send a parameter that
+        # would be rejected - PowerShell errors on an unknown parameter, so leaving a stale one here
+        # would fail every background request instead of merely behaving as before.
+        if ($Private:Result.ContainsKey("NoInteractiveAuthentication")) {
+            $Private:Result.Remove("NoInteractiveAuthentication")
+        }
+
+        return $Private:Result
+    }
+
+    $Private:Result.NoInteractiveAuthentication = $true
+
+    if ($Private:Result.ContainsKey("ForceAuthentication")) {
+        $Private:Result.Remove("ForceAuthentication")
     }
 
     return $Private:Result

--- a/src/Lib/Functions/Private/Add-OmadaNonInteractiveAuthentication.ps1
+++ b/src/Lib/Functions/Private/Add-OmadaNonInteractiveAuthentication.ps1
@@ -1,0 +1,74 @@
+function Add-OmadaNonInteractiveAuthentication {
+    <#
+    .SYNOPSIS
+    Return a copy of a request splat that can use the existing session but can never sign in.
+
+    .DESCRIPTION
+    For requests made on a background worker. A worker has no desktop and its pool is MTA on purpose,
+    so an interactive sign-in there cannot succeed - it fails as a WebView2RuntimeNotFoundException,
+    which is exactly what a live session showed: after a seventy-minute idle the session had expired,
+    the worker tried to sign in, and background execution switched itself off for the rest of the
+    session.
+
+    -NoInteractiveAuthentication (Fortigi/OmadaWeb.PS#85) makes that impossible. No code path under it
+    can open a browser, a WebView2 window or any other prompt, and an expired or missing session comes
+    back as a typed error instead - which Test-OmadaSessionExpiredError recognises and
+    Resolve-ExecuteFallbackAction can then classify properly, rather than guessing from the text of a
+    WebView2 exception.
+
+    Two things this deliberately handles:
+
+    ForceAuthentication is removed. OmadaWeb.PS refuses the two together, and rightly - one forbids
+    signing in, the other requires it - so a splat carrying it from an earlier forced login would fail
+    every background request outright.
+
+    The switch is only added when the installed OmadaWeb.PS actually has it. PowerShell REJECTS an
+    unknown parameter rather than ignoring it, so passing it to an older module would break every
+    background request instead of degrading. The application's minimum is 2026.07.09.9, which predates
+    the switch, so this is a real case and not a theoretical one. Same shape as the SkipBodyRedaction
+    capability check in Build-OmadaRequestParameter.
+
+    On an older module the caller simply gets the splat back unchanged: the worker behaves exactly as
+    it did before, including the WebView2 failure, which Resolve-ExecuteFallbackAction still
+    recognises by message.
+
+    .PARAMETER Parameters
+    The prepared splat. Not mutated - a copy is returned, because the caller's hashtable is the live
+    one the next request is built from.
+
+    .OUTPUTS
+    [hashtable] a copy, safe to hand to a worker.
+    #>
+    [CmdLetBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [hashtable]$Parameters
+    )
+
+    $Private:Result = $Parameters.Clone()
+
+    try {
+        if (-not (Test-OmadaRestMethodParameter -Name "NoInteractiveAuthentication")) {
+            # Older module. Leave the splat alone rather than send a parameter it will reject.
+            if ($Private:Result.ContainsKey("NoInteractiveAuthentication")) {
+                $Private:Result.Remove("NoInteractiveAuthentication")
+            }
+
+            return $Private:Result
+        }
+
+        $Private:Result.NoInteractiveAuthentication = $true
+
+        if ($Private:Result.ContainsKey("ForceAuthentication")) {
+            $Private:Result.Remove("ForceAuthentication")
+        }
+    }
+    catch {
+        # A capability check that cannot run must not stop the query. The worst case is the behaviour
+        # this function was written to improve, which the fallback classification already handles.
+        "Could not determine whether OmadaWeb.PS supports -NoInteractiveAuthentication: {0}" -f $_.Exception.Message | Write-LogOutput -LogType DEBUG
+    }
+
+    return $Private:Result
+}

--- a/src/Lib/Functions/Private/Resolve-ExecuteFallbackAction.ps1
+++ b/src/Lib/Functions/Private/Resolve-ExecuteFallbackAction.ps1
@@ -55,6 +55,17 @@ function Resolve-ExecuteFallbackAction {
         return "Report"
     }
 
+    # The session had gone and the worker refused to sign in, which is what it is told to do
+    # (-NoInteractiveAuthentication, added to worker requests in Start-OmadaBackgroundRequest). That
+    # is a statement about the SESSION, not about the worker: the UI thread signs in, and the worker
+    # then has a session to inherit. Retry, and emphatically do not disable.
+    #
+    # Checked before the status code because the module raises this for a 401 as well as for no cookie
+    # at all, and "401 with no sign-in attempted" is a more precise answer than "401".
+    if (Test-OmadaSessionExpiredError -ErrorRecord $Outcome.ErrorRecord) {
+        return "Retry"
+    }
+
     $Private:StatusCode = Get-OmadaHttpStatusCode -ErrorRecord $Outcome.ErrorRecord
     if ($null -ne $Private:StatusCode) {
         # A status code means a round trip completed. The worker is fine.
@@ -65,9 +76,18 @@ function Resolve-ExecuteFallbackAction {
         return "Report"
     }
 
-    # No status code. Look for the failures that mean this worker can never run a request: they all
-    # come from a worker being pushed into an interactive sign-in it cannot perform. Matched on text
-    # because the exception arrives flattened across the runspace boundary.
+    # No status code, and not a session expiry. What remains are the failures that mean this worker
+    # can never run a request: they all come from a worker being pushed into an interactive sign-in it
+    # cannot perform.
+    #
+    # These should no longer be reachable - a worker now carries -NoInteractiveAuthentication, so it
+    # never reaches a sign-in to fail at. They are kept for the case that switch is not available:
+    # the application's minimum OmadaWeb.PS is 2026.07.09.9, which predates it, and on that version
+    # Add-OmadaNonInteractiveAuthentication deliberately leaves the splat alone. There, this text is
+    # still the only signal there is.
+    #
+    # Matched on text because the exception arrives flattened across the runspace boundary - which is
+    # exactly the brittleness the typed check above replaces wherever the switch is available.
     $Private:Message = [string]$Outcome.ErrorRecord.Exception.Message
     $Private:WorkerFailurePattern = @(
         "WebView2RuntimeNotFoundException"

--- a/src/Lib/Functions/Private/Start-OmadaBackgroundRequest.ps1
+++ b/src/Lib/Functions/Private/Start-OmadaBackgroundRequest.ps1
@@ -90,6 +90,21 @@ function Start-OmadaBackgroundRequest {
             }
         }
 
+        # A worker must never try to sign in. It has no desktop, and its pool is MTA on purpose, so an
+        # interactive sign-in there fails as a WebView2RuntimeNotFoundException - which is what a live
+        # session showed: the first query after a seventy-minute idle blew up that way, and background
+        # execution switched itself off.
+        #
+        # Under -NoInteractiveAuthentication (Fortigi/OmadaWeb.PS#85) no code path can open a browser,
+        # and an expired or missing session comes back as a typed, catchable error instead. That turns
+        # the worker's commonest failure from an explosion into an answer.
+        #
+        # Applied HERE rather than in Build-OmadaRequestParameter because it must apply to the worker
+        # ONLY: the UI thread is exactly where signing in is supposed to happen. Both worker paths
+        # clone from these two lines - the pipeline through $PipelineContext.Parameters, a single
+        # request through the AddArgument below - so one place covers both.
+        $Parameters = Add-OmadaNonInteractiveAuthentication -Parameters $Parameters
+
         # The pipeline builds each step's request itself, but every step still goes out with the
         # session's own transport settings - SessionKey, authentication, redaction - so it is handed
         # the same prepared splat a single request would have used. Cloned, and into a clone of the

--- a/src/Lib/Functions/Private/Test-OmadaRestMethodParameter.ps1
+++ b/src/Lib/Functions/Private/Test-OmadaRestMethodParameter.ps1
@@ -8,9 +8,9 @@ function Test-OmadaRestMethodParameter {
     Get-Command - which Pester itself uses, making it an unreliable thing to intercept.
 
     The probe matters because PowerShell REJECTS an unknown parameter rather than ignoring it. Passing
-    a parameter that a older module does not declare turns a working request into a failed one, so
-    every optional parameter this application adds has to be asked about first. Build-OmadaRequestParameter
-    does the same for SkipBodyRedaction.
+    a parameter that an older module does not declare turns a working request into a failed one, so
+    every optional parameter this application adds has to be asked about first.
+    Build-OmadaRequestParameter does the same for SkipBodyRedaction.
 
     Dynamic parameters count: OmadaWeb.PS declares most of its own through New-DynamicParam, and they
     do appear in Get-Command's .Parameters - verified against both 2026.7.9.9 and 2026.9.9.

--- a/src/Lib/Functions/Private/Test-OmadaRestMethodParameter.ps1
+++ b/src/Lib/Functions/Private/Test-OmadaRestMethodParameter.ps1
@@ -1,0 +1,44 @@
+function Test-OmadaRestMethodParameter {
+    <#
+    .SYNOPSIS
+    Whether the installed OmadaWeb.PS accepts a given parameter on Invoke-OmadaRestMethod.
+
+    .DESCRIPTION
+    A capability probe, in a function of its own so that callers can be tested without mocking
+    Get-Command - which Pester itself uses, making it an unreliable thing to intercept.
+
+    The probe matters because PowerShell REJECTS an unknown parameter rather than ignoring it. Passing
+    a parameter that a older module does not declare turns a working request into a failed one, so
+    every optional parameter this application adds has to be asked about first. Build-OmadaRequestParameter
+    does the same for SkipBodyRedaction.
+
+    Dynamic parameters count: OmadaWeb.PS declares most of its own through New-DynamicParam, and they
+    do appear in Get-Command's .Parameters - verified against both 2026.7.9.9 and 2026.9.9.
+
+    .PARAMETER Name
+    The parameter to ask about.
+
+    .OUTPUTS
+    [bool] $false when the module, or the parameter, is not there.
+    #>
+    [CmdLetBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Name
+    )
+
+    try {
+        $Private:Command = Get-Command -Name "Invoke-OmadaRestMethod" -ErrorAction SilentlyContinue
+        if ($null -eq $Private:Command) {
+            return $false
+        }
+
+        return [bool]$Private:Command.Parameters.ContainsKey($Name)
+    }
+    catch {
+        # An unanswerable question is answered "no": not adding an optional parameter is always safe,
+        # adding one the module rejects is not.
+        return $false
+    }
+}

--- a/tests/Add-OmadaNonInteractiveAuthentication.Tests.ps1
+++ b/tests/Add-OmadaNonInteractiveAuthentication.Tests.ps1
@@ -1,0 +1,165 @@
+#Requires -Version 7.0
+# A background worker must never try to sign in: it has no desktop and its pool is MTA on purpose, so
+# an interactive sign-in there fails as a WebView2RuntimeNotFoundException. That is not theoretical -
+# in the live session that answered "does background execution survive?", the first query after a
+# seventy-minute idle failed exactly that way and switched background execution off.
+#
+# -NoInteractiveAuthentication (Fortigi/OmadaWeb.PS#85) makes it impossible, and turns an expired
+# session from an explosion into a typed, catchable answer.
+#
+# The capability check is not optional. PowerShell REJECTS an unknown parameter rather than ignoring
+# it, and this application's minimum OmadaWeb.PS is 2026.07.09.9 - which predates the switch. Adding
+# it unconditionally would break every background request on that version.
+
+BeforeAll {
+    $ParentPath = Split-Path -Path $PSScriptRoot -Parent
+    $PrivatePath = Join-Path $ParentPath -ChildPath "src\Lib\Functions\Private"
+    . (Join-Path $PrivatePath -ChildPath "Test-OmadaRestMethodParameter.ps1")
+    . (Join-Path $PrivatePath -ChildPath "Add-OmadaNonInteractiveAuthentication.ps1")
+
+    function Write-LogOutput {
+        param([Parameter(ValueFromPipeline = $true)]$InputObject, [string]$LogType, $ErrorObject, [switch]$SkipDialog, [switch]$TabScoped)
+        process { }
+    }
+
+    # The capability probe is its own function precisely so it can be mocked here: mocking
+    # Get-Command is unreliable, because Pester uses it itself.
+    function script:Set-ModuleSupport {
+        param([switch]$SupportsSwitch)
+
+        $Script:TestModuleSupportsSwitch = [bool]$SupportsSwitch
+        Mock Test-OmadaRestMethodParameter { return $Script:TestModuleSupportsSwitch }
+    }
+
+    function script:New-Splat {
+        return @{
+            Uri                 = "https://tenant.omada.cloud/odata/x"
+            Method              = "GET"
+            SessionKey          = "pool-1"
+            ForceAuthentication = $true
+        }
+    }
+}
+
+Describe "Add-OmadaNonInteractiveAuthentication" {
+    Context "The installed module supports the switch" {
+        BeforeEach { Set-ModuleSupport -SupportsSwitch }
+
+        It "adds it, so the worker cannot be pushed into a sign-in" {
+            $Private:Result = Add-OmadaNonInteractiveAuthentication -Parameters (New-Splat)
+
+            $Private:Result.NoInteractiveAuthentication | Should -BeTrue
+        }
+
+        It "removes ForceAuthentication, which the module refuses alongside it" {
+            # One forbids signing in, the other requires it. OmadaWeb.PS rejects the combination up
+            # front, so a splat carrying it from an earlier forced login would fail every request.
+            $Private:Result = Add-OmadaNonInteractiveAuthentication -Parameters (New-Splat)
+
+            $Private:Result.ContainsKey("ForceAuthentication") | Should -BeFalse
+        }
+
+        It "leaves the caller's hashtable untouched" {
+            # The caller's copy is the live one the next request is built from.
+            $Private:Original = New-Splat
+
+            Add-OmadaNonInteractiveAuthentication -Parameters $Private:Original | Out-Null
+
+            $Private:Original.ContainsKey("NoInteractiveAuthentication") | Should -BeFalse
+            $Private:Original.ForceAuthentication | Should -BeTrue
+        }
+
+        It "carries the rest of the transport settings through" {
+            $Private:Result = Add-OmadaNonInteractiveAuthentication -Parameters (New-Splat)
+
+            $Private:Result.SessionKey | Should -Be "pool-1"
+            $Private:Result.Uri | Should -Be "https://tenant.omada.cloud/odata/x"
+        }
+    }
+
+    Context "The installed module predates the switch" {
+        BeforeEach { Set-ModuleSupport }
+
+        It "does not add it, because PowerShell would reject the call outright" {
+            # Not a graceful degradation if we get this wrong: an unknown parameter is an error, so
+            # every background request would fail rather than merely behave as before.
+            $Private:Result = Add-OmadaNonInteractiveAuthentication -Parameters (New-Splat)
+
+            $Private:Result.ContainsKey("NoInteractiveAuthentication") | Should -BeFalse
+        }
+
+        It "leaves ForceAuthentication alone, since nothing now conflicts with it" {
+            $Private:Result = Add-OmadaNonInteractiveAuthentication -Parameters (New-Splat)
+
+            $Private:Result.ForceAuthentication | Should -BeTrue
+        }
+
+        It "drops a stale key if one is somehow already there" {
+            $Private:Splat = New-Splat
+            $Private:Splat.NoInteractiveAuthentication = $true
+
+            $Private:Result = Add-OmadaNonInteractiveAuthentication -Parameters $Private:Splat
+
+            $Private:Result.ContainsKey("NoInteractiveAuthentication") | Should -BeFalse
+        }
+    }
+
+    Context "When the capability cannot be determined" {
+        It "returns a usable splat rather than stopping the query" {
+            Mock Test-OmadaRestMethodParameter { throw "module not loadable" }
+
+            # Assigned outside the scriptblock: a Should -Not -Throw body runs in a child scope, so an
+            # assignment made inside it does not survive.
+            { Add-OmadaNonInteractiveAuthentication -Parameters (New-Splat) } | Should -Not -Throw
+
+            $Private:Result = Add-OmadaNonInteractiveAuthentication -Parameters (New-Splat)
+            $Private:Result.Uri | Should -Be "https://tenant.omada.cloud/odata/x"
+        }
+
+        It "does not add the switch it could not verify" {
+            Mock Test-OmadaRestMethodParameter { throw "module not loadable" }
+
+            $Private:Result = Add-OmadaNonInteractiveAuthentication -Parameters (New-Splat)
+
+            $Private:Result.ContainsKey("NoInteractiveAuthentication") | Should -BeFalse
+        }
+    }
+}
+
+Describe "Test-OmadaRestMethodParameter" {
+    It "answers no when OmadaWeb.PS is not loaded" {
+        # Not adding an optional parameter is always safe; adding one the module rejects is not, so an
+        # unanswerable question is answered no.
+        Mock Get-Command { return $null }
+
+        Test-OmadaRestMethodParameter -Name "NoInteractiveAuthentication" | Should -BeFalse
+    }
+
+    It "answers from the command's declared parameters, dynamic ones included" {
+        # OmadaWeb.PS declares most of its parameters through New-DynamicParam, and those DO appear in
+        # Get-Command's .Parameters - verified against 2026.7.9.9 and 2026.9.9 alike.
+        Mock Get-Command { return [pscustomobject]@{ Parameters = @{ Uri = $null; NoInteractiveAuthentication = $null } } }
+
+        Test-OmadaRestMethodParameter -Name "NoInteractiveAuthentication" | Should -BeTrue
+        Test-OmadaRestMethodParameter -Name "SomethingElse" | Should -BeFalse
+    }
+}
+
+Describe "The worker's requests carry it" {
+    It "is applied in Start-OmadaBackgroundRequest, before either clone" {
+        # Applied there rather than in Build-OmadaRequestParameter because it must apply to the worker
+        # ONLY - the UI thread is exactly where signing in is supposed to happen. Both worker paths
+        # clone from that point, so one call covers the pipeline and the single-request path alike.
+        $Private:Source = Get-Content -Path (Join-Path (Join-Path (Split-Path -Path $PSScriptRoot -Parent) "src\Lib\Functions\Private") "Start-OmadaBackgroundRequest.ps1") -Raw
+
+        $Private:Source | Should -Match '\$Parameters\s*=\s*Add-OmadaNonInteractiveAuthentication\s+-Parameters\s+\$Parameters'
+    }
+
+    It "is not applied to requests the UI thread makes" {
+        # Build-OmadaRequestParameter prepares BOTH paths. Adding it there would stop the UI thread
+        # being able to sign in at all, which is the one place that must be able to.
+        $Private:Source = Get-Content -Path (Join-Path (Join-Path (Split-Path -Path $PSScriptRoot -Parent) "src\Lib\Functions\Private") "Build-OmadaRequestParameter.ps1") -Raw
+
+        $Private:Source | Should -Not -Match 'NoInteractiveAuthentication'
+    }
+}

--- a/tests/Add-OmadaNonInteractiveAuthentication.Tests.ps1
+++ b/tests/Add-OmadaNonInteractiveAuthentication.Tests.ps1
@@ -123,6 +123,20 @@ Describe "Add-OmadaNonInteractiveAuthentication" {
 
             $Private:Result.ContainsKey("NoInteractiveAuthentication") | Should -BeFalse
         }
+
+        It "strips a key that was already there, rather than passing on one it could not verify" {
+            # The version of this test that only checked a splat WITHOUT the key passed against code
+            # that left a pre-existing one in place - so it proved nothing about the case that
+            # actually breaks a request. An unverifiable capability has to reach the same safe
+            # behaviour as a verified absence, by every route including a throw.
+            Mock Test-OmadaRestMethodParameter { throw "module not loadable" }
+            $Private:Splat = New-Splat
+            $Private:Splat.NoInteractiveAuthentication = $true
+
+            $Private:Result = Add-OmadaNonInteractiveAuthentication -Parameters $Private:Splat
+
+            $Private:Result.ContainsKey("NoInteractiveAuthentication") | Should -BeFalse
+        }
     }
 }
 

--- a/tests/Invoke-ExecuteQuery.Tests.ps1
+++ b/tests/Invoke-ExecuteQuery.Tests.ps1
@@ -35,6 +35,7 @@ BeforeAll {
     # The real classifier, not a stub: deciding what a failure means IS the behaviour under test in
     # the fallback suite below, and a stub would assert nothing.
     . (Join-Path $PrivatePath -ChildPath "Get-OmadaHttpStatusCode.ps1")
+    . (Join-Path $PrivatePath -ChildPath "Test-OmadaSessionExpiredError.ps1")
     . (Join-Path $PrivatePath -ChildPath "Resolve-ExecuteFallbackAction.ps1")
     . (Join-Path $PrivatePath -ChildPath "Show-ExecuteQueryPopup.ps1")
     . (Join-Path $PrivatePath -ChildPath "Invoke-ExecuteQuery.ps1")

--- a/tests/Resolve-ExecuteFallbackAction.Tests.ps1
+++ b/tests/Resolve-ExecuteFallbackAction.Tests.ps1
@@ -8,6 +8,7 @@ BeforeAll {
     $ParentPath = Split-Path -Path $PSScriptRoot -Parent
     $PrivatePath = Join-Path $ParentPath -ChildPath "src\Lib\Functions\Private"
     . (Join-Path $PrivatePath -ChildPath "Get-OmadaHttpStatusCode.ps1")
+    . (Join-Path $PrivatePath -ChildPath "Test-OmadaSessionExpiredError.ps1")
     . (Join-Path $PrivatePath -ChildPath "Resolve-ExecuteFallbackAction.ps1")
 
     function script:New-Outcome {
@@ -58,6 +59,48 @@ Describe "Resolve-ExecuteFallbackAction" {
             # Re-running could execute the query a second time against the tenant.
             New-Outcome -Message "something failed later" -CompletedSteps 2 |
                 ForEach-Object { Resolve-ExecuteFallbackAction -Outcome $_ } | Should -Be "Report"
+        }
+    }
+
+    Context "The session had gone and the worker refused to sign in" {
+        # What a worker now reports instead of exploding: it carries -NoInteractiveAuthentication, so
+        # OmadaWeb.PS raises a typed error rather than opening a browser it has no desktop for.
+
+        function script:New-SessionExpiredOutcome {
+            param([int]$CompletedSteps = 0)
+            $Private:Exception = [System.Security.Authentication.AuthenticationException]::new("The Omada session has expired and -NoInteractiveAuthentication was specified")
+            return @{
+                CompletedSteps = $CompletedSteps
+                ErrorRecord    = [System.Management.Automation.ErrorRecord]::new(
+                    $Private:Exception, "OmadaSessionExpired,Invoke-OmadaRequest",
+                    [System.Management.Automation.ErrorCategory]::AuthenticationError, "https://tenant.omada.cloud")
+            }
+        }
+
+        It "retries on the UI thread, which is the one place that can sign in" {
+            Resolve-ExecuteFallbackAction -Outcome (New-SessionExpiredOutcome) | Should -Be "Retry"
+        }
+
+        It "does NOT write off the worker" {
+            # The distinction that matters: an expired session says nothing about whether the worker
+            # can run requests. Once the UI thread has signed in there is a session to inherit, and
+            # disabling here would give up something that is about to start working - which is exactly
+            # what happened in the live session that prompted this.
+            Resolve-ExecuteFallbackAction -Outcome (New-SessionExpiredOutcome) | Should -Not -Be "RetryAndDisable"
+        }
+
+        It "is preferred over the bare status code, being the more precise answer" {
+            # The module raises this for a 401 as well as for no cookie at all, so "401 with no
+            # sign-in attempted" beats "401".
+            $Private:Outcome = New-SessionExpiredOutcome
+            $Private:Outcome.ErrorRecord.Exception | Add-Member -NotePropertyName Response -NotePropertyValue ([pscustomobject]@{ StatusCode = 401 }) -Force
+
+            Resolve-ExecuteFallbackAction -Outcome $Private:Outcome | Should -Be "Retry"
+        }
+
+        It "still reports rather than retries once a step has completed" {
+            # Re-running could execute the query a second time against the tenant, expiry or not.
+            Resolve-ExecuteFallbackAction -Outcome (New-SessionExpiredOutcome -CompletedSteps 2) | Should -Be "Report"
         }
     }
 

--- a/tests/Start-OmadaBackgroundRequest.Tests.ps1
+++ b/tests/Start-OmadaBackgroundRequest.Tests.ps1
@@ -13,6 +13,10 @@ BeforeAll {
     $PrivatePath = Join-Path $ParentPath -ChildPath "src\Lib\Functions\Private"
 
     . (Join-Path $PrivatePath -ChildPath "ConvertTo-RedactedLogString.ps1")
+    # Real, not stubbed: a worker's requests must carry -NoInteractiveAuthentication, and a stub here
+    # would let that silently stop happening. It reads only the installed module's capabilities.
+    . (Join-Path $PrivatePath -ChildPath "Test-OmadaRestMethodParameter.ps1")
+    . (Join-Path $PrivatePath -ChildPath "Add-OmadaNonInteractiveAuthentication.ps1")
     . (Join-Path $PrivatePath -ChildPath "Start-OmadaBackgroundRequest.ps1")
 
     $Script:Tracer = [System.Diagnostics.Trace]


### PR DESCRIPTION
The last piece that needed the OmadaWeb.PS nightly. Now installed and verified: `2026.9.9-nightly82` contains #85, and `-NoInteractiveAuthentication` is present and discoverable.

## The failure this removes

From the live session that answered *"does background execution survive?"*:

```
18:57:02 Disable-OmadaBackgroundRequest: Background query execution is not available ...
Reason: Start-WebView2Login - Error creating CoreWebView2Environment ...
        WebView2RuntimeNotFoundException: Couldn't find a compatible Webview2 Runtime
```

The session had expired during a seventy-minute idle. The worker tried to **sign in** — which it can never do: it has no desktop and its pool is MTA on purpose, precisely so an ownerless login window cannot appear behind the main form. So it exploded, and background execution switched itself off.

## What changed

Worker requests now carry **`-NoInteractiveAuthentication`**. No code path under it can open a browser, and an expired or missing session comes back as a typed, catchable error instead.

| | |
|---|---|
| Applied in `Start-OmadaBackgroundRequest` | Not `Build-OmadaRequestParameter`, which prepares **both** paths — the UI thread is exactly where signing in is supposed to happen. Both worker paths clone from that one point, so it covers the pipeline and the single request alike |
| `ForceAuthentication` stripped | OmadaWeb.PS refuses the two together, rightly: one forbids signing in, the other requires it. A splat carrying it from an earlier forced login would fail every background request |
| Guarded by a capability check | **PowerShell rejects an unknown parameter rather than ignoring it.** The application's minimum is `2026.07.09.9`, which predates the switch — adding it unconditionally would break every background request on that version, not degrade gracefully |

Then `Resolve-ExecuteFallbackAction` classifies the typed error as **`Retry`**, not `RetryAndDisable`:

> An expired session says nothing about whether the worker can run requests. The UI thread signs in, and the worker then has a session to inherit. Disabling there gives up something that is about to start working.

That is the same reasoning as #97's recoverable disable, applied one level earlier — and it means the common case never reaches the disable at all.

## Decisions worth reviewing

- **`Test-OmadaRestMethodParameter` is a function of its own** rather than an inline `Get-Command` call, so callers can be tested without mocking `Get-Command` — which Pester uses itself, and which made the first version of these tests fail for reasons unrelated to the code.
- **The WebView2 text matching stays.** It looks dead now, and on a current module it is: the worker never reaches a sign-in to fail at. But on `2026.07.09.9` the switch is not added, and there that string is still the only signal available. Removing it would silently reintroduce the original bug for anyone on the minimum supported version.
- **The session-expiry check runs before the status-code check.** The module raises the typed error for a 401 as well as for no cookie at all, and *"401 with no sign-in attempted"* is a more precise answer than *"401"*.
- **`Add-OmadaNonInteractiveAuthentication` returns a copy.** The caller's hashtable is the live one the next request is built from.
- **A capability probe that throws answers "no".** Not adding an optional parameter is always safe; adding one the module rejects is not.

## Verification

```
./build/build.ps1 -Task TestBuildOnly   ->  933 tests, 0 failed; PSScriptAnalyzer clean
./build/build.ps1 -Task E2E             ->   54 tests, 0 failed
```

Tests cover both sides of the capability check — including that the switch is **not** added on an older module, since getting that wrong breaks every background request — that the caller's splat is not mutated, that `Build-OmadaRequestParameter` never gains the switch (which would stop the UI thread signing in at all), and that an expired session retries without writing off the worker.

## Still to verify live

The soak: leave the application idle past the expiry window, then run a query. With this plus #98's keep-alive, the expected outcome is that the session never expires — and if it somehow does, the worker reports it cleanly and the next query works rather than background execution switching off.

Part of #40.
