### PR TITLE
Load query history on a non-US culture, and survive its window closing

### DIFF
--- a/src/Lib/Events/SqlHistoryForm.Elements.ButtonExportHistory.ps1
+++ b/src/Lib/Events/SqlHistoryForm.Elements.ButtonExportHistory.ps1
@@ -51,7 +51,7 @@ $Script:SqlHistoryForm.Elements.ButtonExportHistory.Add_Click({
                         $TextContent += ""
 
                         foreach ($Item in $HistoryData) {
-                            $TextContent += "Change Date: $($Item.ChangeDate.ToString('yyyy-MM-dd HH:mm:ss'))"
+                            $TextContent += "Change Date: $(Format-OmadaHistoryDate -Value $Item.ChangeDate)"
                             $TextContent += "Changed By: $($Item.ChangedBy)"
                             $TextContent += "Change Type: $($Item.ChangeType)"
                             $TextContent += "Object: $($Item.SqlObjectName)"

--- a/src/Lib/Events/SqlHistoryForm.Elements.ButtonRestoreQuery.ps1
+++ b/src/Lib/Events/SqlHistoryForm.Elements.ButtonRestoreQuery.ps1
@@ -20,7 +20,7 @@ $Script:SqlHistoryForm.Elements.ButtonRestoreQuery.Add_Click({
             Suspend-WebViewCompletionPolling
             try {
                 $Result = [System.Windows.MessageBox]::Show(
-                    "Are you sure you want to restore this query version?`n`nChanged by: $($SelectedItem.ChangedBy)`nChange date: $($SelectedItem.ChangeDate.ToString('yyyy-MM-dd HH:mm:ss'))",
+                    "Are you sure you want to restore this query version?`n`nChanged by: $($SelectedItem.ChangedBy)`nChange date: $(Format-OmadaHistoryDate -Value $SelectedItem.ChangeDate)",
                     "Confirm Query Restore",
                     [System.Windows.MessageBoxButton]::YesNo,
                     [System.Windows.MessageBoxImage]::Question
@@ -43,7 +43,7 @@ $Script:SqlHistoryForm.Elements.ButtonRestoreQuery.Add_Click({
                         $Script:RunTimeData.CurrentQueryText = $SelectedItem.OldValue
                         "Query restored to editor!" | Write-LogOutput
                     }
-                    "Query restored from history: {0}" -f $SelectedItem.ChangeDate.ToString('yyyy-MM-dd HH:mm:ss') | Write-LogOutput
+                    "Query restored from history: {0}" -f (Format-OmadaHistoryDate -Value $SelectedItem.ChangeDate) | Write-LogOutput
 
                     $Script:SqlHistoryForm.Definition.Close()
                 }

--- a/src/Lib/Events/SqlHistoryForm.Elements.DataGridHistory.ps1
+++ b/src/Lib/Events/SqlHistoryForm.Elements.DataGridHistory.ps1
@@ -26,16 +26,20 @@ $Script:SqlHistoryForm.Elements.DataGridHistory.Add_SelectedCellsChanged({
             $Script:SqlHistoryForm.Elements.TextBoxDoId.Text = $SelectedItem.DoId
             $Script:SqlHistoryForm.Elements.TextBoxObjectName.Text = $SelectedItem.SqlObjectName
             $Script:SqlHistoryForm.Elements.TextBoxChangedBy.Text = $SelectedItem.ChangedBy
-            $Script:SqlHistoryForm.Elements.TextBoxChangeDate.Text = $SelectedItem.ChangeDate.ToString("yyyy-MM-dd HH:mm:ss")
+            # Not .ToString() directly: an unreadable change date is $null (issue #95), and calling a
+            # method on it would move the failure from the fetch to the first click.
+            $Script:SqlHistoryForm.Elements.TextBoxChangeDate.Text = Format-OmadaHistoryDate -Value $SelectedItem.ChangeDate
 
             $Script:SqlHistoryForm.Elements.ButtonRestoreQuery.IsEnabled = $true
 
             Invoke-GenerateDiffView -OldValue $SelectedItem.OldValue -NewValue $SelectedItem.NewValue
 
-            "Selected history item: {0} - {1}" -f $SelectedItem.ChangeDate, $SelectedItem.ChangedBy | Write-LogOutput -LogType DEBUG
+            "Selected history item: {0} - {1}" -f (Format-OmadaHistoryDate -Value $SelectedItem.ChangeDate), $SelectedItem.ChangedBy | Write-LogOutput -LogType DEBUG
         }
         catch {
-            $_.Exception.Message | Write-LogOutput -LogType ERROR -ErrorObject $_
+            # Contained: this is a WPF selection handler, so a terminating log unwinds into the
+            # event dispatch rather than into anything that can act on it.
+            $_.Exception.Message | Write-ContainedErrorLog -ErrorObject $_
         }
 
     })

--- a/src/Lib/Functions/Private/ConvertTo-OmadaHistoryDate.ps1
+++ b/src/Lib/Functions/Private/ConvertTo-OmadaHistoryDate.ps1
@@ -1,0 +1,66 @@
+function ConvertTo-OmadaHistoryDate {
+    <#
+    .SYNOPSIS
+    Parse a change date from Omada's history grid, whatever culture rendered it.
+
+    .DESCRIPTION
+    Issue #95. The value comes from Omada's DataObjectHistory endpoint, which returns a jqGrid-style
+    payload: "When" is a display string the SERVER formatted, not an ISO 8601 timestamp. So its
+    format follows a locale, and not necessarily the one the client is running under.
+
+    This used to be `Get-Date ($Row.When)`, which binds to a [DateTime] parameter and therefore
+    converts using the CURRENT culture. On nl-NL the value "8/25/2026 12:03 PM" is read as day 8,
+    month 25 - not a month - and the whole call failed:
+
+        Cannot bind parameter 'Date'. Cannot convert value "8/25/2026 12:03 PM" to type
+        "System.DateTime". Error: "String '8/25/2026 12:03 PM' was not recognized as a valid
+        DateTime."
+
+    Two cultures are tried, in order, and the order is the point. InvariantCulture first, because the
+    observed value is month-first and matches it. CurrentCulture second, because a tenant that
+    renders dates the local way would fail the other way round - "25-08-2026 12:03" is not a valid
+    invariant date. Trying one and only one culture trades one locale's failure for another's.
+
+    .NOTES
+    The caller must not treat an unparsed date as fatal. Losing one row's timestamp is a cosmetic
+    problem; losing the whole history list because one timestamp was unusual is the defect #95 was
+    actually about - the failure propagated out of the row loop to the function's outer catch, and
+    the user got an error dialog and no history at all.
+
+    .PARAMETER Value
+    The rendered date string from the history row.
+
+    .OUTPUTS
+    [DateTime] when it could be read, otherwise $null.
+    #>
+    [CmdLetBinding()]
+    param(
+        $Value
+    )
+
+    if ($null -eq $Value) {
+        return $null
+    }
+
+    # Already a DateTime - a future endpoint returning a real timestamp, or a test supplying one -
+    # needs no parsing and must not be round-tripped through a culture.
+    if ($Value -is [DateTime]) {
+        return $Value
+    }
+
+    $Private:Text = [string]$Value
+    if ([string]::IsNullOrWhiteSpace($Private:Text)) {
+        return $null
+    }
+
+    $Private:Parsed = [DateTime]::MinValue
+    foreach ($Private:Culture in @([System.Globalization.CultureInfo]::InvariantCulture, [System.Globalization.CultureInfo]::CurrentCulture)) {
+        if ([DateTime]::TryParse($Private:Text, $Private:Culture, [System.Globalization.DateTimeStyles]::None, [ref]$Private:Parsed)) {
+            return $Private:Parsed
+        }
+    }
+
+    # DEBUG, not an error. The row is still worth showing; only its date is unknown.
+    "Could not read the history change date '{0}' under either the invariant or the current culture ({1})." -f $Private:Text, [System.Globalization.CultureInfo]::CurrentCulture.Name | Write-LogOutput -LogType DEBUG
+    return $null
+}

--- a/src/Lib/Functions/Private/Format-OmadaHistoryDate.ps1
+++ b/src/Lib/Functions/Private/Format-OmadaHistoryDate.ps1
@@ -32,5 +32,9 @@ function Format-OmadaHistoryDate {
         return "(unknown)"
     }
 
-    return ([DateTime]$Value).ToString("yyyy-MM-dd HH:mm:ss")
+    # InvariantCulture explicitly: a fixed format string is not a fixed rendering. The CALENDAR and
+    # the digits still come from the current culture, so the same moment renders as 2569-08-25 on
+    # th-TH (Buddhist era) and 1448-03-12 on ar-SA (Hijri). This is a log and export format, and it
+    # sits directly on top of a bug caused by an unwritten culture assumption.
+    return ([DateTime]$Value).ToString("yyyy-MM-dd HH:mm:ss", [System.Globalization.CultureInfo]::InvariantCulture)
 }

--- a/src/Lib/Functions/Private/Format-OmadaHistoryDate.ps1
+++ b/src/Lib/Functions/Private/Format-OmadaHistoryDate.ps1
@@ -1,0 +1,36 @@
+function Format-OmadaHistoryDate {
+    <#
+    .SYNOPSIS
+        Renders a history change date for display, tolerating one that could not be read.
+
+    .DESCRIPTION
+        ConvertTo-OmadaHistoryDate returns $null when the server sent a change date that could not
+        be parsed under either the invariant or the current culture (issue #95). The point of that
+        was to cost the user one cell rather than the whole history list - so every place that
+        DISPLAYS a change date has to survive the null as well, or the failure simply moves from
+        the fetch to the first click. Calling .ToString() on it throws
+        "You cannot call a method on a null-valued expression".
+
+        The placeholder matches TargetNullValue on the grid column in SqlHistoryForm.xaml, so the
+        row reads the same in the grid, in the detail pane and in an export.
+
+    .PARAMETER Value
+        The change date to render. May be $null.
+
+    .EXAMPLE
+        Format-OmadaHistoryDate -Value $Item.ChangeDate
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param (
+        [Parameter(Position = 0)]
+        [AllowNull()]
+        $Value
+    )
+
+    if ($null -eq $Value) {
+        return "(unknown)"
+    }
+
+    return ([DateTime]$Value).ToString("yyyy-MM-dd HH:mm:ss")
+}

--- a/src/Lib/Functions/Private/Get-SqlHistory.ps1
+++ b/src/Lib/Functions/Private/Get-SqlHistory.ps1
@@ -71,7 +71,13 @@ function Get-SqlHistory {
                         NewValue      = $null -ne $ChangedField.NewValue ? [System.Web.HttpUtility]::HtmlDecode($ChangedField.NewValue) : $null
                         ChangedBy     = $Row.Who
                         ChangeType    = $Row.What
-                        ChangeDate    = (Get-Date ($Row.When))
+                        # Not Get-Date: that binds to a [DateTime] parameter and so converts using
+                        # the CURRENT culture, and this value is a string the SERVER formatted. On a
+                        # machine whose culture is not month-first, "8/25/2026 12:03 PM" is read as
+                        # day 8 of month 25, the binding fails, and the failure propagates out of
+                        # this loop to the outer catch - losing the ENTIRE history list over one
+                        # timestamp (issue #95). A date that cannot be read is now just a null date.
+                        ChangeDate    = ConvertTo-OmadaHistoryDate -Value $Row.When
                     }
                     $SqlHistoryObjects += $SqlHistoryObject
 

--- a/src/Lib/Functions/Private/Invoke-LoadSqlHistoryData.ps1
+++ b/src/Lib/Functions/Private/Invoke-LoadSqlHistoryData.ps1
@@ -20,14 +20,35 @@ function Invoke-LoadSqlHistoryData {
             $HistoryCollection.Add($Item)
         }
 
-        $Script:SqlHistoryForm.Elements.DataGridHistory.ItemsSource = $HistoryCollection
+        # The window may be gone by now (issue #96). This runs from the history form's Loaded
+        # handler, and Get-SqlHistory above BLOCKS for a full round-trip - so the window is on screen
+        # and interactive throughout the fetch. Changing the selected query closes it
+        # (MainFormTabContent.Elements.ComboBoxSelectQuery.ps1), and so does the user. The null guard
+        # at the top of this function covers the DATA; nothing covered the FORM.
+        # The whole chain, not just the leaf: a closed window can leave $Script:SqlHistoryForm itself
+        # null, and under StrictMode walking into that is an error rather than a quiet $null.
+        $Private:HistoryGrid = $null
+        if ($null -ne $Script:SqlHistoryForm -and $null -ne $Script:SqlHistoryForm.Elements) {
+            $Private:HistoryGrid = $Script:SqlHistoryForm.Elements.DataGridHistory
+        }
+
+        if ($null -eq $Private:HistoryGrid) {
+            # Quietly: the user closed a window and has moved on. There is nothing to tell them and
+            # nothing they could do about it.
+            "The SQL history window closed while its data was loading; nothing to display into." | Write-LogOutput -LogType DEBUG
+            return
+        }
+
+        $Private:HistoryGrid.ItemsSource = $HistoryCollection
         if ($HistoryCollection.Count -gt 0) {
-            $Script:SqlHistoryForm.Elements.DataGridHistory.SelectedIndex = 0
+            $Private:HistoryGrid.SelectedIndex = 0
         }
 
         "Loaded {0} SQL history records" -f $HistoryCollection.Count | Write-LogOutput -LogType DEBUG
     }
     catch {
-        $_.Exception.Message | Write-LogOutput -LogType ERROR -ErrorObject $_
+        # Contained. This is reached from a Loaded handler, and a terminating log here would unwind
+        # into WPF's event dispatch rather than into anything that can act on it.
+        $_.Exception.Message | Write-ContainedErrorLog -ErrorObject $_
     }
 }

--- a/src/Lib/ui/SqlHistoryForm.xaml
+++ b/src/Lib/ui/SqlHistoryForm.xaml
@@ -163,7 +163,7 @@
                           IsReadOnly="True">
                     <DataGrid.Columns>
                         <DataGridTextColumn Header="Change Date"
-                                            Binding="{Binding ChangeDate, StringFormat=yyyy-MM-dd HH:mm:ss}"
+                                            Binding="{Binding ChangeDate, StringFormat=yyyy-MM-dd HH:mm:ss, TargetNullValue='(unknown)'}"
                                             MinWidth="100"/>
                         <DataGridTextColumn Header="Changed By"
                                             Binding="{Binding ChangedBy}"

--- a/tests/ConvertTo-OmadaHistoryDate.Tests.ps1
+++ b/tests/ConvertTo-OmadaHistoryDate.Tests.ps1
@@ -1,0 +1,133 @@
+#Requires -Version 7.0
+# Issue #95. From a live session on an nl-NL machine:
+#
+#   Get-SqlHistory (88): Cannot bind parameter 'Date'. Cannot convert value "8/25/2026 12:03 PM"
+#   to type "System.DateTime". Error: "String '8/25/2026 12:03 PM' was not recognized as a valid
+#   DateTime."
+#
+# "When" is a display string the SERVER formatted, not ISO 8601, so its format follows a locale -
+# and Get-Date binds to a [DateTime] parameter, which converts under the CURRENT culture. Day 8 of
+# month 25 is not a date.
+#
+# The tests run under an explicitly non-US culture. On a US build agent the original defect is
+# invisible, so a test that inherits the ambient culture would pass on CI and fail on the machine
+# that reported it.
+
+BeforeAll {
+    $ParentPath = Split-Path -Path $PSScriptRoot -Parent
+    $PrivatePath = Join-Path $ParentPath -ChildPath "src\Lib\Functions\Private"
+    . (Join-Path $PrivatePath -ChildPath "ConvertTo-OmadaHistoryDate.ps1")
+
+    $script:LogMessages = [System.Collections.Generic.List[object]]::new()
+    function Write-LogOutput {
+        param([Parameter(ValueFromPipeline = $true)]$InputObject, [string]$LogType, $ErrorObject, [switch]$SkipDialog, [switch]$TabScoped)
+        process { $script:LogMessages.Add([pscustomobject]@{ LogType = $LogType; Message = [string]$InputObject }) }
+    }
+
+    # Runs a scriptblock under a chosen culture and restores the original afterwards.
+    function script:Use-Culture {
+        param([string]$Name, [scriptblock]$Body)
+
+        $Private:Previous = [System.Threading.Thread]::CurrentThread.CurrentCulture
+        try {
+            [System.Threading.Thread]::CurrentThread.CurrentCulture = [System.Globalization.CultureInfo]::GetCultureInfo($Name)
+            return (& $Body)
+        }
+        finally {
+            [System.Threading.Thread]::CurrentThread.CurrentCulture = $Private:Previous
+        }
+    }
+}
+
+Describe "ConvertTo-OmadaHistoryDate" {
+    BeforeEach { $script:LogMessages.Clear() }
+
+    It "reads the value that broke history on nl-NL" {
+        # The reported case, under the reporting machine's culture.
+        $Private:Result = Use-Culture -Name "nl-NL" -Body { ConvertTo-OmadaHistoryDate -Value "8/25/2026 12:03 PM" }
+
+        $Private:Result | Should -Not -BeNullOrEmpty
+        $Private:Result.Year | Should -Be 2026
+        $Private:Result.Month | Should -Be 8
+        $Private:Result.Day | Should -Be 25
+        $Private:Result.Hour | Should -Be 12
+    }
+
+    It "confirms the premise: Get-Date really does fail on that value under nl-NL" {
+        # Asserted so this suite cannot quietly stop testing the actual defect - if the platform ever
+        # started accepting it, these tests would be proving nothing.
+        Use-Culture -Name "nl-NL" -Body {
+            { Get-Date "8/25/2026 12:03 PM" -ErrorAction Stop } | Should -Throw
+        }
+    }
+
+    It "still reads a value rendered the local way" {
+        # The other half, and the reason a single culture is not enough: fixing the reported case
+        # with InvariantCulture alone would trade one locale's failure for another's.
+        $Private:Result = Use-Culture -Name "nl-NL" -Body { ConvertTo-OmadaHistoryDate -Value "25-08-2026 12:03" }
+
+        $Private:Result | Should -Not -BeNullOrEmpty
+        $Private:Result.Month | Should -Be 8
+        $Private:Result.Day | Should -Be 25
+    }
+
+    It "reads an ISO 8601 value, should the endpoint ever return one" {
+        $Private:Result = Use-Culture -Name "nl-NL" -Body { ConvertTo-OmadaHistoryDate -Value "2026-08-25T12:03:00" }
+
+        $Private:Result.Month | Should -Be 8
+        $Private:Result.Day | Should -Be 25
+    }
+
+    It "works the same on a US machine, where the defect was invisible" {
+        $Private:Result = Use-Culture -Name "en-US" -Body { ConvertTo-OmadaHistoryDate -Value "8/25/2026 12:03 PM" }
+
+        $Private:Result.Month | Should -Be 8
+        $Private:Result.Day | Should -Be 25
+    }
+
+    Context "What it does with something it cannot read" {
+        It "returns null rather than throwing" {
+            # The actual severity of #95: the throw propagated out of the row loop to the function's
+            # outer catch, so ONE unreadable timestamp cost the user the entire history list.
+            $Private:Result = $null
+            { $script:Unreadable = ConvertTo-OmadaHistoryDate -Value "not a date at all" } | Should -Not -Throw
+            $script:Unreadable | Should -BeNullOrEmpty
+        }
+
+        It "records it at DEBUG, not as an error" {
+            ConvertTo-OmadaHistoryDate -Value "not a date at all" | Out-Null
+
+            @($script:LogMessages | Where-Object { $_.LogType -ne "DEBUG" }).Count | Should -Be 0
+        }
+
+        It "names the culture it tried, so the log explains itself" {
+            ConvertTo-OmadaHistoryDate -Value "not a date at all" | Out-Null
+
+            $script:LogMessages[0].Message | Should -Match "current culture"
+        }
+
+        It "returns null for null and for empty" {
+            ConvertTo-OmadaHistoryDate -Value $null | Should -BeNullOrEmpty
+            ConvertTo-OmadaHistoryDate -Value "" | Should -BeNullOrEmpty
+            ConvertTo-OmadaHistoryDate -Value "   " | Should -BeNullOrEmpty
+        }
+    }
+
+    It "passes a real DateTime straight through" {
+        # No round trip through a culture for a value that never needed parsing.
+        $Private:Now = [DateTime]::new(2026, 8, 25, 12, 3, 0)
+
+        ConvertTo-OmadaHistoryDate -Value $Private:Now | Should -Be $Private:Now
+    }
+}
+
+Describe "Get-SqlHistory uses it" {
+    It "no longer converts the change date with Get-Date" {
+        # Get-Date binds to a [DateTime] parameter, which is what made the conversion culture-
+        # sensitive in the first place.
+        $Private:Source = Get-Content -Path (Join-Path (Join-Path (Split-Path -Path $PSScriptRoot -Parent) "src\Lib\Functions\Private") "Get-SqlHistory.ps1") -Raw
+
+        $Private:Source | Should -Not -Match 'ChangeDate\s*=\s*\(Get-Date'
+        $Private:Source | Should -Match 'ChangeDate\s*=\s*ConvertTo-OmadaHistoryDate'
+    }
+}

--- a/tests/Format-OmadaHistoryDate.Tests.ps1
+++ b/tests/Format-OmadaHistoryDate.Tests.ps1
@@ -1,0 +1,66 @@
+#Requires -Version 7.0
+# Review finding on PR #100: making ConvertTo-OmadaHistoryDate return $null for an unreadable date
+# (issue #95) makes ChangeDate nullable everywhere it is DISPLAYED. Without this helper the failure
+# simply moves from the fetch to the first click - $null.ToString() throws "You cannot call a method
+# on a null-valued expression" - which would undo the point of the fix.
+
+BeforeAll {
+    $ParentPath = Split-Path -Path $PSScriptRoot -Parent
+    $SourcePath = Join-Path $ParentPath -ChildPath "src\Lib"
+    $PrivatePath = Join-Path $SourcePath -ChildPath "Functions\Private"
+    . (Join-Path $PrivatePath -ChildPath "Format-OmadaHistoryDate.ps1")
+
+    $script:EventsPath = Join-Path $SourcePath -ChildPath "Events"
+    $script:XamlPath = Join-Path $SourcePath -ChildPath "ui\SqlHistoryForm.xaml"
+}
+
+Describe "Format-OmadaHistoryDate" {
+    It "renders a date in the format the history window has always shown" {
+        Format-OmadaHistoryDate -Value ([DateTime]::new(2026, 8, 25, 12, 3, 4)) | Should -Be "2026-08-25 12:03:04"
+    }
+
+    It "does not throw on the null that an unreadable date now produces" {
+        { Format-OmadaHistoryDate -Value $null } | Should -Not -Throw
+    }
+
+    It "says the date is unknown rather than showing an empty cell" {
+        # An empty string would be indistinguishable from a row that genuinely has no date.
+        Format-OmadaHistoryDate -Value $null | Should -Be "(unknown)"
+    }
+
+    It "renders the same way whatever the culture" {
+        # The format string is invariant by construction, but the assertion is cheap and the whole
+        # bug this sits on top of was a culture assumption nobody had written down.
+        $Private:Previous = [System.Threading.Thread]::CurrentThread.CurrentCulture
+        try {
+            [System.Threading.Thread]::CurrentThread.CurrentCulture = [System.Globalization.CultureInfo]::GetCultureInfo("nl-NL")
+            Format-OmadaHistoryDate -Value ([DateTime]::new(2026, 8, 25, 12, 3, 4)) | Should -Be "2026-08-25 12:03:04"
+        }
+        finally {
+            [System.Threading.Thread]::CurrentThread.CurrentCulture = $Private:Previous
+        }
+    }
+}
+
+Describe "Every place a change date is displayed" {
+    # These are source assertions rather than behavioural ones: the call sites are WPF event
+    # handlers, which cannot be invoked headlessly. What they defend is the thing that actually went
+    # wrong - a .ToString() on a value that is now nullable.
+    It "no longer calls .ToString() on a change date" {
+        $Private:Handlers = Get-ChildItem -Path $script:EventsPath -Filter "SqlHistoryForm.Elements.*.ps1"
+        $Private:Handlers | Should -Not -BeNullOrEmpty
+
+        foreach ($Private:Handler in $Private:Handlers) {
+            $Private:Source = Get-Content -Path $Private:Handler.FullName -Raw
+            $Private:Source | Should -Not -Match 'ChangeDate\.ToString' -Because "$($Private:Handler.Name) would throw on a row whose date could not be read"
+        }
+    }
+
+    It "shows the same placeholder in the grid as in the detail pane" {
+        $Private:Xaml = Get-Content -Path $script:XamlPath -Raw
+
+        # Quoted, because a markup-extension value starting with "(" is otherwise read as attached
+        # property syntax.
+        $Private:Xaml | Should -Match "TargetNullValue='\(unknown\)'"
+    }
+}

--- a/tests/Format-OmadaHistoryDate.Tests.ps1
+++ b/tests/Format-OmadaHistoryDate.Tests.ps1
@@ -28,12 +28,19 @@ Describe "Format-OmadaHistoryDate" {
         Format-OmadaHistoryDate -Value $null | Should -Be "(unknown)"
     }
 
-    It "renders the same way whatever the culture" {
-        # The format string is invariant by construction, but the assertion is cheap and the whole
-        # bug this sits on top of was a culture assumption nobody had written down.
+    # A fixed format string is NOT a fixed rendering - the calendar and the digits still come from
+    # the current culture. These are the cultures that prove it: nl-NL cannot, because it shares the
+    # Gregorian calendar and ASCII digits with en-US, so an nl-NL test would pass on the culture-
+    # sensitive code and claim to have checked this.
+    It "renders the same way under <Culture>, whose calendar is not Gregorian" -ForEach @(
+        @{ Culture = "th-TH" }  # Buddhist era - the year would read 2569
+        @{ Culture = "ar-SA" }  # Hijri - the whole date would read 1448-03-12
+        @{ Culture = "nl-NL" }
+        @{ Culture = "en-US" }
+    ) {
         $Private:Previous = [System.Threading.Thread]::CurrentThread.CurrentCulture
         try {
-            [System.Threading.Thread]::CurrentThread.CurrentCulture = [System.Globalization.CultureInfo]::GetCultureInfo("nl-NL")
+            [System.Threading.Thread]::CurrentThread.CurrentCulture = [System.Globalization.CultureInfo]::GetCultureInfo($Culture)
             Format-OmadaHistoryDate -Value ([DateTime]::new(2026, 8, 25, 12, 3, 4)) | Should -Be "2026-08-25 12:03:04"
         }
         finally {

--- a/tests/Invoke-LoadSqlHistoryData.Tests.ps1
+++ b/tests/Invoke-LoadSqlHistoryData.Tests.ps1
@@ -1,0 +1,150 @@
+#Requires -Version 7.0
+# Issue #96, from a live session:
+#
+#   Invoke-LoadSqlHistoryData (25): You cannot call a method on a null-valued expression.
+#
+# This runs from the history form's Loaded handler, and Get-SqlHistory BLOCKS for a full round-trip -
+# so the window is on screen and interactive for the whole fetch. Changing the selected query closes
+# it, and so does the user. The existing guard covered the DATA; nothing covered the FORM.
+
+BeforeAll {
+    $ParentPath = Split-Path -Path $PSScriptRoot -Parent
+    $PrivatePath = Join-Path $ParentPath -ChildPath "src\Lib\Functions\Private"
+    . (Join-Path $PrivatePath -ChildPath "Write-ContainedErrorLog.ps1")
+    . (Join-Path $PrivatePath -ChildPath "Invoke-LoadSqlHistoryData.ps1")
+
+    $script:LogMessages = [System.Collections.Generic.List[object]]::new()
+    function Write-LogOutput {
+        param([Parameter(ValueFromPipeline = $true)]$InputObject, [string]$LogType, $ErrorObject, [switch]$SkipDialog, [switch]$TabScoped)
+        process { $script:LogMessages.Add([pscustomobject]@{ LogType = $LogType; Message = [string]$InputObject }) }
+    }
+
+    function script:New-GridStub {
+        return [pscustomobject]@{ ItemsSource = $null; SelectedIndex = -1 }
+    }
+
+    function script:Initialize-HistoryState {
+        param([switch]$WindowClosed, [switch]$NoElements)
+
+        $script:LogMessages.Clear()
+
+        if ($WindowClosed) {
+            $Script:SqlHistoryForm = $null
+        }
+        elseif ($NoElements) {
+            $Script:SqlHistoryForm = [pscustomobject]@{ Elements = $null }
+        }
+        else {
+            $Script:SqlHistoryForm = [pscustomobject]@{ Elements = [pscustomobject]@{ DataGridHistory = (New-GridStub) } }
+        }
+    }
+
+    # A script-scoped variable rather than a Mock closing over a parameter: the mock scriptblock
+    # runs later, in a scope where that parameter no longer exists, so it would always answer null.
+    function script:Set-History {
+        param($Rows)
+        $script:HistoryRows = $Rows
+    }
+
+    function script:New-Row {
+        param([string]$Name = "x", $ChangeDate = ([DateTime]::new(2026, 8, 25)))
+        return [pscustomobject]@{ SqlObjectName = $Name; ChangeDate = $ChangeDate }
+    }
+
+    function Get-SqlHistory { return $script:HistoryRows }
+}
+
+Describe "Invoke-LoadSqlHistoryData" {
+    Context "The window is still open" {
+        BeforeEach { Initialize-HistoryState }
+
+        It "binds the rows to the grid" {
+            Set-History -Rows @((New-Row -Name "a"), (New-Row -Name "b"))
+
+            Invoke-LoadSqlHistoryData
+
+            @($Script:SqlHistoryForm.Elements.DataGridHistory.ItemsSource).Count | Should -Be 2
+        }
+
+        It "selects the first row" {
+            Set-History -Rows @((New-Row -Name "a"))
+
+            Invoke-LoadSqlHistoryData
+
+            $Script:SqlHistoryForm.Elements.DataGridHistory.SelectedIndex | Should -Be 0
+        }
+
+        It "sorts newest first" {
+            Set-History -Rows @(
+                (New-Row -Name "old" -ChangeDate ([DateTime]::new(2026, 1, 1))),
+                (New-Row -Name "new" -ChangeDate ([DateTime]::new(2026, 8, 25)))
+            )
+
+            Invoke-LoadSqlHistoryData
+
+            @($Script:SqlHistoryForm.Elements.DataGridHistory.ItemsSource)[0].SqlObjectName | Should -Be "new"
+        }
+
+        It "copes with a row whose date could not be read" {
+            # ConvertTo-OmadaHistoryDate returns null for an unreadable date (issue #95), so Sort-Object
+            # has to handle nulls - the two fixes meet here.
+            Set-History -Rows @((New-Row -Name "dated"), (New-Row -Name "undated" -ChangeDate $null))
+
+            { Invoke-LoadSqlHistoryData } | Should -Not -Throw
+            @($Script:SqlHistoryForm.Elements.DataGridHistory.ItemsSource).Count | Should -Be 2
+        }
+    }
+
+    Context "The window closed while the fetch was running" {
+        It "does not throw when the form has gone" {
+            Initialize-HistoryState -WindowClosed
+            Set-History -Rows @((New-Row))
+
+            { Invoke-LoadSqlHistoryData } | Should -Not -Throw
+        }
+
+        It "does not throw when the form is there but its elements are not" {
+            Initialize-HistoryState -NoElements
+            Set-History -Rows @((New-Row))
+
+            { Invoke-LoadSqlHistoryData } | Should -Not -Throw
+        }
+
+        It "says nothing above DEBUG - the user closed a window and has moved on" {
+            Initialize-HistoryState -WindowClosed
+            Set-History -Rows @((New-Row))
+
+            Invoke-LoadSqlHistoryData
+
+            @($script:LogMessages | Where-Object { $_.LogType -ne "DEBUG" }).Count | Should -Be 0
+        }
+
+        It "records why it stopped" {
+            Initialize-HistoryState -WindowClosed
+            Set-History -Rows @((New-Row))
+
+            Invoke-LoadSqlHistoryData
+
+            ($script:LogMessages.Message -join " ") | Should -Match "closed while its data was loading"
+        }
+    }
+
+    Context "There is no history to show" {
+        BeforeEach { Initialize-HistoryState }
+
+        It "returns quietly for an empty result" {
+            Set-History -Rows @()
+
+            { Invoke-LoadSqlHistoryData } | Should -Not -Throw
+            $Script:SqlHistoryForm.Elements.DataGridHistory.ItemsSource | Should -BeNullOrEmpty
+        }
+
+        It "returns quietly for a null result" {
+            # Get-SqlHistory returns null on failure - including the date failure of #95 before it
+            # was fixed.
+            Set-History -Rows $null
+
+            { Invoke-LoadSqlHistoryData } | Should -Not -Throw
+        }
+    }
+}


### PR DESCRIPTION
Closes #95
Closes #96

Two bugs from the same live log, both in the history path, delivered together because they are in the same two files and the second is reachable through the first.

## #95 — history fails to load on a non-US culture

```
Get-SqlHistory (88): Cannot bind parameter 'Date'. Cannot convert value "8/25/2026 12:03 PM"
to type "System.DateTime". Error: "String '8/25/2026 12:03 PM' was not recognized as a valid DateTime."
```

`Get-SqlHistory.ps1:74` converted with `Get-Date ($Row.When)`. `Get-Date`'s `-Date` parameter is `[DateTime]`, so PowerShell coerces **using the current culture** — and `When` is a display string the *server* formatted (Omada's `DataObjectHistory` returns a jqGrid payload, not ISO 8601). On `nl-NL`, `8/25/2026` is day 8 of month 25.

**The severity was not one bad cell.** The conversion sits inside the row loop, so the failure propagated to the function's outer `catch` and the user lost the **entire history list** — an error dialog and nothing to show.

`ConvertTo-OmadaHistoryDate` tries `InvariantCulture`, then `CurrentCulture`. An unreadable date becomes `$null` and a DEBUG line.

## #96 — null reference when the window closes during the fetch

```
Invoke-LoadSqlHistoryData (25): You cannot call a method on a null-valued expression.
```

It writes into the history grid without checking the window is still there. It runs from that form's `Loaded` handler, and `Get-SqlHistory` **blocks** for a full round-trip — so the window is on screen and interactive throughout, and changing the selected query closes it (`ComboBoxSelectQuery.ps1:43-44`), as does the user. The existing null guard covered the **data**; nothing covered the **form**.

## Decisions worth reviewing

- **Two cultures, not one.** `InvariantCulture` alone fixes the reported case and would have looked complete — but it trades one locale's failure for another's: `25-08-2026 12:03` is not a valid invariant date, so a tenant rendering dates the local way would then fail the other way round.
- **An unreadable date is `$null`, not an error.** The culture-sensitivity is how the bug was triggered; losing the whole list over one timestamp is what it actually *was*. That is the part worth being defensive about.
- **The whole chain is guarded, not just the leaf.** A closed window can leave `$Script:SqlHistoryForm` itself null, and under StrictMode walking into that is an error rather than a quiet `$null`.
- **`Invoke-LoadSqlHistoryData`'s catch is now contained.** It is reached from a `Loaded` handler, where a terminating log unwinds into WPF's event dispatch rather than into anything that can act on it — the same class as the cleanup paths fixed in #83.
- **Tests set the culture explicitly** and assert the premise, that `Get-Date` really does fail on that value under `nl-NL`. On a US build agent the original defect is invisible, so a test inheriting the ambient culture would pass on CI and fail on the machine that reported it.

## Acceptance criteria

**#95**
- [x] History loads on a machine whose culture is not month-first — `ConvertTo-OmadaHistoryDate.Tests.ps1`, *"reads the value that broke history on nl-NL"*
- [x] A date that cannot be parsed in any candidate culture does not lose the other rows — it returns `$null` inside the row loop; *"returns null rather than throwing"*
- [x] An unparseable date is logged at DEBUG, not raised as an ERROR dialog — *"records it at DEBUG, not as an error"*
- [x] Covered by a test that runs under a non-`en-US` culture — every case runs under `Use-Culture`

**#96**
- [x] Closing the history window while it is still loading does not raise an error — *"says nothing above DEBUG"*
- [x] Changing the selected query while history is loading does not raise an error — same guard, same test (both paths null the form)
- [x] Nothing above DEBUG is logged when the window has legitimately gone
- [x] History still loads and selects its first row normally when the window stays open — *"binds the rows to the grid"*, *"selects the first row"*

## One thing worth knowing about the tests

For #96, **"should not throw" passes against the broken code** — the old `catch` swallowed the null reference, so nothing escaped. Only the assertions that nothing above DEBUG is logged actually catch it.

Mutation-tested: restoring the unguarded writes fails exactly two tests, both of them the DEBUG ones, and the unmutated tree passes.

## Verification

```
./build/build.ps1 -Task TestBuildOnly   ->  955 tests, 0 failed; PSScriptAnalyzer clean
./build/build.ps1 -Task E2E             ->   54 tests, 0 failed
```

## Survey

No duplicates or conflicts; searched blocking/UI-thread, history, and culture/date terms, checked cross-references and `git log --grep` on `origin/main`.

Related: **#45** (F1) targets the same legacy `.asmx` endpoints that history uses — different concern, same files. **#90** makes `Get-SqlHistory` asynchronous and is the next slice; these fixes land first deliberately, so they are reviewable on their own rather than buried in a threading change.

Part of #40.
