### PR TITLE
Run the SQL Troubleshooting view lookup on a worker, as one job

### DIFF
--- a/src/Lib/Functions/Private/Get-OmadaGetPagingDataObject.ps1
+++ b/src/Lib/Functions/Private/Get-OmadaGetPagingDataObject.ps1
@@ -13,23 +13,15 @@ function Get-OmadaGetPagingDataObject {
 
     try {
         $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4} - Parameters: {5}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement, (ConvertTo-RedactedLogString -InputObject $PSBoundParameters -MaxDepth 1)))
-        $Script:RunTimeData.RestMethodParam.Body = [ordered]@{
-            _search      = $false
-            nd           = 1732546553116
-            rows         = $Rows
-            page         = 1
-            sidx         = $(if ([string]::IsNullOrWhiteSpace($SearchString)) { $null }else { "name" })
-            sord         = "asc"
-            searchField  = $null
-            searchString = $(if ([string]::IsNullOrWhiteSpace($SearchString)) { $null }else { $SearchString })
-            searchOper   = $null
-            filters      = $null
-            dataType     = $DataType
-            dataTypeArgs = $DataTypeArgs
-        }
+        # Built by New-OmadaPagingRequest rather than inline, so this request and the one
+        # Invoke-OmadaViewLookupPipeline issues from a worker are the same request (issue #90). The
+        # body carries a constant cache-busting `nd`, which is precisely the kind of value that
+        # becomes two different constants once it exists in two places.
+        $Private:Request = New-OmadaPagingRequest -DataType $DataType -DataTypeArgs $DataTypeArgs -SearchString $SearchString -Rows $Rows -BaseUrl $Script:AppConfig.BaseUrl
 
-        $Script:RunTimeData.RestMethodParam.Uri = '{0}/WebService/JQGridPopulationWebService.asmx/GetPagingData' -f $Script:AppConfig.BaseUrl
-        $Script:RunTimeData.RestMethodParam.Method = "POST"
+        $Script:RunTimeData.RestMethodParam.Body = $Private:Request.Body
+        $Script:RunTimeData.RestMethodParam.Uri = $Private:Request.Uri
+        $Script:RunTimeData.RestMethodParam.Method = $Private:Request.Method
 
         return Invoke-OmadaPSWebRequestWrapper
 

--- a/src/Lib/Functions/Private/Get-OmadaPipelineWorkerFunction.ps1
+++ b/src/Lib/Functions/Private/Get-OmadaPipelineWorkerFunction.ps1
@@ -70,20 +70,26 @@ function Get-OmadaPipelineWorkerFile {
 function Test-OmadaPipelineWorkerChain {
     <#
     .SYNOPSIS
-    Whether the named entry point is actually defined by one of the named files.
+    Whether the chain's file list includes the file that, by this repository's naming convention,
+    would define the named entry point.
 
     .DESCRIPTION
     The gap this closes: the pre-flight check in Start-OmadaBackgroundRequest confirms the FILES
-    exist, and nothing confirms the FUNCTION is in them. A typo in PipelineFunction therefore passed
+    exist, and nothing related them to the FUNCTION. A typo in PipelineFunction therefore passed
     every check and died inside the worker - turning what the whole fallback design promises to be a
     clean "run it inline instead" into a background job that fails.
 
     Unavailability of any kind has to mean the same thing here, which is why this is a pre-flight
     test rather than a runtime error: slower is better than broken.
 
-    Matched by the repository's one-public-function-per-file convention, so
-    Invoke-OmadaViewLookupPipeline must be accompanied by Invoke-OmadaViewLookupPipeline.ps1. The
-    chain's other files - request builders and the like - are not the entry point and are not
+    It is a NAME check, not a parse: it asks whether "<PipelineFunction>.ps1" is in the list, relying
+    on the repository's one-public-function-per-file convention. It therefore catches a typo and a
+    file left out of the list, which are the mistakes that actually happen; it does not open the file
+    and would not notice a function renamed inside one that still has its old name. Reading the
+    file's contents here would mean parsing PowerShell on the dispatch path for a guard against a
+    mistake the test suite already fails on.
+
+    The chain's other files - request builders and the like - are not the entry point and are not
     matched.
 
     .PARAMETER PipelineFunction

--- a/src/Lib/Functions/Private/Get-OmadaPipelineWorkerFunction.ps1
+++ b/src/Lib/Functions/Private/Get-OmadaPipelineWorkerFunction.ps1
@@ -28,7 +28,10 @@ function Get-OmadaPipelineWorkerFunction {
     )
 
     if ($null -ne $PipelineContext -and -not [string]::IsNullOrWhiteSpace($PipelineContext.PipelineFunction)) {
-        return [string]$PipelineContext.PipelineFunction
+        # Trimmed, because IsNullOrWhiteSpace accepts " Invoke-X " and & " Invoke-X " does not find
+        # it. More to the point, Test-OmadaPipelineWorkerChain matches this name against a file name,
+        # and a comparison is only as sound as the normalisation behind it.
+        return ([string]$PipelineContext.PipelineFunction).Trim()
     }
 
     return "Invoke-OmadaExecutePipeline"
@@ -52,9 +55,59 @@ function Get-OmadaPipelineWorkerFile {
         [hashtable]$PipelineContext
     )
 
-    if ($null -ne $PipelineContext -and $null -ne $PipelineContext.PipelineFiles -and @($PipelineContext.PipelineFiles).Count -gt 0) {
-        return @($PipelineContext.PipelineFiles)
+    if ($null -ne $PipelineContext -and $null -ne $PipelineContext.PipelineFiles) {
+        # Empty and whitespace entries dropped: Join-Path with a null ChildPath throws, and the
+        # pre-flight check that would have caught a missing file instead falls over on the way to it.
+        $Private:Files = @($PipelineContext.PipelineFiles | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | ForEach-Object { ([string]$_).Trim() })
+        if ($Private:Files.Count -gt 0) {
+            return $Private:Files
+        }
     }
 
     return @("New-OmadaQueryRequest.ps1", "Invoke-OmadaExecutePipeline.ps1")
+}
+
+function Test-OmadaPipelineWorkerChain {
+    <#
+    .SYNOPSIS
+    Whether the named entry point is actually defined by one of the named files.
+
+    .DESCRIPTION
+    The gap this closes: the pre-flight check in Start-OmadaBackgroundRequest confirms the FILES
+    exist, and nothing confirms the FUNCTION is in them. A typo in PipelineFunction therefore passed
+    every check and died inside the worker - turning what the whole fallback design promises to be a
+    clean "run it inline instead" into a background job that fails.
+
+    Unavailability of any kind has to mean the same thing here, which is why this is a pre-flight
+    test rather than a runtime error: slower is better than broken.
+
+    Matched by the repository's one-public-function-per-file convention, so
+    Invoke-OmadaViewLookupPipeline must be accompanied by Invoke-OmadaViewLookupPipeline.ps1. The
+    chain's other files - request builders and the like - are not the entry point and are not
+    matched.
+
+    .PARAMETER PipelineFunction
+    The resolved entry point name.
+
+    .PARAMETER PipelineFiles
+    The resolved file list.
+
+    .OUTPUTS
+    [bool]
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [string]$PipelineFunction,
+
+        [string[]]$PipelineFiles
+    )
+
+    if ([string]::IsNullOrWhiteSpace($PipelineFunction) -or $null -eq $PipelineFiles) {
+        return $false
+    }
+
+    $Private:Expected = "{0}.ps1" -f $PipelineFunction.Trim()
+
+    return @($PipelineFiles | Where-Object { $_ -eq $Private:Expected }).Count -gt 0
 }

--- a/src/Lib/Functions/Private/Get-OmadaPipelineWorkerFunction.ps1
+++ b/src/Lib/Functions/Private/Get-OmadaPipelineWorkerFunction.ps1
@@ -1,0 +1,60 @@
+# Which dependent chain a background worker runs, and what it must dot-source to run it.
+#
+# Issue #90, slice A. Start-OmadaBackgroundRequest used to hard-code Invoke-OmadaExecutePipeline as
+# THE worker chain. Both answers are needed in three places - the pre-flight file check, the dispatch
+# itself, and the E2E harness's stand-in for the worker - and a fourth caller getting a different
+# answer from the other three is the failure mode these exist to remove. It happened once already
+# during this slice: the harness answered "execute pipeline" while the dispatch answered "view
+# lookup", so the view lookup came back with an execute-shaped outcome and the failure looked like a
+# defect in the code under test.
+
+function Get-OmadaPipelineWorkerFunction {
+    <#
+    .SYNOPSIS
+    The runspace-safe entry point a worker should call for this pipeline context.
+
+    .PARAMETER PipelineContext
+    The context being dispatched, or $null.
+
+    .OUTPUTS
+    [string] - the function name. Defaults to the execute pipeline, so a caller that says nothing
+    gets exactly the dispatch it got before this became configurable.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [AllowNull()]
+        [hashtable]$PipelineContext
+    )
+
+    if ($null -ne $PipelineContext -and -not [string]::IsNullOrWhiteSpace($PipelineContext.PipelineFunction)) {
+        return [string]$PipelineContext.PipelineFunction
+    }
+
+    return "Invoke-OmadaExecutePipeline"
+}
+
+function Get-OmadaPipelineWorkerFile {
+    <#
+    .SYNOPSIS
+    The files a worker must dot-source to run this pipeline context's chain.
+
+    .PARAMETER PipelineContext
+    The context being dispatched, or $null.
+
+    .OUTPUTS
+    [string[]] - file names relative to Lib\Functions\Private. Defaults to the execute pipeline's.
+    #>
+    [CmdletBinding()]
+    [OutputType([string[]])]
+    param(
+        [AllowNull()]
+        [hashtable]$PipelineContext
+    )
+
+    if ($null -ne $PipelineContext -and $null -ne $PipelineContext.PipelineFiles -and @($PipelineContext.PipelineFiles).Count -gt 0) {
+        return @($PipelineContext.PipelineFiles)
+    }
+
+    return @("New-OmadaQueryRequest.ps1", "Invoke-OmadaExecutePipeline.ps1")
+}

--- a/src/Lib/Functions/Private/Get-SqlTroubleShooterView.ps1
+++ b/src/Lib/Functions/Private/Get-SqlTroubleShooterView.ps1
@@ -160,47 +160,58 @@ function Start-SqlTroubleShooterViewLookup {
                 Write-ExecutePipelineLog -Log $Private:Outcome.Log
             }
 
-            # A worker that could not run the lookup at all is not an answer. Retry once inline,
-            # where authentication works - the same fallback, and the same reasoning, as the schema
-            # fetch: both round-trips are reads, so running them again changes nothing on the tenant.
+            # What a failure MEANS is Resolve-ExecuteFallbackAction's decision, not this function's.
+            # Classifying it here instead - "no completed steps, so the worker is broken" - would
+            # reintroduce precisely the bug that function was written to fix: a tenant can answer
+            # with an HTTP error on the FIRST step (401, 403, 502), which leaves CompletedSteps at 0
+            # even though the worker plainly reached the tenant. That misreading once disabled
+            # background execution for a whole session over one transient 502.
             #
-            # CompletedSteps distinguishes "could not reach the tenant" from "the tenant refused
-            # something". Only the first is worth retrying; a tenant that answered will answer the
-            # same way again.
-            $Private:WorkerFailed = ($null -eq $Private:Outcome -or
-                $Private:Outcome -is [System.Management.Automation.ErrorRecord] -or
-                ($null -ne $Private:Outcome.ErrorRecord -and $Private:Outcome.CompletedSteps -eq 0))
-
-            if ($Private:WorkerFailed -and $Script:ConnectionStatus) {
-                $Private:Reason = if ($null -eq $Private:Outcome) {
-                    "the background worker returned no result"
-                }
-                elseif ($Private:Outcome -is [System.Management.Automation.ErrorRecord]) {
-                    $Private:Outcome.Exception.Message
+            # A status code proves the worker worked. That reasoning belongs in one place, and this
+            # is a second pipeline arriving at the same question - so it asks rather than re-deciding.
+            if ($null -eq $Private:Outcome -or $Private:Outcome -is [System.Management.Automation.ErrorRecord] -or $null -ne $Private:Outcome.ErrorRecord) {
+                # An ErrorRecord rather than an outcome means the wrapper classified a tenant-level
+                # failure. Presented in the shape the classifier reads, so it sees the failure itself
+                # rather than an object with no ErrorRecord - which it would read as "nothing came
+                # back at all".
+                $Private:Classifiable = if ($Private:Outcome -is [System.Management.Automation.ErrorRecord]) {
+                    @{ ErrorRecord = $Private:Outcome; CompletedSteps = 0 }
                 }
                 else {
-                    $Private:Outcome.ErrorRecord.Exception.Message
+                    $Private:Outcome
+                }
+
+                $Private:Failure = $Private:Classifiable.ErrorRecord
+                $Private:Reason = if ($null -eq $Private:Failure) { "the background worker returned no result" } else { $Private:Failure.Exception.Message }
+                $Private:Action = Resolve-ExecuteFallbackAction -Outcome $Private:Classifiable
+
+                if ($Private:Action -eq "Report" -or -not $Script:ConnectionStatus) {
+                    # The tenant answered, and re-running inline would send the identical request and
+                    # get the identical answer. The caller's own "no rows" handling is what that means.
+                    "Could not retrieve the SQL Troubleshooting view: {0}" -f $Private:Reason | Write-LogOutput -LogType WARNING -SkipDialog
+                    & $Pending.Context.Caller.OnResult @{ Rows = $null; DataObjectHtml = $null; RetryInline = $false } $Pending.Context.Caller.Context
+                    return
                 }
 
                 "The SQL Troubleshooting view could not be retrieved on a background worker: {0}" -f $Private:Reason | Write-LogOutput -LogType DEBUG
-                Disable-OmadaBackgroundRequest -Reason $Private:Reason
+
+                # Only on RetryAndDisable. Disabling is a one-way door for the session, so a 401 -
+                # which is Retry - must not take it: the UI thread signs in, and the worker then has
+                # a session to inherit.
+                if ($Private:Action -eq "RetryAndDisable") {
+                    Disable-OmadaBackgroundRequest -Reason $Private:Reason
+                }
 
                 # RetryInline rather than calling Get-SqlTroubleShooterView here: the caller's
                 # synchronous path may be more than this lookup (Update-DataConnectionList follows it
                 # with its own request), and it already exists for the not-dispatched case. Sending
                 # the caller down that same path keeps one definition of it instead of two that can
                 # drift.
+                #
+                # Safe to retry whatever the cause: both round-trips are reads, so running them again
+                # changes nothing on the tenant.
                 "The SQL Troubleshooting view lookup will be retried on the UI thread." | Write-LogOutput -LogType DEBUG
                 & $Pending.Context.Caller.OnResult @{ Rows = $null; DataObjectHtml = $null; RetryInline = $true } $Pending.Context.Caller.Context
-                return
-            }
-
-            # The tenant answered and refused, or answered and holds no such view. Both are answers,
-            # and the caller's own "no rows" handling is what they mean.
-            if ($Private:Outcome -is [System.Management.Automation.ErrorRecord] -or $null -ne $Private:Outcome.ErrorRecord) {
-                $Private:Failure = if ($Private:Outcome -is [System.Management.Automation.ErrorRecord]) { $Private:Outcome } else { $Private:Outcome.ErrorRecord }
-                "Could not retrieve the SQL Troubleshooting view: {0}" -f $Private:Failure.Exception.Message | Write-LogOutput -LogType WARNING -SkipDialog
-                & $Pending.Context.Caller.OnResult @{ Rows = $null; DataObjectHtml = $null; RetryInline = $false } $Pending.Context.Caller.Context
                 return
             }
 

--- a/src/Lib/Functions/Private/Get-SqlTroubleShooterView.ps1
+++ b/src/Lib/Functions/Private/Get-SqlTroubleShooterView.ps1
@@ -38,7 +38,11 @@ function Get-SqlTroubleShooterView {
             }
 
             $Private:Result = Get-OmadaGetPagingDataObject -DataType "DataObjects" -DataTypeArgs $DataTypeArgs
-            $Private:Result = $Private:Result.d.Rows
+            # Normalised to an array, matching Invoke-OmadaViewLookupPipeline. A jqGrid payload for a
+            # view holding nothing has a NULL .d.Rows, and @($null).Count is 1 - so every caller
+            # asking "did I get rows?" the obvious way was told yes for no rows at all. Answering it
+            # here means no caller has to know that.
+            $Private:Result = @($Private:Result.d.Rows | Where-Object { $null -ne $_ })
         }
         return $Private:Result
 

--- a/src/Lib/Functions/Private/Get-SqlTroubleShooterView.ps1
+++ b/src/Lib/Functions/Private/Get-SqlTroubleShooterView.ps1
@@ -135,7 +135,7 @@ function Start-SqlTroubleShooterViewLookup {
 
         # Both the caller's block and the caller's data travel on the context, and are read back from
         # it in the completion. Invoke-OmadaPSWebRequestWrapperAsync nests whatever is passed here
-        # under .Caller, so these are reached as $Pending.Context.Caller.OnRows / .Context.
+        # under .Caller, so these are reached as $Pending.Context.Caller.OnResult / .Context.
         return Invoke-OmadaPSWebRequestWrapperAsync -Description $Script:SqlTroubleShooterViewRequestDescription -Context @{
             OnResult              = $OnResultScriptBlock
             Context               = $Context

--- a/src/Lib/Functions/Private/Get-SqlTroubleShooterView.ps1
+++ b/src/Lib/Functions/Private/Get-SqlTroubleShooterView.ps1
@@ -22,7 +22,11 @@ function Get-SqlTroubleShooterView {
         $ViewResult = Get-OmadaGetPagingDataObject -SearchString "SQL Troubleshooting" -DataType "Views" -DataTypeArgs @{OwnerShipType = "Both" }
         $View = $null
         if ($null -ne $ViewResult -and $ViewResult.d.Records -gt 0) {
-            $View = $ViewResult.d.Rows | Where-Object { $_.Name -eq "SQL Troubleshooting" }
+            # -First 1, matching Invoke-OmadaViewLookupPipeline. A tenant holding two views of this
+            # name would otherwise make $View an array here, and "{0}" -f an array formats as
+            # System.Object[] - an invalid viewId and pageQueryString. The two paths must not differ
+            # on this: one definition of the request is the whole point of New-OmadaPagingRequest.
+            $View = $ViewResult.d.Rows | Where-Object { $_.Name -eq "SQL Troubleshooting" } | Select-Object -First 1
         }
         $Private:Result = $null
         if ($null -ne $View) {
@@ -100,21 +104,44 @@ function Start-SqlTroubleShooterViewLookup {
         # failure AND abandonment when the tab closes, and an entry left behind on that last path
         # would block the tab from ever looking the view up again. The queue cannot get out of step
         # with itself. (The same reasoning, and the same shape, as Get-SqlSchemaObject's guard.)
+        #
+        # It returns the OUTSTANDING item, never $null. $null is this function's "not dispatched, do
+        # what you did before" answer, and the caller's "before" is the three blocking round-trips
+        # this whole slice exists to remove - so answering $null here would defeat the guard AND put
+        # the freeze back, which is worse than the duplicate request it was meant to prevent.
+        #
+        # Matched on shape as well as tab: a lookup running WITHOUT the data connection page cannot
+        # satisfy a caller that needs it, and joining it would leave that caller waiting for data the
+        # worker was never asked to fetch.
+        #
+        # The joining caller's own result block does not run - the outstanding request's does, and
+        # for the same shape on the same tab it does the same work. What it does not carry is the
+        # second caller's context, so where those differ the first call's wins. Today that is only
+        # -NotShowPopupWindow, i.e. whether a popup appears during a refresh that is already
+        # happening.
         $Private:TabSession = Get-ActiveTabSession
-        if ($null -ne $Private:TabSession -and @($Script:PendingWebViewCompletions | Where-Object {
+        if ($null -ne $Private:TabSession) {
+            $Private:Outstanding = @($Script:PendingWebViewCompletions | Where-Object {
                     $_.Description -eq $Script:SqlTroubleShooterViewRequestDescription -and
-                    $_.TabSession.Id -eq $Private:TabSession.Id
-                }).Count -gt 0) {
-            "The SQL Troubleshooting view is already being retrieved for this tab; not requesting it twice." | Write-LogOutput -LogType DEBUG
-            return $null
+                    $_.TabSession.Id -eq $Private:TabSession.Id -and
+                    [bool]$_.Context.Caller.IncludeDataObjectHtml -eq [bool]$IncludeDataObjectHtml
+                }) | Select-Object -First 1
+
+            if ($null -ne $Private:Outstanding) {
+                "The SQL Troubleshooting view is already being retrieved for this tab; joining that request rather than making a second one." | Write-LogOutput -LogType DEBUG
+                return $Private:Outstanding
+            }
         }
 
         # Both the caller's block and the caller's data travel on the context, and are read back from
         # it in the completion. Invoke-OmadaPSWebRequestWrapperAsync nests whatever is passed here
         # under .Caller, so these are reached as $Pending.Context.Caller.OnRows / .Context.
         return Invoke-OmadaPSWebRequestWrapperAsync -Description $Script:SqlTroubleShooterViewRequestDescription -Context @{
-            OnResult = $OnResultScriptBlock
-            Context  = $Context
+            OnResult              = $OnResultScriptBlock
+            Context               = $Context
+            # Recorded so the in-flight guard above can tell whether an outstanding lookup is the
+            # same SHAPE, not merely the same description on the same tab.
+            IncludeDataObjectHtml = [bool]$IncludeDataObjectHtml
         } -PipelineContext @{
             PipelineFunction      = "Invoke-OmadaViewLookupPipeline"
             PipelineFiles         = @("New-OmadaPagingRequest.ps1", "Invoke-OmadaViewLookupPipeline.ps1")

--- a/src/Lib/Functions/Private/Get-SqlTroubleShooterView.ps1
+++ b/src/Lib/Functions/Private/Get-SqlTroubleShooterView.ps1
@@ -1,4 +1,20 @@
+# The label a view lookup carries on the completion queue. A constant because it is matched, not
+# just displayed - see Start-SqlTroubleShooterViewLookup, which reads the queue through it.
+$Script:SqlTroubleShooterViewRequestDescription = "SQL Troubleshooting view"
+
 function Get-SqlTroubleShooterView {
+    <#
+    .SYNOPSIS
+    Find the "SQL Troubleshooting" view and return its data object rows, on the UI thread.
+
+    .DESCRIPTION
+    The blocking form, unchanged in behaviour: two dependent GetPagingData round-trips. It remains
+    the fallback for every case where a background worker may not be used, and it is what
+    Start-SqlTroubleShooterViewLookup retries on when a worker could not do the job.
+
+    Both round-trips are built by New-OmadaPagingRequest, the same builder the background pipeline
+    uses, so the inline and background paths cannot drift apart.
+    #>
     [CmdLetBinding()]
     param()
     try {
@@ -25,5 +41,151 @@ function Get-SqlTroubleShooterView {
     }
     catch {
         $_.Exception.Message | Write-LogOutput -LogType ERROR -ErrorObject $_
+    }
+}
+
+function Start-SqlTroubleShooterViewLookup {
+    <#
+    .SYNOPSIS
+    Run the view lookup on a background worker and hand its rows to a completion block on the UI
+    thread. Returns $null - having done nothing - when it must run inline instead.
+
+    .DESCRIPTION
+    Issue #90, slice A. The two round-trips go to the worker as ONE job (see
+    Invoke-OmadaViewLookupPipeline for why one and not two), so this costs one completion, which is
+    the number of places Set-ActiveTabContext can repoint underneath the work.
+
+    The contract is Invoke-OmadaPSWebRequestWrapperAsync's, deliberately: $null means "not
+    dispatched, do what you did before", so a caller keeps its synchronous path verbatim rather than
+    growing a second implementation of it.
+
+    .PARAMETER OnResultScriptBlock
+    A PLAIN scriptblock (never .GetNewClosure()) invoked on the UI thread with two arguments: a
+    result hashtable, and the caller's own $Context echoed back. The result carries:
+
+      Rows            the view's data object rows, or $null
+      DataObjectHtml  the dataobjdlg.aspx response, when -IncludeDataObjectHtml was asked for
+      RetryInline     $true when the worker could not do the job at all. The caller then runs its
+                      OWN synchronous path - the same one it runs when this function returns $null -
+                      rather than this function keeping a second copy of it.
+
+    .PARAMETER Context
+    Caller data carried to the completion. Read there rather than re-read from $Script: state, which
+    by then may belong to a different tab.
+
+    .PARAMETER IncludeDataObjectHtml
+    Also fetch the dataobjdlg.aspx page for the first row, as a third step of the same worker job.
+    Update-DataConnectionList needs it; Update-QueryList does not.
+
+    .OUTPUTS
+    The pending queue item, or $null when the caller must run the lookup synchronously.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [scriptblock]$OnResultScriptBlock,
+
+        $Context,
+
+        [switch]$IncludeDataObjectHtml
+    )
+
+    try {
+        $Script:Tracer::WriteLine(("{0}: Function: {1} - Caller: {2}({3}) - Command: {4}" -f $($Script:RunTimeConfig.ApplicationName), $($MyInvocation.MyCommand.Name), $($MyInvocation.ScriptName).Split("\")[-1], $($MyInvocation.ScriptLineNumber), $MyInvocation.Statement))
+
+        # Already in flight for this tab? Both of this lookup's callers can be triggered together -
+        # Update-DataConnectionList and Update-QueryList are called one after the other on connect -
+        # and the answer is the same for both. Read straight off the completion queue rather than
+        # from a side table of "lookups in flight": a side table has to be cleared on success,
+        # failure AND abandonment when the tab closes, and an entry left behind on that last path
+        # would block the tab from ever looking the view up again. The queue cannot get out of step
+        # with itself. (The same reasoning, and the same shape, as Get-SqlSchemaObject's guard.)
+        $Private:TabSession = Get-ActiveTabSession
+        if ($null -ne $Private:TabSession -and @($Script:PendingWebViewCompletions | Where-Object {
+                    $_.Description -eq $Script:SqlTroubleShooterViewRequestDescription -and
+                    $_.TabSession.Id -eq $Private:TabSession.Id
+                }).Count -gt 0) {
+            "The SQL Troubleshooting view is already being retrieved for this tab; not requesting it twice." | Write-LogOutput -LogType DEBUG
+            return $null
+        }
+
+        # Both the caller's block and the caller's data travel on the context, and are read back from
+        # it in the completion. Invoke-OmadaPSWebRequestWrapperAsync nests whatever is passed here
+        # under .Caller, so these are reached as $Pending.Context.Caller.OnRows / .Context.
+        return Invoke-OmadaPSWebRequestWrapperAsync -Description $Script:SqlTroubleShooterViewRequestDescription -Context @{
+            OnResult = $OnResultScriptBlock
+            Context  = $Context
+        } -PipelineContext @{
+            PipelineFunction      = "Invoke-OmadaViewLookupPipeline"
+            PipelineFiles         = @("New-OmadaPagingRequest.ps1", "Invoke-OmadaViewLookupPipeline.ps1")
+            BaseUrl               = $Script:AppConfig.BaseUrl
+            IncludeDataObjectHtml = [bool]$IncludeDataObjectHtml
+            SqlQueryDoIdField     = $Script:RunTimeData.DataobjdlgAspxAttributeMapping.SqlQueryDoId
+        } -OnResultScriptBlock {
+            param($Pending)
+
+            $Private:Outcome = $Pending.Outcome
+
+            # Replay what the worker would have logged, at the levels it chose. Without this, moving
+            # the lookup off the UI thread would silently cost this application the log lines it has
+            # always written for these two requests.
+            if ($null -ne $Private:Outcome -and $Private:Outcome -isnot [System.Management.Automation.ErrorRecord]) {
+                Write-ExecutePipelineLog -Log $Private:Outcome.Log
+            }
+
+            # A worker that could not run the lookup at all is not an answer. Retry once inline,
+            # where authentication works - the same fallback, and the same reasoning, as the schema
+            # fetch: both round-trips are reads, so running them again changes nothing on the tenant.
+            #
+            # CompletedSteps distinguishes "could not reach the tenant" from "the tenant refused
+            # something". Only the first is worth retrying; a tenant that answered will answer the
+            # same way again.
+            $Private:WorkerFailed = ($null -eq $Private:Outcome -or
+                $Private:Outcome -is [System.Management.Automation.ErrorRecord] -or
+                ($null -ne $Private:Outcome.ErrorRecord -and $Private:Outcome.CompletedSteps -eq 0))
+
+            if ($Private:WorkerFailed -and $Script:ConnectionStatus) {
+                $Private:Reason = if ($null -eq $Private:Outcome) {
+                    "the background worker returned no result"
+                }
+                elseif ($Private:Outcome -is [System.Management.Automation.ErrorRecord]) {
+                    $Private:Outcome.Exception.Message
+                }
+                else {
+                    $Private:Outcome.ErrorRecord.Exception.Message
+                }
+
+                "The SQL Troubleshooting view could not be retrieved on a background worker: {0}" -f $Private:Reason | Write-LogOutput -LogType DEBUG
+                Disable-OmadaBackgroundRequest -Reason $Private:Reason
+
+                # RetryInline rather than calling Get-SqlTroubleShooterView here: the caller's
+                # synchronous path may be more than this lookup (Update-DataConnectionList follows it
+                # with its own request), and it already exists for the not-dispatched case. Sending
+                # the caller down that same path keeps one definition of it instead of two that can
+                # drift.
+                "The SQL Troubleshooting view lookup will be retried on the UI thread." | Write-LogOutput -LogType DEBUG
+                & $Pending.Context.Caller.OnResult @{ Rows = $null; DataObjectHtml = $null; RetryInline = $true } $Pending.Context.Caller.Context
+                return
+            }
+
+            # The tenant answered and refused, or answered and holds no such view. Both are answers,
+            # and the caller's own "no rows" handling is what they mean.
+            if ($Private:Outcome -is [System.Management.Automation.ErrorRecord] -or $null -ne $Private:Outcome.ErrorRecord) {
+                $Private:Failure = if ($Private:Outcome -is [System.Management.Automation.ErrorRecord]) { $Private:Outcome } else { $Private:Outcome.ErrorRecord }
+                "Could not retrieve the SQL Troubleshooting view: {0}" -f $Private:Failure.Exception.Message | Write-LogOutput -LogType WARNING -SkipDialog
+                & $Pending.Context.Caller.OnResult @{ Rows = $null; DataObjectHtml = $null; RetryInline = $false } $Pending.Context.Caller.Context
+                return
+            }
+
+            & $Pending.Context.Caller.OnResult @{
+                Rows           = $Private:Outcome.Rows
+                DataObjectHtml = $Private:Outcome.DataObjectHtml
+                RetryInline    = $false
+            } $Pending.Context.Caller.Context
+        }
+    }
+    catch {
+        "Could not start the SQL Troubleshooting view lookup on a background worker; it will run on the UI thread. {0}" -f $_.Exception.Message | Write-LogOutput -LogType WARNING -SkipDialog
+        return $null
     }
 }

--- a/src/Lib/Functions/Private/Invoke-OmadaViewLookupPipeline.ps1
+++ b/src/Lib/Functions/Private/Invoke-OmadaViewLookupPipeline.ps1
@@ -1,0 +1,206 @@
+function Invoke-OmadaViewLookupPipeline {
+    <#
+    .SYNOPSIS
+    Run both halves of the "SQL Troubleshooting" view lookup - find the view, then fetch its rows -
+    as one sequence, and return what the UI needs to apply it.
+
+    .DESCRIPTION
+    Issue #90, slice A. Get-SqlTroubleShooterView makes two dependent GetPagingData round-trips: the
+    second needs the view id the first returns, so they cannot be fired off in parallel. That pair
+    is what Update-DataConnectionList blocks on before it makes its own request, and what
+    Update-QueryList blocks on whenever a "my queries" filter is on.
+
+    Two chained background completions would work, and it is deliberately NOT what this is - for the
+    reason Invoke-OmadaExecutePipeline gives at greater length and that issue #90 names as the
+    dominant risk of this whole slice: between completions, Set-ActiveTabContext can repoint
+    $Script:MainForm.Elements, $Script:RunTimeData and $Script:AppConfig onto a different tab. Two
+    completions is a smaller version of that defect, not a different one. One background job means
+    ONE completion, so the tab-context risk is removed rather than managed.
+
+    Runspace-safe, on the same terms as Invoke-OmadaExecutePipeline: no $Script: reads, no logging,
+    no WPF, and no calls into this module beyond New-OmadaPagingRequest and Invoke-OmadaRequestCore,
+    which are equally pure. What it cannot do - write the log, touch a dropdown - it does not
+    attempt; it returns a description of what happened and the UI thread applies it.
+
+    .PARAMETER Context
+    Plain values gathered on the UI thread:
+      BaseUrl              the tenant base URL
+      Parameters           the prepared Invoke-OmadaRestMethod splat (Uri, Method and Body are
+                           overwritten per step; everything else - SessionKey, authentication,
+                           redaction - carries)
+      IncludeDataObjectHtml  $true to also fetch the dataobjdlg.aspx page for the first row, which is
+                           where the data connection options live. This is Update-DataConnectionList's
+                           third round-trip, and it is a step of THIS job rather than a second
+                           background request chained off this one's completion - for the reason
+                           above. Update-QueryList needs only the first two steps and omits it.
+      SqlQueryDoIdField    the row property holding the data object id, from
+                           $Script:RunTimeData.DataobjdlgAspxAttributeMapping. Passed in because that
+                           mapping is UI-thread state. Required when IncludeDataObjectHtml is set.
+
+    .OUTPUTS
+    Hashtable:
+      Rows           the view's data object rows, or $null when the view was not found
+      ViewId         the id of the "SQL Troubleshooting" view, or $null
+      ViewFound      $false when the tenant answered but holds no such view - which is a legitimate
+                     answer, not a failure, and must not be reported as one
+      DataObjectHtml the dataobjdlg.aspx response, when IncludeDataObjectHtml was set and there was
+                     a row to fetch it for; otherwise $null
+      ErrorRecord    the first failure, or $null
+      FailedStep     which step failed, or $null
+      CompletedSteps how many requests came back without an error
+      Steps          an ordered trace of @{ Name; Method; Uri }
+      Log            an ordered list of log entries for the UI thread to replay
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [hashtable]$Context
+    )
+
+    $Outcome = @{
+        Rows           = $null
+        ViewId         = $null
+        ViewFound      = $false
+        DataObjectHtml = $null
+        ErrorRecord    = $null
+        FailedStep     = $null
+        Steps          = [System.Collections.Generic.List[object]]::new()
+        CompletedSteps = 0
+        Log            = [System.Collections.Generic.List[object]]::new()
+    }
+
+    # The same two log shapes the execute pipeline uses, for the same reason: redaction
+    # (ConvertTo-RedactedLogString) is a UI-thread function and must stay one, so the worker records
+    # WHAT to log and the UI thread decides how much of it may be written down.
+    $Log = {
+        param($Level, $Text)
+        $Outcome.Log.Add(@{ Level = $Level; Text = $Text })
+    }
+
+    $LogObject = {
+        param($Level, $Format, $Object, $ShapeOnly)
+        $Outcome.Log.Add(@{ Level = $Level; Format = $Format; Redact = $Object; ShapeOnly = [bool]$ShapeOnly })
+    }
+
+    # One local helper rather than a call out to another file: this runs in a worker runspace, and
+    # every extra name it depends on is another thing that has to be dot-sourced there.
+    $Invoke = {
+        param($StepName, $Request)
+        $Parameters = $Context.Parameters.Clone()
+        $Parameters.Uri = $Request.Uri
+        $Parameters.Method = $Request.Method
+        if ($null -eq $Request.Body) {
+            if ($Parameters.ContainsKey("Body")) { $Parameters.Remove("Body") }
+        }
+        else {
+            $Parameters.Body = $Request.Body
+        }
+
+        $Outcome.Steps.Add(@{ Name = $StepName; Method = $Request.Method; Uri = $Request.Uri })
+
+        & $Log "DEBUG" ("QueryUrl: {0}" -f $Request.Uri)
+        if ($null -ne $Request.Body) {
+            & $LogObject "VERBOSE" "Body: {0}" $Request.Body $true
+        }
+        & $LogObject "VERBOSE" "Parameters: {0}" $Parameters $false
+
+        $StepOutcome = Invoke-OmadaRequestCore -Parameters $Parameters
+
+        if ($null -eq $StepOutcome.ErrorRecord) {
+            $Outcome.CompletedSteps = $Outcome.CompletedSteps + 1
+            & $LogObject "VERBOSE" "Result: {0}" $StepOutcome.Result $false
+        }
+        else {
+            # DEBUG, not ERROR: the pipeline reports its failure through the outcome, and the caller
+            # decides how loudly to say so. An ERROR written from here would be written twice.
+            & $Log "DEBUG" ("Step '{0}' failed: {1}" -f $StepName, $StepOutcome.ErrorRecord.Exception.Message)
+        }
+        return $StepOutcome
+    }
+
+    try {
+        # --- 1. Find the "SQL Troubleshooting" view ------------------------------------------------
+        & $Log "DEBUG" "Retrieve data connections"
+
+        $Private:ViewLookup = & $Invoke "FindView" (New-OmadaPagingRequest -DataType "Views" -DataTypeArgs @{ OwnerShipType = "Both" } -SearchString "SQL Troubleshooting" -BaseUrl $Context.BaseUrl)
+        if ($null -ne $Private:ViewLookup.ErrorRecord) {
+            $Outcome.ErrorRecord = $Private:ViewLookup.ErrorRecord
+            $Outcome.FailedStep = "FindView"
+            return $Outcome
+        }
+
+        # Records greater than zero before reading Rows, exactly as Get-SqlTroubleShooterView has
+        # always checked. The search is a contains-match on the name, so the result may hold other
+        # views; the exact-name filter is what picks this one out.
+        $Private:View = $null
+        if ($null -ne $Private:ViewLookup.Result -and $Private:ViewLookup.Result.d.Records -gt 0) {
+            $Private:View = $Private:ViewLookup.Result.d.Rows | Where-Object { $_.Name -eq "SQL Troubleshooting" } | Select-Object -First 1
+        }
+
+        if ($null -eq $Private:View) {
+            # A tenant without the view is not a failed request. Reporting it through ErrorRecord
+            # would send the caller down the retry-on-the-UI-thread path, which would ask the same
+            # question again and get the same answer.
+            & $Log "DEBUG" "The 'SQL Troubleshooting' view was not found."
+            return $Outcome
+        }
+
+        $Outcome.ViewFound = $true
+        $Outcome.ViewId = $Private:View.Id
+
+        # --- 2. Fetch the view's rows ---------------------------------------------------------------
+        $Private:RowRequest = New-OmadaPagingRequest -DataType "DataObjects" -BaseUrl $Context.BaseUrl -DataTypeArgs ([ordered]@{
+                viewId          = ("{0}" -f $Private:View.Id)
+                pageQueryString = ("{0}/dataobjlst.aspx?view={1}" -f $Context.BaseUrl, $Private:View.Id)
+                readOnlyMode    = $false
+                countRows       = $false
+            })
+
+        $Private:Rows = & $Invoke "FetchViewRows" $Private:RowRequest
+        if ($null -ne $Private:Rows.ErrorRecord) {
+            $Outcome.ErrorRecord = $Private:Rows.ErrorRecord
+            $Outcome.FailedStep = "FetchViewRows"
+            return $Outcome
+        }
+
+        $Outcome.Rows = $Private:Rows.Result.d.Rows
+
+        # --- 3. The data connection page, when the caller wants it ---------------------------------
+        if (-not $Context.IncludeDataObjectHtml) {
+            return $Outcome
+        }
+
+        $Private:FirstRow = @($Outcome.Rows) | Select-Object -First 1
+        if ($null -eq $Private:FirstRow) {
+            # No rows means no data object to open, which Update-DataConnectionList already treats as
+            # "cannot change the data connection". Not an error.
+            & $Log "DEBUG" "The SQL Troubleshooting view returned no rows; no data connection page to fetch."
+            return $Outcome
+        }
+
+        $Private:DataObjectId = $Private:FirstRow.$($Context.SqlQueryDoIdField)
+
+        $Private:Html = & $Invoke "FetchDataConnectionPage" (@{
+                Method = "GET"
+                Uri    = "{0}/dataobjdlg.aspx?DOID={1}" -f $Context.BaseUrl, $Private:DataObjectId
+                Body   = $null
+            })
+        if ($null -ne $Private:Html.ErrorRecord) {
+            $Outcome.ErrorRecord = $Private:Html.ErrorRecord
+            $Outcome.FailedStep = "FetchDataConnectionPage"
+            return $Outcome
+        }
+
+        $Outcome.DataObjectHtml = $Private:Html.Result
+        return $Outcome
+    }
+    catch {
+        # A throw from here would surface as a worker that died rather than as an answer, and the
+        # caller cannot classify that. Report it the same way a failed step is reported.
+        $Outcome.ErrorRecord = $_
+        if ($null -eq $Outcome.FailedStep) {
+            $Outcome.FailedStep = "ViewLookup"
+        }
+        return $Outcome
+    }
+}

--- a/src/Lib/Functions/Private/Invoke-OmadaViewLookupPipeline.ps1
+++ b/src/Lib/Functions/Private/Invoke-OmadaViewLookupPipeline.ps1
@@ -163,7 +163,11 @@ function Invoke-OmadaViewLookupPipeline {
             return $Outcome
         }
 
-        $Outcome.Rows = $Private:Rows.Result.d.Rows
+        # Normalised to an array, and never left as $null. A jqGrid payload for a view with nothing in
+        # it has a null .d.Rows, and @($null).Count is 1 - so "did I get rows?" answered yes for an
+        # empty view, and the caller reported it as a failed fetch and disabled the dropdown. Callers
+        # should not have to know that; the outcome carries an array or an empty array.
+        $Outcome.Rows = @($Private:Rows.Result.d.Rows | Where-Object { $null -ne $_ })
 
         # --- 3. The data connection page, when the caller wants it ---------------------------------
         if (-not $Context.IncludeDataObjectHtml) {

--- a/src/Lib/Functions/Private/New-OmadaPagingRequest.ps1
+++ b/src/Lib/Functions/Private/New-OmadaPagingRequest.ps1
@@ -1,0 +1,75 @@
+function New-OmadaPagingRequest {
+    <#
+    .SYNOPSIS
+    Build the method, URI and body for one jqGrid GetPagingData request, from plain values.
+
+    .DESCRIPTION
+    Issue #90, slice A. The same idea as New-OmadaQueryRequest, for the other endpoint this
+    application talks to: a pure function of a context hashtable - no $Script: reads, no logging, no
+    network - so that the UI-thread caller (Get-OmadaGetPagingDataObject) and the background worker
+    (Invoke-OmadaViewLookupPipeline) build byte-identical requests instead of two copies drifting
+    apart.
+
+    That mattered immediately. The body below carries `nd = 1732546553116`, a cache-busting
+    timestamp that jqGrid normally regenerates per request and which this application has always
+    sent as a constant. Copying it into a second definition is exactly how a value like that
+    silently becomes two different constants.
+
+    .PARAMETER DataType
+    The jqGrid data type - "Views" or "DataObjects" for the lookups this application makes.
+
+    .PARAMETER DataTypeArgs
+    The type-specific arguments, passed through unchanged.
+
+    .PARAMETER SearchString
+    Optional. When supplied, the request searches the "name" column for it; when not, no sort index
+    and no search string are sent. Preserved exactly as Get-OmadaGetPagingDataObject has always
+    built it, because sidx and searchString move together.
+
+    .PARAMETER Rows
+    Page size. Defaults to the 1000 this application has always requested.
+
+    .PARAMETER BaseUrl
+    The tenant base URL. Passed in rather than read from $Script:AppConfig, which does not exist in a
+    worker runspace.
+
+    .OUTPUTS
+    Hashtable @{ Method; Uri; Body }.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$DataType,
+
+        [Parameter(Mandatory = $true)]
+        [hashtable]$DataTypeArgs,
+
+        [string]$SearchString = $null,
+
+        [int]$Rows = 1000,
+
+        [Parameter(Mandatory = $true)]
+        [string]$BaseUrl
+    )
+
+    $Private:HasSearch = -not [string]::IsNullOrWhiteSpace($SearchString)
+
+    return @{
+        Method = "POST"
+        Uri    = "{0}/WebService/JQGridPopulationWebService.asmx/GetPagingData" -f $BaseUrl
+        Body   = [ordered]@{
+            _search      = $false
+            nd           = 1732546553116
+            rows         = $Rows
+            page         = 1
+            sidx         = $(if ($Private:HasSearch) { "name" } else { $null })
+            sord         = "asc"
+            searchField  = $null
+            searchString = $(if ($Private:HasSearch) { $SearchString } else { $null })
+            searchOper   = $null
+            filters      = $null
+            dataType     = $DataType
+            dataTypeArgs = $DataTypeArgs
+        }
+    }
+}

--- a/src/Lib/Functions/Private/Resolve-ExecuteFallbackAction.ps1
+++ b/src/Lib/Functions/Private/Resolve-ExecuteFallbackAction.ps1
@@ -31,7 +31,11 @@ function Resolve-ExecuteFallbackAction {
     a one-way door for the session, so it is taken only on evidence, not on the absence of it.
 
     .PARAMETER Outcome
-    The pipeline outcome from Invoke-OmadaExecutePipeline, or $null when the worker returned nothing.
+    A pipeline outcome - anything carrying ErrorRecord and CompletedSteps - or $null when the worker
+    returned nothing. Named for the execute path it was written for, but the question it answers is
+    "what does this worker failure mean?", which is not execute-specific: issue #90's view lookup
+    asks it too, and asks rather than deciding for itself precisely so the 502 misclassification
+    described above cannot be reinvented one pipeline at a time.
 
     .OUTPUTS
     [string] one of "Report", "Retry", "RetryAndDisable".

--- a/src/Lib/Functions/Private/Start-OmadaBackgroundRequest.ps1
+++ b/src/Lib/Functions/Private/Start-OmadaBackgroundRequest.ps1
@@ -58,9 +58,17 @@ function Start-OmadaBackgroundRequest {
 
         $Context,
 
-        # When supplied, the worker runs the whole dependent execute chain (Invoke-OmadaExecutePipeline)
-        # instead of a single request, and returns its outcome as the Result. This is what makes C1-5
-        # possible with ONE completion rather than five - see the pipeline's own notes.
+        # When supplied, the worker runs a whole dependent chain instead of a single request, and
+        # returns its outcome as the Result. This is what makes C1-5 possible with ONE completion
+        # rather than five - see the pipeline's own notes.
+        #
+        # WHICH chain is data on the context, so that a second one can be added without this function
+        # growing a branch per caller (issue #90, slice A):
+        #   PipelineFunction  the runspace-safe entry point to call, defaulting to
+        #                     Invoke-OmadaExecutePipeline
+        #   PipelineFiles     the files the worker must dot-source for it, defaulting to the execute
+        #                     pipeline's
+        # Both default to the execute path, so #40's dispatch is unchanged by their absence.
         [hashtable]$PipelineContext,
 
         [string]$Description = "Omada request"
@@ -81,7 +89,10 @@ function Start-OmadaBackgroundRequest {
         $Private:PrivateFolder = Join-Path $Script:RunTimeConfig.ModuleFolder -ChildPath "Lib\Functions\Private"
         $Private:RequiredWorkerFiles = @("Invoke-OmadaRequestCore.ps1")
         if ($null -ne $PipelineContext) {
-            $Private:RequiredWorkerFiles += @("New-OmadaQueryRequest.ps1", "Invoke-OmadaExecutePipeline.ps1")
+            # The chain's OWN files, not the execute pipeline's. Checking a fixed pair here would
+            # have left a second chain's files unchecked - dispatching a worker that then fails on
+            # its first line, which is exactly what this guard exists to prevent.
+            $Private:RequiredWorkerFiles += Get-OmadaPipelineWorkerFile -PipelineContext $PipelineContext
         }
         foreach ($Private:WorkerFile in $Private:RequiredWorkerFiles) {
             if (-not (Test-Path -LiteralPath (Join-Path $Private:PrivateFolder -ChildPath $Private:WorkerFile))) {
@@ -114,6 +125,13 @@ function Start-OmadaBackgroundRequest {
         # the pipeline, and only for the temporary object's id: cancellation kills the worker outright
         # so its own clean-up never runs, and the UI has to know which object to remove.
         $Private:Progress = [hashtable]::Synchronized(@{})
+
+        # Resolved HERE, on the UI thread, rather than inside the worker block: the defaults are the
+        # execute pipeline's, so a caller that says nothing gets exactly the dispatch it got before
+        # this became configurable, and the worker block itself needs no knowledge of which chains
+        # exist.
+        $Private:PipelineFunction = Get-OmadaPipelineWorkerFunction -PipelineContext $PipelineContext
+        $Private:PipelineFiles = Get-OmadaPipelineWorkerFile -PipelineContext $PipelineContext
         if ($null -ne $PipelineContext) {
             $PipelineContext = $PipelineContext.Clone()
             $PipelineContext.Parameters = $Parameters.Clone()
@@ -127,11 +145,12 @@ function Start-OmadaBackgroundRequest {
         # copy of every function, and those files are already the things the unit tests execute.
         # $TransportScriptPath is the mock seam - see Install-OmadaMockTransport.
         [void]$Private:Shell.AddScript({
-                param($PrivateFolder, $RequestParameters, $PipelineContext, $TransportScriptPath, $TransportContext)
+                param($PrivateFolder, $RequestParameters, $PipelineContext, $TransportScriptPath, $TransportContext, $PipelineFunction, $PipelineFiles)
                 . (Join-Path $PrivateFolder "Invoke-OmadaRequestCore.ps1")
                 if ($null -ne $PipelineContext) {
-                    . (Join-Path $PrivateFolder "New-OmadaQueryRequest.ps1")
-                    . (Join-Path $PrivateFolder "Invoke-OmadaExecutePipeline.ps1")
+                    foreach ($PipelineFile in $PipelineFiles) {
+                        . (Join-Path $PrivateFolder $PipelineFile)
+                    }
                 }
                 if (![string]::IsNullOrWhiteSpace($TransportScriptPath) -and (Test-Path -LiteralPath $TransportScriptPath)) {
                     . $TransportScriptPath
@@ -141,7 +160,7 @@ function Start-OmadaBackgroundRequest {
                     }
                 }
                 if ($null -ne $PipelineContext) {
-                    $PipelineOutcome = Invoke-OmadaExecutePipeline -Context $PipelineContext
+                    $PipelineOutcome = & $PipelineFunction -Context $PipelineContext
                     # Reported in the transport's own shape so the UI-side plumbing needs no special
                     # case: the whole outcome is the Result, and the pipeline's first failure is also
                     # surfaced as the ErrorRecord so Resolve-OmadaRequestFailure still classifies an
@@ -149,7 +168,7 @@ function Start-OmadaBackgroundRequest {
                     return @{ Result = $PipelineOutcome; ErrorRecord = $PipelineOutcome.ErrorRecord }
                 }
                 return (Invoke-OmadaRequestCore -Parameters $RequestParameters)
-            }).AddArgument($Private:PrivateFolder).AddArgument($Parameters.Clone()).AddArgument($PipelineContext).AddArgument($Script:OmadaRequestWorkerTransportPath).AddArgument($Script:OmadaRequestWorkerTransportContext)
+            }).AddArgument($Private:PrivateFolder).AddArgument($Parameters.Clone()).AddArgument($PipelineContext).AddArgument($Script:OmadaRequestWorkerTransportPath).AddArgument($Script:OmadaRequestWorkerTransportContext).AddArgument($Private:PipelineFunction).AddArgument($Private:PipelineFiles)
 
         $Private:AsyncResult = $Private:Shell.BeginInvoke()
 

--- a/src/Lib/Functions/Private/Start-OmadaBackgroundRequest.ps1
+++ b/src/Lib/Functions/Private/Start-OmadaBackgroundRequest.ps1
@@ -94,12 +94,15 @@ function Start-OmadaBackgroundRequest {
             # its first line, which is exactly what this guard exists to prevent.
             $Private:RequiredWorkerFiles += Get-OmadaPipelineWorkerFile -PipelineContext $PipelineContext
 
-            # And the entry point has to be IN those files. Checking only that the files exist left a
-            # typo in the function name to be discovered inside the worker, which is the one outcome
-            # this whole path is designed not to have: an unavailable chain must mean "run it inline
-            # instead", not "dispatch a job that dies".
-            if (-not (Test-OmadaPipelineWorkerChain -PipelineFunction (Get-OmadaPipelineWorkerFunction -PipelineContext $PipelineContext) -PipelineFiles $Private:RequiredWorkerFiles)) {
-                "Background worker chain '{0}' is not defined by any of its files; running on the UI thread instead." -f (Get-OmadaPipelineWorkerFunction -PipelineContext $PipelineContext) | Write-LogOutput -LogType WARNING -SkipDialog
+            # And the file that would DEFINE the entry point has to be among them. Checking only that
+            # the listed files exist left a typo in the function name to be discovered inside the
+            # worker, which is the one outcome this whole path is designed not to have: an
+            # unavailable chain must mean "run it inline instead", not "dispatch a job that dies".
+            $Private:ChainFunction = Get-OmadaPipelineWorkerFunction -PipelineContext $PipelineContext
+            if (-not (Test-OmadaPipelineWorkerChain -PipelineFunction $Private:ChainFunction -PipelineFiles $Private:RequiredWorkerFiles)) {
+                # Says what was actually checked - a file name, not the file's contents - so the
+                # reason is actionable when this fires.
+                "Background worker chain '{0}' has no matching '{0}.ps1' among the files it lists; running on the UI thread instead." -f $Private:ChainFunction | Write-LogOutput -LogType WARNING -SkipDialog
                 return $null
             }
         }

--- a/src/Lib/Functions/Private/Start-OmadaBackgroundRequest.ps1
+++ b/src/Lib/Functions/Private/Start-OmadaBackgroundRequest.ps1
@@ -93,6 +93,15 @@ function Start-OmadaBackgroundRequest {
             # have left a second chain's files unchecked - dispatching a worker that then fails on
             # its first line, which is exactly what this guard exists to prevent.
             $Private:RequiredWorkerFiles += Get-OmadaPipelineWorkerFile -PipelineContext $PipelineContext
+
+            # And the entry point has to be IN those files. Checking only that the files exist left a
+            # typo in the function name to be discovered inside the worker, which is the one outcome
+            # this whole path is designed not to have: an unavailable chain must mean "run it inline
+            # instead", not "dispatch a job that dies".
+            if (-not (Test-OmadaPipelineWorkerChain -PipelineFunction (Get-OmadaPipelineWorkerFunction -PipelineContext $PipelineContext) -PipelineFiles $Private:RequiredWorkerFiles)) {
+                "Background worker chain '{0}' is not defined by any of its files; running on the UI thread instead." -f (Get-OmadaPipelineWorkerFunction -PipelineContext $PipelineContext) | Write-LogOutput -LogType WARNING -SkipDialog
+                return $null
+            }
         }
         foreach ($Private:WorkerFile in $Private:RequiredWorkerFiles) {
             if (-not (Test-Path -LiteralPath (Join-Path $Private:PrivateFolder -ChildPath $Private:WorkerFile))) {

--- a/src/Lib/Functions/Private/Update-DataConnectionList.ps1
+++ b/src/Lib/Functions/Private/Update-DataConnectionList.ps1
@@ -45,7 +45,11 @@ function Update-DataConnectionList {
                 return
             }
 
-            Complete-DataConnectionListUpdate -DataObjectHtml $Result.DataObjectHtml -HasRows:(@($Result.Rows).Count -gt 0) -NotShowPopupWindow:$CallerContext.NotShowPopupWindow
+            # Filtered, not just wrapped: @($null).Count is 1, so a plain @($Result.Rows).Count -gt 0
+            # answers "yes, there are rows" for no rows at all - and the renderer then reports a
+            # failed fetch and disables the dropdown. The pipeline normalises its own Rows, but the
+            # completion's other paths pass $null deliberately, so this has to be honest about that.
+            Complete-DataConnectionListUpdate -DataObjectHtml $Result.DataObjectHtml -HasRows:(@($Result.Rows | Where-Object { $null -ne $_ }).Count -gt 0) -NotShowPopupWindow:$CallerContext.NotShowPopupWindow
         }
 
         if ($null -ne $Private:Pending) {

--- a/src/Lib/Functions/Private/Update-DataConnectionList.ps1
+++ b/src/Lib/Functions/Private/Update-DataConnectionList.ps1
@@ -90,7 +90,10 @@ function Get-DataConnectionPageInline {
     # and its answer reported as "Failed to retrieve data connections!" - which disables the dropdown
     # and the schema button. A wasted round-trip producing the wrong outcome, where the right one is
     # to leave the list alone, as the original code did for this case.
-    $Private:SqlQueryViewContents = @(Get-SqlTroubleShooterView)
+    # Filtered as well as wrapped. Get-SqlTroubleShooterView normalises its own result now, but this
+    # is the third place in this change where @($null).Count -eq 1 turned no rows into one - so the
+    # count is taken over something that cannot contain a null rather than trusting the shape.
+    $Private:SqlQueryViewContents = @(Get-SqlTroubleShooterView | Where-Object { $null -ne $_ })
     if ($Private:SqlQueryViewContents.Count -eq 0) {
         return @{ HasRows = $false; Html = $null }
     }

--- a/src/Lib/Functions/Private/Update-DataConnectionList.ps1
+++ b/src/Lib/Functions/Private/Update-DataConnectionList.ps1
@@ -1,6 +1,23 @@
 function Update-DataConnectionList {
+    <#
+    .SYNOPSIS
+    Refresh the data connection dropdown for the active tab.
+
+    .DESCRIPTION
+    Issue #90, slice A. This was the worst of the blocking list refreshes: THREE dependent round-trips
+    on the UI thread - the view lookup's two, then the dataobjdlg.aspx page that actually holds the
+    options - and it runs on connect and on tab materialisation, which is where the window visibly
+    froze.
+
+    All three now go to a worker as ONE job (Invoke-OmadaViewLookupPipeline), so there is one
+    completion rather than three. That number is the point: between completions Set-ActiveTabContext
+    can repoint $Script:MainForm.Elements onto a different tab, and issue #90 names that as the
+    dominant risk of this whole slice.
+
+    When a worker may not be used - a disconnected tab, a forced re-authentication, background
+    requests switched off - the original synchronous path below runs unchanged.
+    #>
     [CmdLetBinding()]
-    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'SetInitialConnection', Justification = 'The variable is used, but script analyzer does not recognize it')]
     param(
         [switch]$NotShowPopupWindow
     )
@@ -13,73 +30,167 @@ function Update-DataConnectionList {
         }
 
         "Retrieve data connections" | Write-LogOutput -LogType DEBUG
-        $SqlQueryViewContents = Get-SqlTroubleShooterView
-        if ($null -ne $SqlQueryViewContents) {
-            $Script:RunTimeData.RestMethodParam.Uri = "{0}/dataobjdlg.aspx?DOID={1}" -f $Script:AppConfig.BaseUrl, $SqlQueryViewContents[0].$($Script:RunTimeData.DataobjdlgAspxAttributeMapping.SqlQueryDoId)
-            $Script:RunTimeData.RestMethodParam.Body = $null
-            $Script:RunTimeData.RestMethodParam.Method = "GET"
-            $Private:Result = Invoke-OmadaPSWebRequestWrapper
 
-            if ($null -eq $Private:Result) {
-                "Failed to retrieve data connections! Data connection cannot be changed!" | Write-LogOutput -LogType WARNING
-                $Script:MainForm.Elements.ComboBoxSelectDataConnection.IsEnabled = $false
-                $Script:MainForm.Elements.ButtonShowSqlSchema.IsEnabled = $false
+        # The completion block is plain (never .GetNewClosure()) and reads everything it needs from
+        # its arguments: by the time it runs, the user may be looking at another tab, and
+        # -NotShowPopupWindow must be the value THIS call was made with.
+        $Private:Pending = Start-SqlTroubleShooterViewLookup -IncludeDataObjectHtml -Context @{
+            NotShowPopupWindow = [bool]$NotShowPopupWindow
+        } -OnResultScriptBlock {
+            param($Result, $CallerContext)
+
+            if ($Result.RetryInline) {
+                $Private:Inline = Get-DataConnectionPageInline
+                Complete-DataConnectionListUpdate -DataObjectHtml $Private:Inline.Html -HasRows:$Private:Inline.HasRows -NotShowPopupWindow:$CallerContext.NotShowPopupWindow
+                return
             }
-            else {
-                if (!$NotShowPopupWindow) {
-                    $UpdateDataConnectionsWindow = Show-PopupWindow -Message "Updating Data Connections..."
-                }
 
-                $SelectedDataConnection = $Script:MainForm.Elements.ComboBoxSelectDataConnection.SelectedItem.Content
-                "Stored current selected data connection (if not empty): {0}" -f $SelectedDataConnection | Write-LogOutput -LogType DEBUG
-                $Script:MainForm.Elements.ComboBoxSelectDataConnection.Items.Clear()
-
-                if ($null -ne $Private:Result) {
-
-                    $SetInitialConnection = $true
-                    foreach ($DataConnectionDisplayName in (Get-DataConnectionOptionList -Html $Private:Result)) {
-                        if ($DataConnectionDisplayName -notin $Script:MainForm.Elements.ComboBoxSelectDataConnection.Items.Content) {
-                            "Add data connection {0}" -f $DataConnectionDisplayName | Write-LogOutput -LogType DEBUG
-                            $ComboBoxDataConnectionItem = New-Object System.Windows.Controls.ComboBoxItem
-                            $ComboBoxDataConnectionItem.Content = $DataConnectionDisplayName
-                            $Script:MainForm.Elements.ComboBoxSelectDataConnection.Items.Add($ComboBoxDataConnectionItem) | Out-Null
-                            if ($null -ne $SelectedDataConnection -and $SelectedDataConnection -eq $DataConnectionDisplayName) {
-                                "Set connection {0} as selected data connection" -f $DataConnectionDisplayName | Write-LogOutput -LogType DEBUG
-                                $Script:MainForm.Elements.ComboBoxSelectDataConnection.SelectedItem = $ComboBoxDataConnectionItem
-                                $SetInitialConnection = $false
-                            }
-                        }
-                    }
-
-
-                    if ($SetInitialConnection) {
-                        "Set initial data connection to OISES" | Write-LogOutput -LogType DEBUG
-                        $Script:MainForm.Elements.ComboBoxSelectDataConnection.SelectedItem = $Script:MainForm.Elements.ComboBoxSelectDataConnection.Items | Where-Object { $_.Content -like "OISES -*" }
-                    }
-
-                    $ComboBoxDataConnectionSelectedItem = $Script:MainForm.Elements.ComboBoxSelectDataConnection.SelectedItem
-                    $ComboBoxDataConnectionItems = $Script:MainForm.Elements.ComboBoxSelectDataConnection.Items | Sort-Object
-                    $Script:MainForm.Elements.ComboBoxSelectDataConnection.Items?.Clear()
-                    foreach ($Item in $ComboBoxDataConnectionItems) {
-                        $Script:MainForm.Elements.ComboBoxSelectDataConnection.Items.Add($Item) | Out-Null
-                    }
-                    if ($null -ne $ComboBoxDataConnectionSelectedItem) {
-                        $Script:MainForm.Elements.ComboBoxSelectDataConnection.SelectedItem = $Script:MainForm.Elements.ComboBoxSelectDataConnection.Items | Where-Object { $_.Content -eq $ComboBoxDataConnectionSelectedItem.Content }
-                    }
-
-                    $Script:MainForm.Elements.TextBoxDisplayName.IsEnabled = $true
-                    $Script:MainForm.Elements.ComboBoxSelectDataConnection.IsEnabled = $true
-                    $Script:MainForm.Elements.ButtonShowSqlSchema.IsEnabled = $true
-                }
-                "{0} data connections processed!" -f ($Script:MainForm.Elements.ComboBoxSelectDataConnection.Items | Measure-Object).Count | Write-LogOutput
-
-                if ($null -ne $UpdateDataConnectionsWindow) {
-                    $UpdateDataConnectionsWindow.Close()
-                }
-            }
+            Complete-DataConnectionListUpdate -DataObjectHtml $Result.DataObjectHtml -HasRows:(@($Result.Rows).Count -gt 0) -NotShowPopupWindow:$CallerContext.NotShowPopupWindow
         }
+
+        if ($null -ne $Private:Pending) {
+            # Dispatched. Everything after the responses now happens in the completion block.
+            return
+        }
+
+        # Not eligible for a worker, or none available: exactly the pre-#90 behaviour.
+        $Private:Inline = Get-DataConnectionPageInline
+        Complete-DataConnectionListUpdate -DataObjectHtml $Private:Inline.Html -HasRows:$Private:Inline.HasRows -NotShowPopupWindow:$NotShowPopupWindow
     }
     catch {
         $_.Exception.Message | Write-LogOutput -LogType ERROR -ErrorObject $_
+    }
+}
+
+function Get-DataConnectionPageInline {
+    <#
+    .SYNOPSIS
+    Fetch the dataobjdlg.aspx page that holds the data connection options, on the UI thread.
+
+    .DESCRIPTION
+    The blocking path, preserved verbatim from before issue #90: look the view up, take the first
+    row's data object id, and GET its page. One definition, used both when no worker was available
+    and when a worker could not do the job.
+
+    .OUTPUTS
+    Hashtable @{ HasRows; Html }. HasRows is $false when the view holds nothing, which the original
+    code treated differently from a failed page fetch - see Complete-DataConnectionListUpdate.
+    #>
+    [CmdLetBinding()]
+    param()
+
+    $Private:SqlQueryViewContents = Get-SqlTroubleShooterView
+    if ($null -eq $Private:SqlQueryViewContents) {
+        return @{ HasRows = $false; Html = $null }
+    }
+
+    $Script:RunTimeData.RestMethodParam.Uri = "{0}/dataobjdlg.aspx?DOID={1}" -f $Script:AppConfig.BaseUrl, $Private:SqlQueryViewContents[0].$($Script:RunTimeData.DataobjdlgAspxAttributeMapping.SqlQueryDoId)
+    $Script:RunTimeData.RestMethodParam.Body = $null
+    $Script:RunTimeData.RestMethodParam.Method = "GET"
+    return @{ HasRows = $true; Html = (Invoke-OmadaPSWebRequestWrapper) }
+}
+
+function Complete-DataConnectionListUpdate {
+    <#
+    .SYNOPSIS
+    Everything that happens once the data connection page is in hand: rebuild the dropdown, restore
+    the selection, and enable the controls that depend on it.
+
+    .DESCRIPTION
+    Split out of Update-DataConnectionList by issue #90 so the same work runs whether the page
+    arrived synchronously or from a background worker. It touches WPF elements, so it is UI thread
+    only - which it always is: the background path reaches it from the completion poll timer, with
+    the owning tab already made active by Set-ActiveTabContext.
+
+    .PARAMETER DataObjectHtml
+    The dataobjdlg.aspx response, or $null when it could not be retrieved.
+
+    .PARAMETER HasRows
+    Whether the "SQL Troubleshooting" view held any rows. This is deliberately separate from a null
+    page: the original code only entered its whole body when the view returned rows, so a tenant
+    without them left the dropdown untouched and said nothing, whereas a FAILED page fetch warned and
+    disabled the controls. Two different outcomes that both arrive here as a null page, so the
+    distinction has to travel alongside it rather than be inferred.
+
+    .PARAMETER NotShowPopupWindow
+    Suppress the "Updating Data Connections..." popup, as the auto-connect paths always have.
+    #>
+    [CmdLetBinding()]
+    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'SetInitialConnection', Justification = 'The variable is used, but script analyzer does not recognize it')]
+    param(
+        $DataObjectHtml,
+
+        [switch]$HasRows,
+
+        [switch]$NotShowPopupWindow
+    )
+
+    try {
+        $Private:Result = $DataObjectHtml
+
+        if (-not $HasRows) {
+            "The SQL Troubleshooting view returned no rows; leaving the data connection list as it is." | Write-LogOutput -LogType DEBUG
+            return
+        }
+
+        if ($null -eq $Private:Result) {
+            "Failed to retrieve data connections! Data connection cannot be changed!" | Write-LogOutput -LogType WARNING
+            $Script:MainForm.Elements.ComboBoxSelectDataConnection.IsEnabled = $false
+            $Script:MainForm.Elements.ButtonShowSqlSchema.IsEnabled = $false
+            return
+        }
+
+        if (!$NotShowPopupWindow) {
+            $UpdateDataConnectionsWindow = Show-PopupWindow -Message "Updating Data Connections..."
+        }
+
+        $SelectedDataConnection = $Script:MainForm.Elements.ComboBoxSelectDataConnection.SelectedItem.Content
+        "Stored current selected data connection (if not empty): {0}" -f $SelectedDataConnection | Write-LogOutput -LogType DEBUG
+        $Script:MainForm.Elements.ComboBoxSelectDataConnection.Items.Clear()
+
+        $SetInitialConnection = $true
+        foreach ($DataConnectionDisplayName in (Get-DataConnectionOptionList -Html $Private:Result)) {
+            if ($DataConnectionDisplayName -notin $Script:MainForm.Elements.ComboBoxSelectDataConnection.Items.Content) {
+                "Add data connection {0}" -f $DataConnectionDisplayName | Write-LogOutput -LogType DEBUG
+                $ComboBoxDataConnectionItem = New-Object System.Windows.Controls.ComboBoxItem
+                $ComboBoxDataConnectionItem.Content = $DataConnectionDisplayName
+                $Script:MainForm.Elements.ComboBoxSelectDataConnection.Items.Add($ComboBoxDataConnectionItem) | Out-Null
+                if ($null -ne $SelectedDataConnection -and $SelectedDataConnection -eq $DataConnectionDisplayName) {
+                    "Set connection {0} as selected data connection" -f $DataConnectionDisplayName | Write-LogOutput -LogType DEBUG
+                    $Script:MainForm.Elements.ComboBoxSelectDataConnection.SelectedItem = $ComboBoxDataConnectionItem
+                    $SetInitialConnection = $false
+                }
+            }
+        }
+
+        if ($SetInitialConnection) {
+            "Set initial data connection to OISES" | Write-LogOutput -LogType DEBUG
+            $Script:MainForm.Elements.ComboBoxSelectDataConnection.SelectedItem = $Script:MainForm.Elements.ComboBoxSelectDataConnection.Items | Where-Object { $_.Content -like "OISES -*" }
+        }
+
+        $ComboBoxDataConnectionSelectedItem = $Script:MainForm.Elements.ComboBoxSelectDataConnection.SelectedItem
+        $ComboBoxDataConnectionItems = $Script:MainForm.Elements.ComboBoxSelectDataConnection.Items | Sort-Object
+        $Script:MainForm.Elements.ComboBoxSelectDataConnection.Items?.Clear()
+        foreach ($Item in $ComboBoxDataConnectionItems) {
+            $Script:MainForm.Elements.ComboBoxSelectDataConnection.Items.Add($Item) | Out-Null
+        }
+        if ($null -ne $ComboBoxDataConnectionSelectedItem) {
+            $Script:MainForm.Elements.ComboBoxSelectDataConnection.SelectedItem = $Script:MainForm.Elements.ComboBoxSelectDataConnection.Items | Where-Object { $_.Content -eq $ComboBoxDataConnectionSelectedItem.Content }
+        }
+
+        $Script:MainForm.Elements.TextBoxDisplayName.IsEnabled = $true
+        $Script:MainForm.Elements.ComboBoxSelectDataConnection.IsEnabled = $true
+        $Script:MainForm.Elements.ButtonShowSqlSchema.IsEnabled = $true
+
+        "{0} data connections processed!" -f ($Script:MainForm.Elements.ComboBoxSelectDataConnection.Items | Measure-Object).Count | Write-LogOutput
+
+        if ($null -ne $UpdateDataConnectionsWindow) {
+            $UpdateDataConnectionsWindow.Close()
+        }
+    }
+    catch {
+        # Contained: this is reached from the completion poll timer, where a terminating log would
+        # unwind into the timer's own Tick handler rather than into anything that can act on it.
+        $_.Exception.Message | Write-ContainedErrorLog -ErrorObject $_
     }
 }

--- a/src/Lib/Functions/Private/Update-DataConnectionList.ps1
+++ b/src/Lib/Functions/Private/Update-DataConnectionList.ps1
@@ -151,48 +151,55 @@ function Complete-DataConnectionListUpdate {
             $UpdateDataConnectionsWindow = Show-PopupWindow -Message "Updating Data Connections..."
         }
 
-        $SelectedDataConnection = $Script:MainForm.Elements.ComboBoxSelectDataConnection.SelectedItem.Content
-        "Stored current selected data connection (if not empty): {0}" -f $SelectedDataConnection | Write-LogOutput -LogType DEBUG
-        $Script:MainForm.Elements.ComboBoxSelectDataConnection.Items.Clear()
+        # try/finally around everything after the popup is shown. The close used to sit on the
+        # success path only, so anything that threw while rebuilding or sorting the items left the
+        # popup on screen for the rest of the session - the catch below would log it and the user
+        # would be looking at a progress window over an application that had stopped working on it.
+        try {
+            $SelectedDataConnection = $Script:MainForm.Elements.ComboBoxSelectDataConnection.SelectedItem.Content
+            "Stored current selected data connection (if not empty): {0}" -f $SelectedDataConnection | Write-LogOutput -LogType DEBUG
+            $Script:MainForm.Elements.ComboBoxSelectDataConnection.Items.Clear()
 
-        $SetInitialConnection = $true
-        foreach ($DataConnectionDisplayName in (Get-DataConnectionOptionList -Html $Private:Result)) {
-            if ($DataConnectionDisplayName -notin $Script:MainForm.Elements.ComboBoxSelectDataConnection.Items.Content) {
-                "Add data connection {0}" -f $DataConnectionDisplayName | Write-LogOutput -LogType DEBUG
-                $ComboBoxDataConnectionItem = New-Object System.Windows.Controls.ComboBoxItem
-                $ComboBoxDataConnectionItem.Content = $DataConnectionDisplayName
-                $Script:MainForm.Elements.ComboBoxSelectDataConnection.Items.Add($ComboBoxDataConnectionItem) | Out-Null
-                if ($null -ne $SelectedDataConnection -and $SelectedDataConnection -eq $DataConnectionDisplayName) {
-                    "Set connection {0} as selected data connection" -f $DataConnectionDisplayName | Write-LogOutput -LogType DEBUG
-                    $Script:MainForm.Elements.ComboBoxSelectDataConnection.SelectedItem = $ComboBoxDataConnectionItem
-                    $SetInitialConnection = $false
+            $SetInitialConnection = $true
+            foreach ($DataConnectionDisplayName in (Get-DataConnectionOptionList -Html $Private:Result)) {
+                if ($DataConnectionDisplayName -notin $Script:MainForm.Elements.ComboBoxSelectDataConnection.Items.Content) {
+                    "Add data connection {0}" -f $DataConnectionDisplayName | Write-LogOutput -LogType DEBUG
+                    $ComboBoxDataConnectionItem = New-Object System.Windows.Controls.ComboBoxItem
+                    $ComboBoxDataConnectionItem.Content = $DataConnectionDisplayName
+                    $Script:MainForm.Elements.ComboBoxSelectDataConnection.Items.Add($ComboBoxDataConnectionItem) | Out-Null
+                    if ($null -ne $SelectedDataConnection -and $SelectedDataConnection -eq $DataConnectionDisplayName) {
+                        "Set connection {0} as selected data connection" -f $DataConnectionDisplayName | Write-LogOutput -LogType DEBUG
+                        $Script:MainForm.Elements.ComboBoxSelectDataConnection.SelectedItem = $ComboBoxDataConnectionItem
+                        $SetInitialConnection = $false
+                    }
                 }
             }
+
+            if ($SetInitialConnection) {
+                "Set initial data connection to OISES" | Write-LogOutput -LogType DEBUG
+                $Script:MainForm.Elements.ComboBoxSelectDataConnection.SelectedItem = $Script:MainForm.Elements.ComboBoxSelectDataConnection.Items | Where-Object { $_.Content -like "OISES -*" }
+            }
+
+            $ComboBoxDataConnectionSelectedItem = $Script:MainForm.Elements.ComboBoxSelectDataConnection.SelectedItem
+            $ComboBoxDataConnectionItems = $Script:MainForm.Elements.ComboBoxSelectDataConnection.Items | Sort-Object
+            $Script:MainForm.Elements.ComboBoxSelectDataConnection.Items?.Clear()
+            foreach ($Item in $ComboBoxDataConnectionItems) {
+                $Script:MainForm.Elements.ComboBoxSelectDataConnection.Items.Add($Item) | Out-Null
+            }
+            if ($null -ne $ComboBoxDataConnectionSelectedItem) {
+                $Script:MainForm.Elements.ComboBoxSelectDataConnection.SelectedItem = $Script:MainForm.Elements.ComboBoxSelectDataConnection.Items | Where-Object { $_.Content -eq $ComboBoxDataConnectionSelectedItem.Content }
+            }
+
+            $Script:MainForm.Elements.TextBoxDisplayName.IsEnabled = $true
+            $Script:MainForm.Elements.ComboBoxSelectDataConnection.IsEnabled = $true
+            $Script:MainForm.Elements.ButtonShowSqlSchema.IsEnabled = $true
+
+            "{0} data connections processed!" -f ($Script:MainForm.Elements.ComboBoxSelectDataConnection.Items | Measure-Object).Count | Write-LogOutput
         }
-
-        if ($SetInitialConnection) {
-            "Set initial data connection to OISES" | Write-LogOutput -LogType DEBUG
-            $Script:MainForm.Elements.ComboBoxSelectDataConnection.SelectedItem = $Script:MainForm.Elements.ComboBoxSelectDataConnection.Items | Where-Object { $_.Content -like "OISES -*" }
-        }
-
-        $ComboBoxDataConnectionSelectedItem = $Script:MainForm.Elements.ComboBoxSelectDataConnection.SelectedItem
-        $ComboBoxDataConnectionItems = $Script:MainForm.Elements.ComboBoxSelectDataConnection.Items | Sort-Object
-        $Script:MainForm.Elements.ComboBoxSelectDataConnection.Items?.Clear()
-        foreach ($Item in $ComboBoxDataConnectionItems) {
-            $Script:MainForm.Elements.ComboBoxSelectDataConnection.Items.Add($Item) | Out-Null
-        }
-        if ($null -ne $ComboBoxDataConnectionSelectedItem) {
-            $Script:MainForm.Elements.ComboBoxSelectDataConnection.SelectedItem = $Script:MainForm.Elements.ComboBoxSelectDataConnection.Items | Where-Object { $_.Content -eq $ComboBoxDataConnectionSelectedItem.Content }
-        }
-
-        $Script:MainForm.Elements.TextBoxDisplayName.IsEnabled = $true
-        $Script:MainForm.Elements.ComboBoxSelectDataConnection.IsEnabled = $true
-        $Script:MainForm.Elements.ButtonShowSqlSchema.IsEnabled = $true
-
-        "{0} data connections processed!" -f ($Script:MainForm.Elements.ComboBoxSelectDataConnection.Items | Measure-Object).Count | Write-LogOutput
-
-        if ($null -ne $UpdateDataConnectionsWindow) {
-            $UpdateDataConnectionsWindow.Close()
+        finally {
+            if ($null -ne $UpdateDataConnectionsWindow) {
+                $UpdateDataConnectionsWindow.Close()
+            }
         }
     }
     catch {

--- a/src/Lib/Functions/Private/Update-DataConnectionList.ps1
+++ b/src/Lib/Functions/Private/Update-DataConnectionList.ps1
@@ -80,8 +80,12 @@ function Get-DataConnectionPageInline {
     param()
 
     # Count, not a null check. A view that exists but holds nothing comes back as an empty array,
-    # which is not $null - and indexing [0] into it throws under StrictMode ("Index was outside the
-    # bounds of the array"), so the intended "no rows" outcome would arrive as an error instead.
+    # which is not $null - so the null check let it straight through. Nothing throws: this codebase
+    # never enables Set-StrictMode (see ConvertTo-TabSessionConfig), so @()[0] is $null and so is the
+    # id read off it. The request was then built as "dataobjdlg.aspx?DOID=" with no id at all, sent,
+    # and its answer reported as "Failed to retrieve data connections!" - which disables the dropdown
+    # and the schema button. A wasted round-trip producing the wrong outcome, where the right one is
+    # to leave the list alone, as the original code did for this case.
     $Private:SqlQueryViewContents = @(Get-SqlTroubleShooterView)
     if ($Private:SqlQueryViewContents.Count -eq 0) {
         return @{ HasRows = $false; Html = $null }

--- a/src/Lib/Functions/Private/Update-DataConnectionList.ps1
+++ b/src/Lib/Functions/Private/Update-DataConnectionList.ps1
@@ -79,8 +79,11 @@ function Get-DataConnectionPageInline {
     [CmdLetBinding()]
     param()
 
-    $Private:SqlQueryViewContents = Get-SqlTroubleShooterView
-    if ($null -eq $Private:SqlQueryViewContents) {
+    # Count, not a null check. A view that exists but holds nothing comes back as an empty array,
+    # which is not $null - and indexing [0] into it throws under StrictMode ("Index was outside the
+    # bounds of the array"), so the intended "no rows" outcome would arrive as an error instead.
+    $Private:SqlQueryViewContents = @(Get-SqlTroubleShooterView)
+    if ($Private:SqlQueryViewContents.Count -eq 0) {
         return @{ HasRows = $false; Html = $null }
     }
 

--- a/tests/Get-OmadaPipelineWorkerFunction.Tests.ps1
+++ b/tests/Get-OmadaPipelineWorkerFunction.Tests.ps1
@@ -32,6 +32,48 @@ Describe "Get-OmadaPipelineWorkerFunction" {
         Get-OmadaPipelineWorkerFunction -PipelineContext @{ PipelineFunction = "" } | Should -Be "Invoke-OmadaExecutePipeline"
         Get-OmadaPipelineWorkerFunction -PipelineContext @{ PipelineFunction = "   " } | Should -Be "Invoke-OmadaExecutePipeline"
     }
+
+    It "trims a padded name, which IsNullOrWhiteSpace accepts but the call operator does not" {
+        Get-OmadaPipelineWorkerFunction -PipelineContext @{ PipelineFunction = "  Invoke-OmadaViewLookupPipeline  " } | Should -Be "Invoke-OmadaViewLookupPipeline"
+    }
+}
+
+Describe "Test-OmadaPipelineWorkerChain" {
+    # The gap: the pre-flight check confirms the FILES exist and nothing confirmed the FUNCTION was
+    # in them, so a typo passed every check and died inside the worker - turning a clean "run it
+    # inline instead" into a background job that fails.
+    It "accepts an entry point defined by one of its files" {
+        Test-OmadaPipelineWorkerChain -PipelineFunction "Invoke-OmadaViewLookupPipeline" -PipelineFiles @("New-OmadaPagingRequest.ps1", "Invoke-OmadaViewLookupPipeline.ps1") | Should -BeTrue
+    }
+
+    It "rejects a typo" {
+        Test-OmadaPipelineWorkerChain -PipelineFunction "Invoke-OmadaViewLookupPipelin" -PipelineFiles @("Invoke-OmadaViewLookupPipeline.ps1") | Should -BeFalse
+    }
+
+    It "rejects a chain whose entry point file was left out of the list" {
+        Test-OmadaPipelineWorkerChain -PipelineFunction "Invoke-OmadaViewLookupPipeline" -PipelineFiles @("New-OmadaPagingRequest.ps1") | Should -BeFalse
+    }
+
+    It "accepts the default chain, so #40's dispatch still goes to a worker" {
+        # If this ever returns false, every background execute silently runs inline instead.
+        Test-OmadaPipelineWorkerChain -PipelineFunction (Get-OmadaPipelineWorkerFunction -PipelineContext $null) -PipelineFiles (Get-OmadaPipelineWorkerFile -PipelineContext $null) | Should -BeTrue
+    }
+
+    It "accepts the view lookup's chain as the code actually declares it" {
+        # Reads the real declaration rather than a restated copy of it, so a rename that updates the
+        # function but not the file list fails here.
+        $Private:Source = Get-Content -Path (Join-Path $script:PrivatePath "Get-SqlTroubleShooterView.ps1") -Raw
+        $Private:Function = ([regex]::Match($Private:Source, 'PipelineFunction\s*=\s*"([^"]+)"')).Groups[1].Value
+        $Private:Files = @([regex]::Matches($Private:Source, '"([A-Za-z-]+\.ps1)"') | ForEach-Object { $_.Groups[1].Value })
+
+        $Private:Function | Should -Not -BeNullOrEmpty
+        Test-OmadaPipelineWorkerChain -PipelineFunction $Private:Function -PipelineFiles $Private:Files | Should -BeTrue
+    }
+
+    It "says no rather than throwing when there is nothing to check" {
+        Test-OmadaPipelineWorkerChain -PipelineFunction "" -PipelineFiles @("x.ps1") | Should -BeFalse
+        Test-OmadaPipelineWorkerChain -PipelineFunction "Invoke-X" -PipelineFiles $null | Should -BeFalse
+    }
 }
 
 Describe "Get-OmadaPipelineWorkerFile" {
@@ -47,6 +89,14 @@ Describe "Get-OmadaPipelineWorkerFile" {
 
     It "ignores an empty list rather than dot-sourcing nothing" {
         Get-OmadaPipelineWorkerFile -PipelineContext @{ PipelineFiles = @() } | Should -Be @("New-OmadaQueryRequest.ps1", "Invoke-OmadaExecutePipeline.ps1")
+    }
+
+    It "drops empty entries, which would throw on Join-Path before anything could check them" {
+        Get-OmadaPipelineWorkerFile -PipelineContext @{ PipelineFiles = @("Invoke-OmadaViewLookupPipeline.ps1", $null, "  ") } | Should -Be @("Invoke-OmadaViewLookupPipeline.ps1")
+    }
+
+    It "falls back to the default when every entry was empty" {
+        Get-OmadaPipelineWorkerFile -PipelineContext @{ PipelineFiles = @($null, "") } | Should -Be @("New-OmadaQueryRequest.ps1", "Invoke-OmadaExecutePipeline.ps1")
     }
 
     It "names files that exist, for <_>" -ForEach @(

--- a/tests/Get-OmadaPipelineWorkerFunction.Tests.ps1
+++ b/tests/Get-OmadaPipelineWorkerFunction.Tests.ps1
@@ -1,0 +1,84 @@
+#Requires -Version 7.0
+# Issue #90, slice A. Which chain a worker runs is now data on the pipeline context. Three places
+# need that answer - the pre-flight file check, the dispatch, and the E2E harness's stand-in for the
+# worker - and they must not disagree.
+#
+# They did, once, and it is the reason these functions exist rather than three copies of an `if`:
+# the harness answered "execute pipeline" while the dispatch answered "view lookup", so the view
+# lookup came back with an execute-shaped outcome, the data connection dropdown was never populated,
+# and the E2E failure looked like a defect in the code under test.
+
+BeforeAll {
+    $ParentPath = Split-Path -Path $PSScriptRoot -Parent
+    $script:PrivatePath = Join-Path $ParentPath -ChildPath "src\Lib\Functions\Private"
+    . (Join-Path $script:PrivatePath -ChildPath "Get-OmadaPipelineWorkerFunction.ps1")
+}
+
+Describe "Get-OmadaPipelineWorkerFunction" {
+    It "defaults to the execute pipeline when there is no context at all" {
+        # A single background request, not a chain. #40's callers pass nothing.
+        Get-OmadaPipelineWorkerFunction -PipelineContext $null | Should -Be "Invoke-OmadaExecutePipeline"
+    }
+
+    It "defaults to the execute pipeline when the context names no chain" {
+        Get-OmadaPipelineWorkerFunction -PipelineContext @{ BaseUrl = "https://t" } | Should -Be "Invoke-OmadaExecutePipeline"
+    }
+
+    It "returns the chain the context names" {
+        Get-OmadaPipelineWorkerFunction -PipelineContext @{ PipelineFunction = "Invoke-OmadaViewLookupPipeline" } | Should -Be "Invoke-OmadaViewLookupPipeline"
+    }
+
+    It "ignores an empty or whitespace name rather than dispatching nothing" {
+        Get-OmadaPipelineWorkerFunction -PipelineContext @{ PipelineFunction = "" } | Should -Be "Invoke-OmadaExecutePipeline"
+        Get-OmadaPipelineWorkerFunction -PipelineContext @{ PipelineFunction = "   " } | Should -Be "Invoke-OmadaExecutePipeline"
+    }
+}
+
+Describe "Get-OmadaPipelineWorkerFile" {
+    It "defaults to the execute pipeline's files" {
+        Get-OmadaPipelineWorkerFile -PipelineContext $null | Should -Be @("New-OmadaQueryRequest.ps1", "Invoke-OmadaExecutePipeline.ps1")
+    }
+
+    It "returns the files the context names" {
+        $Private:Files = Get-OmadaPipelineWorkerFile -PipelineContext @{ PipelineFiles = @("New-OmadaPagingRequest.ps1", "Invoke-OmadaViewLookupPipeline.ps1") }
+
+        $Private:Files | Should -Be @("New-OmadaPagingRequest.ps1", "Invoke-OmadaViewLookupPipeline.ps1")
+    }
+
+    It "ignores an empty list rather than dot-sourcing nothing" {
+        Get-OmadaPipelineWorkerFile -PipelineContext @{ PipelineFiles = @() } | Should -Be @("New-OmadaQueryRequest.ps1", "Invoke-OmadaExecutePipeline.ps1")
+    }
+
+    It "names files that exist, for <_>" -ForEach @(
+        @{ PipelineFunction = "Invoke-OmadaExecutePipeline" },
+        @{ PipelineFunction = "Invoke-OmadaViewLookupPipeline"; PipelineFiles = @("New-OmadaPagingRequest.ps1", "Invoke-OmadaViewLookupPipeline.ps1") }
+    ) {
+        # A named file that does not exist fails inside a worker runspace, where it surfaces as a job
+        # that died rather than as a missing file.
+        foreach ($Private:File in (Get-OmadaPipelineWorkerFile -PipelineContext $_)) {
+            Join-Path $script:PrivatePath $Private:File | Should -Exist
+        }
+    }
+}
+
+Describe "Everyone asks the same question" {
+    # The regression that made these functions necessary. Each of the three places must go through
+    # them rather than deciding for itself.
+    It "<Name> resolves the chain through the shared helper" -ForEach @(
+        @{ Name = "the dispatch"; Path = "src\Lib\Functions\Private\Start-OmadaBackgroundRequest.ps1" }
+        @{ Name = "the E2E worker stand-in"; Path = "tests\e2e\OmadaMocks.ps1" }
+    ) {
+        $Private:Source = Get-Content -Path (Join-Path (Split-Path -Path $PSScriptRoot -Parent) $Path) -Raw
+
+        $Private:Source | Should -Match 'Get-OmadaPipelineWorkerFunction -PipelineContext'
+        $Private:Source | Should -Not -Match '=\s*Invoke-OmadaExecutePipeline -Context'
+    }
+
+    It "the pre-flight file check asks for the chain's own files" {
+        # It used to require the execute pipeline's two files whatever the chain was, so a second
+        # chain's files were never checked - dispatching a worker that then failed on its first line.
+        $Private:Source = Get-Content -Path (Join-Path $script:PrivatePath "Start-OmadaBackgroundRequest.ps1") -Raw
+
+        $Private:Source | Should -Match 'RequiredWorkerFiles \+= Get-OmadaPipelineWorkerFile'
+    }
+}

--- a/tests/Invoke-OmadaViewLookupPipeline.Tests.ps1
+++ b/tests/Invoke-OmadaViewLookupPipeline.Tests.ps1
@@ -184,6 +184,21 @@ Describe "Invoke-OmadaViewLookupPipeline" {
             @($script:Calls | Where-Object { $_.Key -eq "page" }).Count | Should -Be 0
         }
 
+        It "reports an empty view as an empty array, never as null" {
+            # A jqGrid payload for a view with nothing in it has a null .d.Rows, and @($null).Count is
+            # 1 - so a caller asking "did I get rows?" the obvious way was told yes. Normalising here
+            # means no caller has to know that.
+            Reset-Transport
+            $script:Responses["view-rows"] = [pscustomobject]@{ d = [pscustomobject]@{ Rows = $null } }
+
+            $Private:Outcome = Invoke-OmadaViewLookupPipeline -Context (New-Context)
+
+            # Compared, not piped: Should unrolls the pipeline, so an empty array arrives as nothing
+            # and the assertion would be about $null either way.
+            ($null -eq $Private:Outcome.Rows) | Should -BeFalse
+            @($Private:Outcome.Rows).Count | Should -Be 0
+        }
+
         It "does not fetch it when the view returned no rows" {
             Reset-Transport -NoRows
 

--- a/tests/Invoke-OmadaViewLookupPipeline.Tests.ps1
+++ b/tests/Invoke-OmadaViewLookupPipeline.Tests.ps1
@@ -110,6 +110,20 @@ Describe "Invoke-OmadaViewLookupPipeline" {
             $Private:Outcome.Rows[0].Id | Should -Be 900
         }
 
+        It "takes one view even when the tenant holds two of that name" {
+            # Without -First 1 the match is an array, and "{0}" -f an array formats as
+            # System.Object[] - an invalid viewId and pageQueryString. The inline path in
+            # Get-SqlTroubleShooterView must agree; a source assertion below keeps it honest.
+            $script:Responses["find-view"] = New-ViewResponse -Views @(
+                [pscustomobject]@{ Id = 42; Name = "SQL Troubleshooting" },
+                [pscustomobject]@{ Id = 43; Name = "SQL Troubleshooting" }
+            )
+
+            $null = Invoke-OmadaViewLookupPipeline -Context (New-Context)
+
+            ($script:Calls | Where-Object { $_.Key -eq "view-rows" }).Body.dataTypeArgs.viewId | Should -Be "42"
+        }
+
         It "picks the view by exact name, not by the search match" {
             # The search is a contains-match, so the response legitimately holds other views. Taking
             # the first row would pass on any fixture where the wanted view happens to come first.
@@ -274,6 +288,14 @@ Describe "Invoke-OmadaViewLookupPipeline" {
 
             $Private:Outcome.Steps.Name | Should -Be @("FindView", "FetchViewRows", "FetchDataConnectionPage")
         }
+    }
+
+    It "does not disagree with the inline path about picking one view" {
+        # The two paths build the same requests by construction (New-OmadaPagingRequest); this is the
+        # one decision made OUTSIDE the builder, so it is the one place they can still drift.
+        $Private:Inline = Get-Content -Path (Join-Path $script:PrivatePath "Get-SqlTroubleShooterView.ps1") -Raw
+
+        $Private:Inline | Should -Match 'Where-Object \{ \$_\.Name -eq "SQL Troubleshooting" \} \| Select-Object -First 1'
     }
 
     It "is runspace-safe - no script state, no logging, no WPF" {

--- a/tests/Invoke-OmadaViewLookupPipeline.Tests.ps1
+++ b/tests/Invoke-OmadaViewLookupPipeline.Tests.ps1
@@ -1,0 +1,288 @@
+#Requires -Version 7.0
+# The view lookup as one background job (issue #90, slice A).
+#
+# Get-SqlTroubleShooterView makes two dependent GetPagingData round-trips - the second needs the view
+# id the first returns - and Update-DataConnectionList follows them with a third. All three run as
+# ONE worker job so there is one completion rather than three, which is the number of places
+# Set-ActiveTabContext can repoint underneath the work.
+#
+# Each case asserts the ORDER and SHAPE of the requests, using a recording transport, so a change to
+# the sequencing fails here rather than on someone's tenant.
+
+BeforeAll {
+    $ParentPath = Split-Path -Path $PSScriptRoot -Parent
+    $script:PrivatePath = Join-Path $ParentPath -ChildPath "src\Lib\Functions\Private"
+    . (Join-Path $script:PrivatePath -ChildPath "New-OmadaPagingRequest.ps1")
+    . (Join-Path $script:PrivatePath -ChildPath "Invoke-OmadaViewLookupPipeline.ps1")
+
+    $script:Calls = [System.Collections.Generic.List[object]]::new()
+    $script:Responses = @{}
+    $script:Failures = @{}
+
+    function script:Get-CallKey {
+        param($Method, $Uri, $Body)
+        if ($Uri -like "*dataobjdlg.aspx*") { return "page" }
+        if ($Body.dataType -eq "Views") { return "find-view" }
+        if ($Body.dataType -eq "DataObjects") { return "view-rows" }
+        return "unknown"
+    }
+
+    function Invoke-OmadaRequestCore {
+        param([hashtable]$Parameters)
+        $Key = Get-CallKey -Method $Parameters.Method -Uri $Parameters.Uri -Body $Parameters.Body
+        $script:Calls.Add([pscustomobject]@{ Key = $Key; Method = $Parameters.Method; Uri = $Parameters.Uri; Body = $Parameters.Body; SessionKey = $Parameters.SessionKey })
+
+        if ($script:Failures.ContainsKey($Key)) {
+            return @{ Result = $null; ErrorRecord = [System.Management.Automation.ErrorRecord]::new(
+                    [System.Exception]::new($script:Failures[$Key]), "ViewLookupTestFailure",
+                    [System.Management.Automation.ErrorCategory]::ConnectionError, $null) }
+        }
+        if ($script:Responses.ContainsKey($Key)) {
+            return @{ Result = $script:Responses[$Key]; ErrorRecord = $null }
+        }
+        return @{ Result = $null; ErrorRecord = $null }
+    }
+
+    function script:New-ViewResponse {
+        param([object[]]$Views)
+        return [pscustomobject]@{ d = [pscustomobject]@{ Records = @($Views).Count; Rows = $Views } }
+    }
+
+    function script:Reset-Transport {
+        param([switch]$NoView, [switch]$NoRows)
+
+        $script:Calls.Clear()
+        $script:Failures = @{}
+        $script:Responses = @{}
+
+        if (-not $NoView) {
+            $script:Responses["find-view"] = New-ViewResponse -Views @(
+                [pscustomobject]@{ Id = 7; Name = "Some other view" },
+                [pscustomobject]@{ Id = 42; Name = "SQL Troubleshooting" }
+            )
+        }
+        else {
+            $script:Responses["find-view"] = New-ViewResponse -Views @()
+        }
+
+        $script:Rows = if ($NoRows) { @() } else { @([pscustomobject]@{ Id = 900; C_SQLQUERYDOID = "abc-123" }) }
+        $script:Responses["view-rows"] = [pscustomobject]@{ d = [pscustomobject]@{ Rows = $script:Rows } }
+        $script:Responses["page"] = "<html>the data connection page</html>"
+    }
+
+    # The code, without its comments. A purity scan over raw source is defeated by its own
+    # documentation: this function's help explains WHY it may not read $Script: state, and a naive
+    # match then fails on the explanation rather than on a violation. Tokenizing drops comments -
+    # including the comment-based help block, which is one Comment token.
+    function script:Get-CodeOnly {
+        param([string]$Path)
+        $Private:Tokens = $null
+        $Private:Errors = $null
+        $null = [System.Management.Automation.Language.Parser]::ParseFile($Path, [ref]$Private:Tokens, [ref]$Private:Errors)
+        return (($Private:Tokens | Where-Object { $_.Kind -ne "Comment" }).Text -join " ")
+    }
+
+    function script:New-Context {
+        param([switch]$IncludeDataObjectHtml)
+        return @{
+            BaseUrl               = "https://tenant.omada.cloud"
+            Parameters            = @{ SessionKey = "tab-1"; Uri = "stale"; Method = "STALE" }
+            IncludeDataObjectHtml = [bool]$IncludeDataObjectHtml
+            SqlQueryDoIdField     = "C_SQLQUERYDOID"
+        }
+    }
+}
+
+Describe "Invoke-OmadaViewLookupPipeline" {
+    BeforeEach { Reset-Transport }
+
+    Context "The happy path" {
+        It "looks the view up, then fetches its rows, in that order" {
+            $null = Invoke-OmadaViewLookupPipeline -Context (New-Context)
+
+            $script:Calls.Key | Should -Be @("find-view", "view-rows")
+        }
+
+        It "returns the rows" {
+            $Private:Outcome = Invoke-OmadaViewLookupPipeline -Context (New-Context)
+
+            @($Private:Outcome.Rows).Count | Should -Be 1
+            $Private:Outcome.Rows[0].Id | Should -Be 900
+        }
+
+        It "picks the view by exact name, not by the search match" {
+            # The search is a contains-match, so the response legitimately holds other views. Taking
+            # the first row would pass on any fixture where the wanted view happens to come first.
+            $Private:Outcome = Invoke-OmadaViewLookupPipeline -Context (New-Context)
+
+            $Private:Outcome.ViewId | Should -Be 42
+            $Private:Outcome.ViewFound | Should -BeTrue
+        }
+
+        It "asks the second request for the view the first one found" {
+            $null = Invoke-OmadaViewLookupPipeline -Context (New-Context)
+
+            $Private:RowCall = $script:Calls | Where-Object { $_.Key -eq "view-rows" }
+            $Private:RowCall.Body.dataTypeArgs.viewId | Should -Be "42"
+            $Private:RowCall.Body.dataTypeArgs.pageQueryString | Should -Be "https://tenant.omada.cloud/dataobjlst.aspx?view=42"
+        }
+
+        It "counts both steps as completed" {
+            (Invoke-OmadaViewLookupPipeline -Context (New-Context)).CompletedSteps | Should -Be 2
+        }
+
+        It "carries the session's transport settings into every step" {
+            # The splat is cloned per step with only Uri, Method and Body replaced. Losing SessionKey
+            # would send the worker's requests to the wrong authenticated session.
+            $null = Invoke-OmadaViewLookupPipeline -Context (New-Context)
+
+            @($script:Calls | Where-Object { $_.SessionKey -ne "tab-1" }).Count | Should -Be 0
+        }
+
+        It "overwrites the stale Uri and Method left on the splat" {
+            $null = Invoke-OmadaViewLookupPipeline -Context (New-Context)
+
+            @($script:Calls | Where-Object { $_.Uri -eq "stale" -or $_.Method -eq "STALE" }).Count | Should -Be 0
+        }
+    }
+
+    Context "The optional data connection page" {
+        It "fetches it as a third step of the same job" {
+            # The whole point of the slice: three round-trips, one completion.
+            $null = Invoke-OmadaViewLookupPipeline -Context (New-Context -IncludeDataObjectHtml)
+
+            $script:Calls.Key | Should -Be @("find-view", "view-rows", "page")
+        }
+
+        It "opens the first row's data object" {
+            $null = Invoke-OmadaViewLookupPipeline -Context (New-Context -IncludeDataObjectHtml)
+
+            ($script:Calls | Where-Object { $_.Key -eq "page" }).Uri | Should -Be "https://tenant.omada.cloud/dataobjdlg.aspx?DOID=abc-123"
+        }
+
+        It "returns the page" {
+            (Invoke-OmadaViewLookupPipeline -Context (New-Context -IncludeDataObjectHtml)).DataObjectHtml | Should -Be "<html>the data connection page</html>"
+        }
+
+        It "does not fetch it when the caller did not ask for it" {
+            $null = Invoke-OmadaViewLookupPipeline -Context (New-Context)
+
+            @($script:Calls | Where-Object { $_.Key -eq "page" }).Count | Should -Be 0
+        }
+
+        It "does not fetch it when the view returned no rows" {
+            Reset-Transport -NoRows
+
+            $Private:Outcome = Invoke-OmadaViewLookupPipeline -Context (New-Context -IncludeDataObjectHtml)
+
+            @($script:Calls | Where-Object { $_.Key -eq "page" }).Count | Should -Be 0
+            $Private:Outcome.ErrorRecord | Should -BeNullOrEmpty
+        }
+    }
+
+    Context "When the view does not exist" {
+        BeforeEach { Reset-Transport -NoView }
+
+        It "stops after the lookup" {
+            $null = Invoke-OmadaViewLookupPipeline -Context (New-Context)
+
+            $script:Calls.Key | Should -Be @("find-view")
+        }
+
+        It "reports it as an answer, not as a failure" {
+            # Reporting it through ErrorRecord would send the caller down the retry-on-the-UI-thread
+            # path, which would ask the same question again and get the same answer.
+            $Private:Outcome = Invoke-OmadaViewLookupPipeline -Context (New-Context)
+
+            $Private:Outcome.ErrorRecord | Should -BeNullOrEmpty
+            $Private:Outcome.ViewFound | Should -BeFalse
+            $Private:Outcome.Rows | Should -BeNullOrEmpty
+        }
+    }
+
+    Context "When a step fails" {
+        It "stops at the failing step and names it" {
+            Reset-Transport
+            $script:Failures["find-view"] = "the tenant said no"
+
+            $Private:Outcome = Invoke-OmadaViewLookupPipeline -Context (New-Context)
+
+            $script:Calls.Key | Should -Be @("find-view")
+            $Private:Outcome.FailedStep | Should -Be "FindView"
+            $Private:Outcome.ErrorRecord.Exception.Message | Should -Be "the tenant said no"
+        }
+
+        It "reports how many steps had already succeeded" {
+            # This is what tells the caller "could not reach the tenant" from "the tenant refused
+            # something", and only the first is safe to retry.
+            Reset-Transport
+            $script:Failures["view-rows"] = "gone"
+
+            $Private:Outcome = Invoke-OmadaViewLookupPipeline -Context (New-Context)
+
+            $Private:Outcome.FailedStep | Should -Be "FetchViewRows"
+            $Private:Outcome.CompletedSteps | Should -Be 1
+        }
+
+        It "names the page step when that is the one that failed" {
+            Reset-Transport
+            $script:Failures["page"] = "no page"
+
+            $Private:Outcome = Invoke-OmadaViewLookupPipeline -Context (New-Context -IncludeDataObjectHtml)
+
+            $Private:Outcome.FailedStep | Should -Be "FetchDataConnectionPage"
+            $Private:Outcome.CompletedSteps | Should -Be 2
+        }
+
+        It "returns an outcome rather than throwing when something unexpected happens" {
+            # A throw from a worker surfaces as a job that died, which the UI thread cannot classify -
+            # it has no ErrorRecord to run through Resolve-OmadaRequestFailure and no step trace.
+            #
+            # A string where the splat should be: .Clone() does not exist on it, so this throws from
+            # inside the step helper rather than at the boundary. (Passing $null instead would fail
+            # parameter binding before the function is entered, which tests PowerShell, not this.)
+            Reset-Transport
+            # script:, not Private: - the Should -Not -Throw body runs in a child scope, where a
+            # $Private: variable does not resolve and the call would fail on a null argument instead
+            # of on the thing being tested.
+            $script:Broken = New-Context
+            $script:Broken.Parameters = "not a hashtable"
+
+            { $script:Unexpected = Invoke-OmadaViewLookupPipeline -Context $script:Broken } | Should -Not -Throw
+            $script:Unexpected.ErrorRecord | Should -Not -BeNullOrEmpty
+            $script:Unexpected.FailedStep | Should -Be "ViewLookup"
+        }
+    }
+
+    Context "What it records for the UI thread" {
+        It "logs each request's URL, for a log that reads as it always did" {
+            $Private:Outcome = Invoke-OmadaViewLookupPipeline -Context (New-Context)
+
+            @($Private:Outcome.Log | Where-Object { $_.Text -like "QueryUrl:*" }).Count | Should -Be 2
+        }
+
+        It "hands the body over to be redacted rather than writing it out" {
+            # ConvertTo-RedactedLogString is a UI-thread function. The worker records WHAT to log and
+            # the UI thread decides how much of it may be written down.
+            $Private:Outcome = Invoke-OmadaViewLookupPipeline -Context (New-Context)
+
+            @($Private:Outcome.Log | Where-Object { $null -ne $_.Redact }).Count | Should -BeGreaterThan 0
+        }
+
+        It "traces the steps it ran" {
+            $Private:Outcome = Invoke-OmadaViewLookupPipeline -Context (New-Context -IncludeDataObjectHtml)
+
+            $Private:Outcome.Steps.Name | Should -Be @("FindView", "FetchViewRows", "FetchDataConnectionPage")
+        }
+    }
+
+    It "is runspace-safe - no script state, no logging, no WPF" {
+        # It runs in a worker runspace, where none of that exists. A single $Script: read here is a
+        # CommandNotFoundException or a null in a background job, found on a tenant rather than here.
+        $Private:Code = Get-CodeOnly -Path (Join-Path $script:PrivatePath "Invoke-OmadaViewLookupPipeline.ps1")
+
+        $Private:Code | Should -Not -Match '\$Script:'
+        $Private:Code | Should -Not -Match 'Write-LogOutput'
+        $Private:Code | Should -Not -Match 'System\.Windows'
+    }
+}

--- a/tests/Invoke-OmadaViewLookupPipeline.Tests.ps1
+++ b/tests/Invoke-OmadaViewLookupPipeline.Tests.ps1
@@ -305,6 +305,14 @@ Describe "Invoke-OmadaViewLookupPipeline" {
         }
     }
 
+    It "does not disagree with the inline path about an empty row set either" {
+        # Both paths normalise .d.Rows to an array, because a null one counted as a single row and
+        # every caller downstream believed it.
+        $Private:Inline = Get-Content -Path (Join-Path $script:PrivatePath "Get-SqlTroubleShooterView.ps1") -Raw
+
+        $Private:Inline | Should -Match '@\(\$Private:Result\.d\.Rows \| Where-Object \{ \$null -ne \$_ \}\)'
+    }
+
     It "does not disagree with the inline path about picking one view" {
         # The two paths build the same requests by construction (New-OmadaPagingRequest); this is the
         # one decision made OUTSIDE the builder, so it is the one place they can still drift.

--- a/tests/New-OmadaPagingRequest.Tests.ps1
+++ b/tests/New-OmadaPagingRequest.Tests.ps1
@@ -1,0 +1,103 @@
+#Requires -Version 7.0
+# Issue #90, slice A. The point of this builder is that the UI thread and the worker send the SAME
+# request; these tests are mostly about that equality, not about the shape in isolation.
+
+BeforeAll {
+    $ParentPath = Split-Path -Path $PSScriptRoot -Parent
+    $script:PrivatePath = Join-Path $ParentPath -ChildPath "src\Lib\Functions\Private"
+    . (Join-Path $script:PrivatePath -ChildPath "New-OmadaPagingRequest.ps1")
+
+    # The code, without its comments. A purity scan over raw source is defeated by its own
+    # documentation: this function's help explains why it may not read $Script: state, and a naive
+    # match then fails on the explanation rather than on a violation.
+    function script:Get-CodeOnly {
+        param([string]$Path)
+        $Private:Tokens = $null
+        $Private:Errors = $null
+        $null = [System.Management.Automation.Language.Parser]::ParseFile($Path, [ref]$Private:Tokens, [ref]$Private:Errors)
+        return (($Private:Tokens | Where-Object { $_.Kind -ne "Comment" }).Text -join " ")
+    }
+}
+
+Describe "New-OmadaPagingRequest" {
+    It "posts to the jqGrid paging endpoint" {
+        $Private:Request = New-OmadaPagingRequest -DataType "Views" -DataTypeArgs @{ OwnerShipType = "Both" } -BaseUrl "https://tenant.omada.cloud"
+
+        $Private:Request.Method | Should -Be "POST"
+        $Private:Request.Uri | Should -Be "https://tenant.omada.cloud/WebService/JQGridPopulationWebService.asmx/GetPagingData"
+    }
+
+    It "carries the data type and its arguments through untouched" {
+        $Private:Args = [ordered]@{ viewId = "42"; countRows = $false }
+
+        $Private:Request = New-OmadaPagingRequest -DataType "DataObjects" -DataTypeArgs $Private:Args -BaseUrl "https://tenant.omada.cloud"
+
+        $Private:Request.Body.dataType | Should -Be "DataObjects"
+        $Private:Request.Body.dataTypeArgs.viewId | Should -Be "42"
+        $Private:Request.Body.dataTypeArgs.countRows | Should -Be $false
+    }
+
+    Context "Searching" {
+        It "sets both the sort index and the search string together" {
+            # sidx and searchString move as a pair in the original code; splitting them is the
+            # plausible way to break this builder without any single assertion noticing.
+            $Private:Request = New-OmadaPagingRequest -DataType "Views" -DataTypeArgs @{} -SearchString "SQL Troubleshooting" -BaseUrl "https://t"
+
+            $Private:Request.Body.sidx | Should -Be "name"
+            $Private:Request.Body.searchString | Should -Be "SQL Troubleshooting"
+        }
+
+        It "leaves both empty when there is nothing to search for" {
+            $Private:Request = New-OmadaPagingRequest -DataType "Views" -DataTypeArgs @{} -BaseUrl "https://t"
+
+            $Private:Request.Body.sidx | Should -BeNullOrEmpty
+            $Private:Request.Body.searchString | Should -BeNullOrEmpty
+        }
+
+        It "treats whitespace as nothing to search for" {
+            $Private:Request = New-OmadaPagingRequest -DataType "Views" -DataTypeArgs @{} -SearchString "   " -BaseUrl "https://t"
+
+            $Private:Request.Body.sidx | Should -BeNullOrEmpty
+        }
+    }
+
+    It "sends the cache-busting nd value this application has always sent" {
+        # A constant where jqGrid would send a timestamp. Asserted because it is exactly the kind of
+        # value that quietly becomes two different constants once it exists in two places - which is
+        # the reason this builder exists at all.
+        (New-OmadaPagingRequest -DataType "Views" -DataTypeArgs @{} -BaseUrl "https://t").Body.nd | Should -Be 1732546553116
+    }
+
+    It "defaults to the page size the application has always requested" {
+        (New-OmadaPagingRequest -DataType "Views" -DataTypeArgs @{} -BaseUrl "https://t").Body.rows | Should -Be 1000
+    }
+
+    It "asks for one page, unsearched, ascending" {
+        $Private:Body = (New-OmadaPagingRequest -DataType "Views" -DataTypeArgs @{} -BaseUrl "https://t").Body
+
+        $Private:Body._search | Should -Be $false
+        $Private:Body.page | Should -Be 1
+        $Private:Body.sord | Should -Be "asc"
+    }
+
+    It "is a pure function - no script state, no network" {
+        # If this ever stops being true it cannot run in a worker runspace, where none of that
+        # exists. Cheaper to assert here than to discover from a CommandNotFoundException inside a
+        # background job.
+        $Private:Code = Get-CodeOnly -Path (Join-Path $script:PrivatePath "New-OmadaPagingRequest.ps1")
+
+        $Private:Code | Should -Not -Match '\$Script:'
+        $Private:Code | Should -Not -Match 'Write-LogOutput'
+        $Private:Code | Should -Not -Match 'Invoke-Omada'
+    }
+}
+
+Describe "Get-OmadaGetPagingDataObject uses it" {
+    It "no longer builds the body inline" {
+        # The equality that matters: one definition, so the inline and background paths cannot drift.
+        $Private:Source = Get-Content -Path (Join-Path $script:PrivatePath "Get-OmadaGetPagingDataObject.ps1") -Raw
+
+        $Private:Source | Should -Match 'New-OmadaPagingRequest'
+        $Private:Source | Should -Not -Match 'nd\s+=\s+1732546553116'
+    }
+}

--- a/tests/Start-OmadaBackgroundRequest.Tests.ps1
+++ b/tests/Start-OmadaBackgroundRequest.Tests.ps1
@@ -17,6 +17,10 @@ BeforeAll {
     # would let that silently stop happening. It reads only the installed module's capabilities.
     . (Join-Path $PrivatePath -ChildPath "Test-OmadaRestMethodParameter.ps1")
     . (Join-Path $PrivatePath -ChildPath "Add-OmadaNonInteractiveAuthentication.ps1")
+    # Real, not stubbed: it is pure, and it decides which chain a worker runs. Stubbing it would let
+    # the dispatch and the pre-flight file check disagree about that without any test noticing -
+    # which is the exact regression these helpers were extracted to prevent.
+    . (Join-Path $PrivatePath -ChildPath "Get-OmadaPipelineWorkerFunction.ps1")
     . (Join-Path $PrivatePath -ChildPath "Start-OmadaBackgroundRequest.ps1")
 
     $Script:Tracer = [System.Diagnostics.Trace]

--- a/tests/Start-OmadaBackgroundRequestPipelineSelection.Tests.ps1
+++ b/tests/Start-OmadaBackgroundRequestPipelineSelection.Tests.ps1
@@ -1,0 +1,50 @@
+#Requires -Version 7.0
+# Issue #90, slice A. Start-OmadaBackgroundRequest used to hard-code Invoke-OmadaExecutePipeline as
+# THE worker chain. Which chain to run is now data on the pipeline context.
+#
+# WHICH chain gets chosen is covered by Get-OmadaPipelineWorkerFunction.Tests.ps1. What is asserted
+# here is that the choice actually reaches the worker: the resolution happens on the UI thread, so
+# both answers have to be passed across the runspace boundary, and dropping either one leaves the
+# worker calling a null command or dot-sourcing nothing.
+
+BeforeAll {
+    $ParentPath = Split-Path -Path $PSScriptRoot -Parent
+    $script:DispatchSource = Get-Content -Path (Join-Path $ParentPath "src\Lib\Functions\Private\Start-OmadaBackgroundRequest.ps1") -Raw
+}
+
+Describe "The chosen chain reaches the worker" {
+    It "resolves both answers on the UI thread" {
+        # Rather than inside the worker block, which then needs no knowledge of which chains exist.
+        $script:DispatchSource | Should -Match '\$Private:PipelineFunction = Get-OmadaPipelineWorkerFunction'
+        $script:DispatchSource | Should -Match '\$Private:PipelineFiles = Get-OmadaPipelineWorkerFile'
+    }
+
+    It "passes both across the runspace boundary" {
+        $script:DispatchSource | Should -Match 'AddArgument\(\$Private:PipelineFunction\)\.AddArgument\(\$Private:PipelineFiles\)'
+    }
+
+    It "receives both in the worker, in the same order" {
+        # Positional arguments: a parameter added in the wrong place silently shifts every later one.
+        $script:DispatchSource | Should -Match 'param\(\$PrivateFolder, \$RequestParameters, \$PipelineContext, \$TransportScriptPath, \$TransportContext, \$PipelineFunction, \$PipelineFiles\)'
+    }
+
+    It "dot-sources whatever files the chain named, not a fixed pair" {
+        $script:DispatchSource | Should -Match 'foreach \(\$PipelineFile in \$PipelineFiles\)'
+    }
+
+    It "invokes the resolved function rather than a hard-coded one" {
+        # The line that would otherwise still say Invoke-OmadaExecutePipeline and make the whole
+        # mechanism decorative.
+        $script:DispatchSource | Should -Match '& \$PipelineFunction -Context \$PipelineContext'
+    }
+}
+
+Describe "The view lookup names a chain that exists" {
+    It "points at Invoke-OmadaViewLookupPipeline and its files" {
+        $Private:Source = Get-Content -Path (Join-Path (Split-Path -Path $PSScriptRoot -Parent) "src\Lib\Functions\Private\Get-SqlTroubleShooterView.ps1") -Raw
+
+        $Private:Source | Should -Match 'PipelineFunction\s*=\s*"Invoke-OmadaViewLookupPipeline"'
+        $Private:Source | Should -Match 'New-OmadaPagingRequest\.ps1'
+        $Private:Source | Should -Match 'Invoke-OmadaViewLookupPipeline\.ps1'
+    }
+}

--- a/tests/Update-DataConnectionList.Tests.ps1
+++ b/tests/Update-DataConnectionList.Tests.ps1
@@ -150,6 +150,17 @@ Describe "Update-DataConnectionList" {
             $script:Rendered[0].Html | Should -Be "<html>inline page</html>"
         }
 
+        It "treats a view that exists but holds no rows as no rows, without throwing" {
+            # An empty view comes back as an empty ARRAY, which is not $null - and indexing [0] into
+            # it throws under StrictMode, so the intended outcome would have arrived as an error.
+            $script:WorkerAvailable = $false
+            $script:InlineViewRows = @()
+
+            { Update-DataConnectionList } | Should -Not -Throw
+            $script:Rendered[0].HasRows | Should -BeFalse
+            $script:InlinePageCalls | Should -Be 0
+        }
+
         It "tells the worker which row property holds the data object id" {
             # The attribute mapping is UI-thread state; a worker runspace has none, so it has to
             # travel on the context or the third step opens DOID= nothing.
@@ -201,30 +212,75 @@ Describe "Update-DataConnectionList" {
 Describe "Start-SqlTroubleShooterViewLookup" {
     BeforeEach { Initialize-TestState }
 
-    It "does not ask for the same lookup twice for one tab" {
-        # Update-DataConnectionList and Update-QueryList are called one after the other on connect,
-        # and the answer is the same for both.
+    Context "When a lookup is already in flight" {
+        BeforeEach {
+            $script:Outstanding = [pscustomobject]@{
+                Description = $Script:SqlTroubleShooterViewRequestDescription
+                TabSession  = [pscustomobject]@{ Id = "tab-1" }
+                Context     = @{ Caller = @{ IncludeDataObjectHtml = $false } }
+            }
+            $Script:PendingWebViewCompletions.Add($script:Outstanding)
+        }
+
+        It "does not ask for the same lookup twice for one tab" {
+            $null = Start-SqlTroubleShooterViewLookup -OnResultScriptBlock { } -Context @{}
+
+            $script:Dispatched | Should -BeNullOrEmpty
+        }
+
+        It "returns the outstanding request, NEVER null" {
+            # $null is this function's "not dispatched, do what you did before" answer, and the
+            # caller's "before" is the three blocking round-trips this slice exists to remove.
+            # Answering $null here would defeat the guard AND put the freeze back - worse than the
+            # duplicate request the guard was meant to prevent.
+            $Private:Pending = Start-SqlTroubleShooterViewLookup -OnResultScriptBlock { } -Context @{}
+
+            $Private:Pending | Should -Not -BeNullOrEmpty
+            $Private:Pending | Should -Be $script:Outstanding
+        }
+
+        It "does ask when the outstanding lookup belongs to another tab" {
+            # Per tab, not per session: each tab has its own connection and its own dropdown to fill.
+            $script:Outstanding.TabSession = [pscustomobject]@{ Id = "tab-2" }
+
+            $null = Start-SqlTroubleShooterViewLookup -OnResultScriptBlock { } -Context @{}
+
+            $script:Dispatched | Should -Not -BeNullOrEmpty
+        }
+
+        It "does ask when the outstanding lookup is a different shape" {
+            # A lookup running WITHOUT the data connection page cannot satisfy a caller that needs
+            # it: joining would leave that caller waiting for data the worker was never asked to
+            # fetch. This is the case slice B creates, where Update-QueryList wants the rows only.
+            $null = Start-SqlTroubleShooterViewLookup -IncludeDataObjectHtml -OnResultScriptBlock { } -Context @{}
+
+            $script:Dispatched | Should -Not -BeNullOrEmpty
+            $script:Dispatched.PipelineContext.IncludeDataObjectHtml | Should -BeTrue
+        }
+    }
+
+    It "records its shape, so the in-flight guard can compare it" {
+        $null = Start-SqlTroubleShooterViewLookup -IncludeDataObjectHtml -OnResultScriptBlock { } -Context @{}
+
+        $script:Dispatched.Context.IncludeDataObjectHtml | Should -BeTrue
+    }
+
+    It "does not run the blocking path when it joins an outstanding request" {
+        # The whole point, end to end: a second Update-DataConnectionList while one is in flight must
+        # not reach the UI thread's three round-trips.
+        Update-DataConnectionList
         $Script:PendingWebViewCompletions.Add([pscustomobject]@{
                 Description = $Script:SqlTroubleShooterViewRequestDescription
                 TabSession  = [pscustomobject]@{ Id = "tab-1" }
+                Context     = @{ Caller = @{ IncludeDataObjectHtml = $true } }
             })
+        $script:InlineViewCalls = 0
+        $script:InlinePageCalls = 0
 
-        $Private:Pending = Start-SqlTroubleShooterViewLookup -OnResultScriptBlock { } -Context @{}
+        Update-DataConnectionList
 
-        $Private:Pending | Should -BeNullOrEmpty
-        $script:Dispatched | Should -BeNullOrEmpty
-    }
-
-    It "does ask when the outstanding lookup belongs to another tab" {
-        # Per tab, not per session: each tab has its own connection and its own dropdown to fill.
-        $Script:PendingWebViewCompletions.Add([pscustomobject]@{
-                Description = $Script:SqlTroubleShooterViewRequestDescription
-                TabSession  = [pscustomobject]@{ Id = "tab-2" }
-            })
-
-        $null = Start-SqlTroubleShooterViewLookup -OnResultScriptBlock { } -Context @{}
-
-        $script:Dispatched | Should -Not -BeNullOrEmpty
+        $script:InlineViewCalls | Should -Be 0
+        $script:InlinePageCalls | Should -Be 0
     }
 
     It "leaves the third step out when the caller does not want it" {

--- a/tests/Update-DataConnectionList.Tests.ps1
+++ b/tests/Update-DataConnectionList.Tests.ps1
@@ -21,6 +21,22 @@ BeforeAll {
         process { $script:LogMessages.Add([pscustomobject]@{ LogType = $LogType; Message = [string]$InputObject }) }
     }
 
+    # Real, not stubbed: what a worker failure MEANS is this function's decision, and the whole point
+    # of asking it is that the view lookup must not re-decide. A stub here would let the two drift
+    # apart silently - which is the misclassification it exists to prevent.
+    . (Join-Path $PrivatePath -ChildPath "Get-OmadaHttpStatusCode.ps1")
+    . (Join-Path $PrivatePath -ChildPath "Test-OmadaSessionExpiredError.ps1")
+    . (Join-Path $PrivatePath -ChildPath "Resolve-ExecuteFallbackAction.ps1")
+
+    # The shape a worker's HTTP failure actually arrives in: flattened across the runspace boundary,
+    # with the code recoverable from the message text. Get-OmadaHttpStatusCode reads it either way.
+    function script:New-HttpErrorRecord {
+        param([int]$StatusCode, [string]$Message)
+        return [System.Management.Automation.ErrorRecord]::new(
+            [System.Exception]::new(("Response status code does not indicate success: {0} ({1})." -f $StatusCode, $Message)),
+            "x", [System.Management.Automation.ErrorCategory]::ConnectionError, $null)
+    }
+
     function ConvertTo-RedactedLogString { param($InputObject, $MaxDepth, [switch]$ShapeOnly) return "<redacted>" }
     function Test-ConnectionRequirements { return $script:ConnectionReady }
     function Get-ActiveTabSession { return $script:ActiveTab }
@@ -300,19 +316,20 @@ Describe "Start-SqlTroubleShooterViewLookup" {
             } -Context @{}
         }
 
-        It "asks for an inline retry when the worker never reached the tenant" {
+        It "retries AND disables when the worker produced nothing at all" {
+            # No outcome is the only thing that proves a worker cannot serve a request.
             & $script:Dispatched.OnResult ([pscustomobject]@{
-                    Outcome = @{ ErrorRecord = [System.Management.Automation.ErrorRecord]::new([System.Exception]::new("no session"), "x", "NotSpecified", $null); CompletedSteps = 0; Log = @() }
+                    Outcome = $null
                     Context = @{ Caller = $script:Dispatched.Context }
                 })
 
             $script:Received.RetryInline | Should -BeTrue
-            $script:DisabledReason | Should -Be "no session"
+            $script:DisabledReason | Should -Not -BeNullOrEmpty
         }
 
         It "does NOT retry when the tenant answered and then refused" {
-            # CompletedSteps is what separates the two. A tenant that answered will answer the same
-            # way again, so retrying it inline just costs the user another round-trip.
+            # A tenant that answered will answer the same way again, so retrying inline just costs
+            # the user another round-trip.
             & $script:Dispatched.OnResult ([pscustomobject]@{
                     Outcome = @{ ErrorRecord = [System.Management.Automation.ErrorRecord]::new([System.Exception]::new("forbidden"), "x", "NotSpecified", $null); CompletedSteps = 1; Log = @() }
                     Context = @{ Caller = $script:Dispatched.Context }
@@ -321,6 +338,42 @@ Describe "Start-SqlTroubleShooterViewLookup" {
             $script:Received.RetryInline | Should -BeFalse
             $script:Received.Rows | Should -BeNullOrEmpty
             $script:DisabledReason | Should -BeNullOrEmpty
+        }
+
+        It "does not disable background execution over a first-step HTTP error" {
+            # THE regression this classification exists to prevent. A tenant can answer with an HTTP
+            # error on the FIRST step, which leaves CompletedSteps at 0 - but a status code proves the
+            # worker reached the tenant. Reading that as "the worker is broken" once disabled
+            # background execution for a whole session over one transient 502.
+            & $script:Dispatched.OnResult ([pscustomobject]@{
+                    Outcome = @{ ErrorRecord = (New-HttpErrorRecord -StatusCode 502 -Message "Bad Gateway"); CompletedSteps = 0; Log = @() }
+                    Context = @{ Caller = $script:Dispatched.Context }
+                })
+
+            $script:DisabledReason | Should -BeNullOrEmpty
+            $script:Received.RetryInline | Should -BeFalse
+        }
+
+        It "retries a 401 without disabling, because the UI thread can sign in" {
+            # Retry, not RetryAndDisable: the session expired, which says nothing about the worker.
+            # Once the UI thread has signed in, the worker has a session to inherit.
+            & $script:Dispatched.OnResult ([pscustomobject]@{
+                    Outcome = @{ ErrorRecord = (New-HttpErrorRecord -StatusCode 401 -Message "Unauthorized"); CompletedSteps = 0; Log = @() }
+                    Context = @{ Caller = $script:Dispatched.Context }
+                })
+
+            $script:Received.RetryInline | Should -BeTrue
+            $script:DisabledReason | Should -BeNullOrEmpty
+        }
+
+        It "asks Resolve-ExecuteFallbackAction rather than deciding for itself" {
+            # A source assertion, because the defect is a re-implementation rather than a wrong
+            # answer: a second copy of this reasoning would pass every behavioural test above on the
+            # day it was written and drift from the original afterwards.
+            $Private:Source = Get-Content -Path (Join-Path (Split-Path -Path $PSScriptRoot -Parent) "src\Lib\Functions\Private\Get-SqlTroubleShooterView.ps1") -Raw
+
+            $Private:Source | Should -Match 'Resolve-ExecuteFallbackAction -Outcome'
+            $Private:Source | Should -Not -Match 'CompletedSteps -eq 0'
         }
 
         It "hands the rows and the page over on success" {

--- a/tests/Update-DataConnectionList.Tests.ps1
+++ b/tests/Update-DataConnectionList.Tests.ps1
@@ -207,6 +207,15 @@ Describe "Update-DataConnectionList" {
             $script:Rendered[0].Html | Should -Be "<html>inline page</html>"
         }
 
+        It "reports a null row set as no rows, not as one row" {
+            # @($null).Count is 1, so the obvious wrapping answers "yes, there are rows" for none at
+            # all - and the renderer then reports a failed fetch and disables the dropdown. This is
+            # the worker-path twin of the empty-array bug on the inline path.
+            Invoke-Completion -Outcome (New-WorkerOutcome -Rows $null -CompletedSteps 2)
+
+            $script:Rendered[0].HasRows | Should -BeFalse
+        }
+
         It "reports no rows as no rows, not as a failed page fetch" {
             # The distinction the original code made and that both arrive here as a null page: a view
             # with no rows left the dropdown untouched and said nothing, a FAILED fetch warned and

--- a/tests/Update-DataConnectionList.Tests.ps1
+++ b/tests/Update-DataConnectionList.Tests.ps1
@@ -1,0 +1,345 @@
+#Requires -Version 7.0
+# Issue #90, slice A. Update-DataConnectionList was the worst of the blocking list refreshes - three
+# dependent round-trips on the UI thread, on connect and on tab materialisation.
+#
+# What is asserted here is the DECISION: dispatch or run inline, and which of the four outcomes the
+# completion turns into which UI action. The rendering itself (Complete-DataConnectionListUpdate)
+# creates WPF ComboBoxItems and so cannot run headlessly on CI; it is stubbed, and the E2E suite
+# covers the real thing.
+
+BeforeAll {
+    $ParentPath = Split-Path -Path $PSScriptRoot -Parent
+    $PrivatePath = Join-Path $ParentPath -ChildPath "src\Lib\Functions\Private"
+    . (Join-Path $PrivatePath -ChildPath "Get-SqlTroubleShooterView.ps1")
+    . (Join-Path $PrivatePath -ChildPath "Update-DataConnectionList.ps1")
+
+    $Script:Tracer = [System.Diagnostics.Trace]
+
+    $script:LogMessages = [System.Collections.Generic.List[object]]::new()
+    function Write-LogOutput {
+        param([Parameter(ValueFromPipeline = $true)]$InputObject, [string]$LogType, $ErrorObject, [switch]$SkipDialog, [switch]$TabScoped)
+        process { $script:LogMessages.Add([pscustomobject]@{ LogType = $LogType; Message = [string]$InputObject }) }
+    }
+
+    function ConvertTo-RedactedLogString { param($InputObject, $MaxDepth, [switch]$ShapeOnly) return "<redacted>" }
+    function Test-ConnectionRequirements { return $script:ConnectionReady }
+    function Get-ActiveTabSession { return $script:ActiveTab }
+    function Disable-OmadaBackgroundRequest { param($Reason) $script:DisabledReason = $Reason }
+    function Write-ExecutePipelineLog { param($Log) $script:ReplayedLog = $Log }
+    function Write-ContainedErrorLog { param([Parameter(ValueFromPipeline = $true)]$InputObject, $ErrorObject) process { } }
+
+    # The rendering, stubbed: it creates WPF ComboBoxItems, which CI's headless pwsh cannot resolve.
+    # Recorded rather than performed, so the tests assert what it was ASKED to do.
+    $script:Rendered = [System.Collections.Generic.List[object]]::new()
+    function Complete-DataConnectionListUpdate {
+        param($DataObjectHtml, [switch]$HasRows, [switch]$NotShowPopupWindow)
+        $script:Rendered.Add([pscustomobject]@{
+                Html               = $DataObjectHtml
+                HasRows            = [bool]$HasRows
+                NotShowPopupWindow = [bool]$NotShowPopupWindow
+                TabId              = $Script:ActiveTabIdForTest
+            })
+    }
+
+    # The inline path's two halves.
+    function Get-SqlTroubleShooterView { $script:InlineViewCalls++; return $script:InlineViewRows }
+    function Invoke-OmadaPSWebRequestWrapper { $script:InlinePageCalls++; return $script:InlinePage }
+
+    # Dispatch, stubbed: records what was asked for and hands back the completion block so a test can
+    # drive it with any outcome. $null models "not dispatched".
+    function Invoke-OmadaPSWebRequestWrapperAsync {
+        param([scriptblock]$OnResultScriptBlock, $Context, [hashtable]$PipelineContext, [string]$Description)
+        $script:Dispatched = [pscustomobject]@{
+            Description     = $Description
+            Context         = $Context
+            PipelineContext = $PipelineContext
+            OnResult        = $OnResultScriptBlock
+        }
+        if (-not $script:WorkerAvailable) {
+            return $null
+        }
+        return [pscustomobject]@{ Description = $Description; Context = @{ Caller = $Context }; TabSession = $script:ActiveTab }
+    }
+
+    function script:Initialize-TestState {
+        $script:LogMessages.Clear()
+        $script:Rendered.Clear()
+        $script:ConnectionReady = $true
+        $script:WorkerAvailable = $true
+        $script:Dispatched = $null
+        $script:DisabledReason = $null
+        $script:ReplayedLog = $null
+        $script:InlineViewCalls = 0
+        $script:InlinePageCalls = 0
+        $script:InlineViewRows = @([pscustomobject]@{ C_SQLQUERYDOID = "inline-doid" })
+        $script:InlinePage = "<html>inline page</html>"
+        $script:ActiveTab = [pscustomobject]@{ Id = "tab-1" }
+        $Script:ActiveTabIdForTest = "tab-1"
+        $Script:ConnectionStatus = $true
+        $Script:PendingWebViewCompletions = [System.Collections.Generic.List[object]]::new()
+        $Script:AppConfig = [pscustomobject]@{ BaseUrl = "https://tenant.omada.cloud" }
+        $Script:RunTimeData = [pscustomobject]@{
+            RestMethodParam                 = @{ SessionKey = "tab-1" }
+            DataobjdlgAspxAttributeMapping  = [pscustomobject]@{ SqlQueryDoId = "C_SQLQUERYDOID" }
+        }
+    }
+
+    # Drives the REAL chain: the block registered on the queue is Start-SqlTroubleShooterViewLookup's
+    # own completion, which classifies the worker's outcome and then calls the caller's block. Tests
+    # hand it a pipeline outcome, exactly as the poll timer would, rather than short-circuiting to
+    # the caller's block and proving nothing about the classification.
+    function script:Invoke-Completion {
+        param($Outcome, $Dispatch = $script:Dispatched)
+        & $Dispatch.OnResult ([pscustomobject]@{
+                Outcome = $Outcome
+                Context = @{ Caller = $Dispatch.Context }
+            })
+    }
+
+    function script:New-WorkerOutcome {
+        param($Rows = @(), $DataObjectHtml = $null, $CompletedSteps = 3, $ErrorMessage = $null)
+        return @{
+            Rows           = $Rows
+            DataObjectHtml = $DataObjectHtml
+            CompletedSteps = $CompletedSteps
+            Log            = @()
+            ErrorRecord    = $(if ($null -eq $ErrorMessage) { $null } else {
+                    [System.Management.Automation.ErrorRecord]::new([System.Exception]::new($ErrorMessage), "x", "NotSpecified", $null)
+                })
+        }
+    }
+}
+
+Describe "Update-DataConnectionList" {
+    BeforeEach { Initialize-TestState }
+
+    Context "Choosing between a worker and the UI thread" {
+        It "does not touch the tenant when the connection is not ready" {
+            $script:ConnectionReady = $false
+
+            Update-DataConnectionList
+
+            $script:Dispatched | Should -BeNullOrEmpty
+            $script:InlineViewCalls | Should -Be 0
+        }
+
+        It "dispatches one job, not three requests" {
+            # The whole point of the slice: three round-trips, one completion.
+            Update-DataConnectionList
+
+            $script:Dispatched.PipelineContext.PipelineFunction | Should -Be "Invoke-OmadaViewLookupPipeline"
+            $script:Dispatched.PipelineContext.IncludeDataObjectHtml | Should -BeTrue
+        }
+
+        It "does nothing on the UI thread once dispatched" {
+            Update-DataConnectionList
+
+            $script:InlineViewCalls | Should -Be 0
+            $script:InlinePageCalls | Should -Be 0
+            $script:Rendered.Count | Should -Be 0
+        }
+
+        It "runs the whole thing inline when no worker is available" {
+            # Exactly the pre-#90 behaviour, which is the fallback's entire contract.
+            $script:WorkerAvailable = $false
+
+            Update-DataConnectionList
+
+            $script:InlineViewCalls | Should -Be 1
+            $script:InlinePageCalls | Should -Be 1
+            $script:Rendered[0].Html | Should -Be "<html>inline page</html>"
+        }
+
+        It "tells the worker which row property holds the data object id" {
+            # The attribute mapping is UI-thread state; a worker runspace has none, so it has to
+            # travel on the context or the third step opens DOID= nothing.
+            Update-DataConnectionList
+
+            $script:Dispatched.PipelineContext.SqlQueryDoIdField | Should -Be "C_SQLQUERYDOID"
+        }
+    }
+
+    Context "What the completion does with each outcome" {
+        BeforeEach { Update-DataConnectionList }
+
+        It "renders the page the worker fetched" {
+            Invoke-Completion -Outcome (New-WorkerOutcome -Rows @([pscustomobject]@{ Id = 1 }) -DataObjectHtml "<html>worker page</html>")
+
+            $script:Rendered[0].Html | Should -Be "<html>worker page</html>"
+            $script:Rendered[0].HasRows | Should -BeTrue
+        }
+
+        It "runs the caller's own inline path when the worker could not do the job" {
+            # RetryInline rather than a second copy of the inline path inside the lookup helper.
+            Invoke-Completion -Outcome (New-WorkerOutcome -CompletedSteps 0 -ErrorMessage "no session")
+
+            $script:InlineViewCalls | Should -Be 1
+            $script:InlinePageCalls | Should -Be 1
+            $script:Rendered[0].Html | Should -Be "<html>inline page</html>"
+        }
+
+        It "reports no rows as no rows, not as a failed page fetch" {
+            # The distinction the original code made and that both arrive here as a null page: a view
+            # with no rows left the dropdown untouched and said nothing, a FAILED fetch warned and
+            # disabled the controls.
+            Invoke-Completion -Outcome (New-WorkerOutcome -Rows @() -CompletedSteps 2)
+
+            $script:Rendered[0].HasRows | Should -BeFalse
+        }
+
+        It "carries this call's popup preference, not whatever the active tab wants now" {
+            Initialize-TestState
+            Update-DataConnectionList -NotShowPopupWindow
+
+            Invoke-Completion -Outcome (New-WorkerOutcome -Rows @([pscustomobject]@{ Id = 1 }) -DataObjectHtml "<html>x</html>")
+
+            $script:Rendered[0].NotShowPopupWindow | Should -BeTrue
+        }
+    }
+}
+
+Describe "Start-SqlTroubleShooterViewLookup" {
+    BeforeEach { Initialize-TestState }
+
+    It "does not ask for the same lookup twice for one tab" {
+        # Update-DataConnectionList and Update-QueryList are called one after the other on connect,
+        # and the answer is the same for both.
+        $Script:PendingWebViewCompletions.Add([pscustomobject]@{
+                Description = $Script:SqlTroubleShooterViewRequestDescription
+                TabSession  = [pscustomobject]@{ Id = "tab-1" }
+            })
+
+        $Private:Pending = Start-SqlTroubleShooterViewLookup -OnResultScriptBlock { } -Context @{}
+
+        $Private:Pending | Should -BeNullOrEmpty
+        $script:Dispatched | Should -BeNullOrEmpty
+    }
+
+    It "does ask when the outstanding lookup belongs to another tab" {
+        # Per tab, not per session: each tab has its own connection and its own dropdown to fill.
+        $Script:PendingWebViewCompletions.Add([pscustomobject]@{
+                Description = $Script:SqlTroubleShooterViewRequestDescription
+                TabSession  = [pscustomobject]@{ Id = "tab-2" }
+            })
+
+        $null = Start-SqlTroubleShooterViewLookup -OnResultScriptBlock { } -Context @{}
+
+        $script:Dispatched | Should -Not -BeNullOrEmpty
+    }
+
+    It "leaves the third step out when the caller does not want it" {
+        $null = Start-SqlTroubleShooterViewLookup -OnResultScriptBlock { } -Context @{}
+
+        $script:Dispatched.PipelineContext.IncludeDataObjectHtml | Should -BeFalse
+    }
+
+    Context "Classifying what came back" {
+        BeforeEach {
+            $script:Received = $null
+            $null = Start-SqlTroubleShooterViewLookup -OnResultScriptBlock {
+                param($Result, $CallerContext)
+                $script:Received = $Result
+            } -Context @{}
+        }
+
+        It "asks for an inline retry when the worker never reached the tenant" {
+            & $script:Dispatched.OnResult ([pscustomobject]@{
+                    Outcome = @{ ErrorRecord = [System.Management.Automation.ErrorRecord]::new([System.Exception]::new("no session"), "x", "NotSpecified", $null); CompletedSteps = 0; Log = @() }
+                    Context = @{ Caller = $script:Dispatched.Context }
+                })
+
+            $script:Received.RetryInline | Should -BeTrue
+            $script:DisabledReason | Should -Be "no session"
+        }
+
+        It "does NOT retry when the tenant answered and then refused" {
+            # CompletedSteps is what separates the two. A tenant that answered will answer the same
+            # way again, so retrying it inline just costs the user another round-trip.
+            & $script:Dispatched.OnResult ([pscustomobject]@{
+                    Outcome = @{ ErrorRecord = [System.Management.Automation.ErrorRecord]::new([System.Exception]::new("forbidden"), "x", "NotSpecified", $null); CompletedSteps = 1; Log = @() }
+                    Context = @{ Caller = $script:Dispatched.Context }
+                })
+
+            $script:Received.RetryInline | Should -BeFalse
+            $script:Received.Rows | Should -BeNullOrEmpty
+            $script:DisabledReason | Should -BeNullOrEmpty
+        }
+
+        It "hands the rows and the page over on success" {
+            & $script:Dispatched.OnResult ([pscustomobject]@{
+                    Outcome = @{ Rows = @([pscustomobject]@{ Id = 5 }); DataObjectHtml = "<html>ok</html>"; ErrorRecord = $null; CompletedSteps = 3; Log = @() }
+                    Context = @{ Caller = $script:Dispatched.Context }
+                })
+
+            $script:Received.RetryInline | Should -BeFalse
+            $script:Received.DataObjectHtml | Should -Be "<html>ok</html>"
+            @($script:Received.Rows).Count | Should -Be 1
+        }
+
+        It "replays what the worker would have logged" {
+            # A worker cannot log. Without the replay, moving these requests off the UI thread would
+            # silently cost the application the lines it has always written for them - which for a
+            # troubleshooting tool is the point of the tool.
+            & $script:Dispatched.OnResult ([pscustomobject]@{
+                    Outcome = @{ Rows = @(); ErrorRecord = $null; CompletedSteps = 2; Log = @(@{ Level = "DEBUG"; Text = "QueryUrl: https://x" }) }
+                    Context = @{ Caller = $script:Dispatched.Context }
+                })
+
+            @($script:ReplayedLog).Count | Should -Be 1
+        }
+    }
+}
+
+Describe "Two tabs with a lookup in flight" {
+    # Issue #90's own criterion: every completion resolves against the tab that started the work.
+    # Set-ActiveTabContext repoints $Script:MainForm.Elements and friends between dispatch and
+    # completion, so a completion that re-reads ambient state renders into whichever tab happens to
+    # be on screen.
+    BeforeEach { Initialize-TestState }
+
+    It "renders each tab's answer into that tab" {
+        # Tab 1 dispatches...
+        $Script:ActiveTabIdForTest = "tab-1"
+        $script:ActiveTab = [pscustomobject]@{ Id = "tab-1" }
+        Update-DataConnectionList
+        $Private:TabOneCompletion = $script:Dispatched
+
+        # ...then tab 2 becomes the active context and dispatches its own.
+        $Script:ActiveTabIdForTest = "tab-2"
+        $script:ActiveTab = [pscustomobject]@{ Id = "tab-2" }
+        Update-DataConnectionList -NotShowPopupWindow
+        $Private:TabTwoCompletion = $script:Dispatched
+
+        # The poll timer makes the owning tab active before running a completion. Tab 1's lands while
+        # tab 2 is on screen, which is the case that used to render into the wrong tab.
+        $Script:ActiveTabIdForTest = "tab-1"
+        Invoke-Completion -Dispatch $Private:TabOneCompletion -Outcome (New-WorkerOutcome -Rows @([pscustomobject]@{ Id = 1 }) -DataObjectHtml "<html>one</html>")
+
+        $Script:ActiveTabIdForTest = "tab-2"
+        Invoke-Completion -Dispatch $Private:TabTwoCompletion -Outcome (New-WorkerOutcome -Rows @([pscustomobject]@{ Id = 2 }) -DataObjectHtml "<html>two</html>")
+
+        $script:Rendered.Count | Should -Be 2
+        ($script:Rendered | Where-Object { $_.TabId -eq "tab-1" }).Html | Should -Be "<html>one</html>"
+        ($script:Rendered | Where-Object { $_.TabId -eq "tab-2" }).Html | Should -Be "<html>two</html>"
+    }
+
+    It "keeps each tab's popup preference with its own completion" {
+        # The parameter that would be re-read from ambient state if it were not carried: tab 1 wants
+        # the popup, tab 2 does not.
+        $script:ActiveTab = [pscustomobject]@{ Id = "tab-1" }
+        Update-DataConnectionList
+        $Private:TabOne = $script:Dispatched
+
+        $script:ActiveTab = [pscustomobject]@{ Id = "tab-2" }
+        Update-DataConnectionList -NotShowPopupWindow
+        $Private:TabTwo = $script:Dispatched
+
+        # Out of dispatch order deliberately: nothing guarantees the workers finish in the order they
+        # were started.
+        Invoke-Completion -Dispatch $Private:TabTwo -Outcome (New-WorkerOutcome -Rows @(1) -DataObjectHtml "<html>two</html>")
+        Invoke-Completion -Dispatch $Private:TabOne -Outcome (New-WorkerOutcome -Rows @(1) -DataObjectHtml "<html>one</html>")
+
+        ($script:Rendered | Where-Object { $_.Html -eq "<html>one</html>" }).NotShowPopupWindow | Should -BeFalse
+        ($script:Rendered | Where-Object { $_.Html -eq "<html>two</html>" }).NotShowPopupWindow | Should -BeTrue
+    }
+}

--- a/tests/Update-DataConnectionList.Tests.ps1
+++ b/tests/Update-DataConnectionList.Tests.ps1
@@ -151,8 +151,10 @@ Describe "Update-DataConnectionList" {
         }
 
         It "treats a view that exists but holds no rows as no rows, without throwing" {
-            # An empty view comes back as an empty ARRAY, which is not $null - and indexing [0] into
-            # it throws under StrictMode, so the intended outcome would have arrived as an error.
+            # An empty view comes back as an empty ARRAY, which is not $null, so a null check let it
+            # through. Nothing throws (this codebase never enables Set-StrictMode) - it sent a
+            # request with no DOID and reported the answer as a failed fetch, which disables the
+            # dropdown. Hence the assertion that no page request is made at all.
             $script:WorkerAvailable = $false
             $script:InlineViewRows = @()
 

--- a/tests/Update-DataConnectionList.Tests.ps1
+++ b/tests/Update-DataConnectionList.Tests.ps1
@@ -166,6 +166,20 @@ Describe "Update-DataConnectionList" {
             $script:Rendered[0].Html | Should -Be "<html>inline page</html>"
         }
 
+        It "treats a NULL row set from the inline lookup as no rows" {
+            # The third appearance of @($null).Count -eq 1 in this change, and the one that survived
+            # the first fix: a jqGrid payload for an empty view has a null .d.Rows, so the inline
+            # lookup returned $null, the count said 1, and the request went out as "DOID=" with no id
+            # - reported back as a failed fetch, disabling the dropdown.
+            $script:WorkerAvailable = $false
+            $script:InlineViewRows = $null
+
+            Update-DataConnectionList
+
+            $script:Rendered[0].HasRows | Should -BeFalse
+            $script:InlinePageCalls | Should -Be 0
+        }
+
         It "treats a view that exists but holds no rows as no rows, without throwing" {
             # An empty view comes back as an empty ARRAY, which is not $null, so a null check let it
             # through. Nothing throws (this codebase never enables Set-StrictMode) - it sent a

--- a/tests/e2e/OmadaMocks.ps1
+++ b/tests/e2e/OmadaMocks.ps1
@@ -88,15 +88,23 @@ function script:Start-OmadaBackgroundRequest {
     $Payload = @{ Result = $null; ErrorRecord = $null }
 
     if ($null -ne $PipelineContext) {
-        # C1-5: the worker runs the whole dependent chain. The REAL Invoke-OmadaExecutePipeline is
-        # used here, on the UI thread, because it is runspace-safe and therefore also
-        # dispatcher-safe - so the scenarios exercise the actual sequencing, the actual step
-        # decisions and the actual temporary-object clean-up. Only the transport under it is the
-        # fixture, via Invoke-OmadaRequestCore's seam below.
+        # C1-5: the worker runs the whole dependent chain. The REAL pipeline is used here, on the UI
+        # thread, because it is runspace-safe and therefore also dispatcher-safe - so the scenarios
+        # exercise the actual sequencing, the actual step decisions and the actual temporary-object
+        # clean-up. Only the transport under it is the fixture, via Invoke-OmadaRequestCore's seam
+        # below.
+        #
+        # WHICH pipeline comes from the context, mirroring the real Start-OmadaBackgroundRequest
+        # (issue #90). Hard-coding the execute pipeline here made every OTHER chain silently run the
+        # execute one instead: the view lookup came back with an execute-shaped outcome, so the data
+        # connection dropdown was never populated and the failure looked like a defect in the code
+        # under test rather than in this stand-in.
+        $Private:PipelineFunction = Get-OmadaPipelineWorkerFunction -PipelineContext $PipelineContext
+
         $PipelineContext = $PipelineContext.Clone()
         $PipelineContext.Parameters = $Parameters.Clone()
         $PipelineContext.Progress = $Progress
-        $PipelineOutcome = Invoke-OmadaExecutePipeline -Context $PipelineContext
+        $PipelineOutcome = & $Private:PipelineFunction -Context $PipelineContext
         $Payload.Result = $PipelineOutcome
         $Payload.ErrorRecord = $PipelineOutcome.ErrorRecord
     }

--- a/tests/e2e/scenarios/Core.ps1
+++ b/tests/e2e/scenarios/Core.ps1
@@ -7,7 +7,10 @@ E2ESuite -Name "Connect" -Body {
         Reset-E2EConnection
 
         Set-E2EConnectionFields
-        Invoke-E2EConnect
+        # AndWait since issue #90: the data connection list is fetched on a background worker now, so
+        # the dropdown this case asserts on is populated by a completion rather than before the click
+        # returns. The same reason Invoke-E2EConnectAndWait was added for the schema fetch in #40.
+        Invoke-E2EConnectAndWait
 
         $Elements = Get-E2EElements
         E2EAssertTrue $Script:ConnectionStatus "ConnectionStatus should be true after a successful connect"
@@ -22,7 +25,9 @@ E2ESuite -Name "Execute" -Body {
         Reset-E2EScenario
         Reset-E2EConnection
         Set-E2EConnectionFields
-        Invoke-E2EConnect
+        # AndWait since issue #90: connect's list fetches land on completions now, and one arriving
+        # mid-execute is exactly what "exactly one execute should have fired" is there to catch.
+        Invoke-E2EConnectAndWait
 
         $Item = Select-E2EQuery
         E2EAssertTrue ($null -ne $Item) "Query item 'TestQuery - 100' should exist in the dropdown"

--- a/tests/e2e/scenarios/Regression.ps1
+++ b/tests/e2e/scenarios/Regression.ps1
@@ -82,7 +82,9 @@ E2ESuite -Name "SchemaCache" -Body {
     E2ECase -Name "picking a data connection in the ComboBox retrieves the schema without the schema window" -Body {
         Reset-E2ETabsToOne
         Set-E2EConnectionFields
-        Invoke-E2EConnect
+        # AndWait since issue #90: this case reads the data connection dropdown, which is populated
+        # by a completion now rather than before the click returns.
+        Invoke-E2EConnectAndWait
 
         $Script:TreeViewSqlSchema = $null
         $Script:SqlSchemaForm = $null


### PR DESCRIPTION
Part of #90 (slice A of four). Not `Closes` — the remaining callers land in later slices.

`Update-DataConnectionList` was the worst of the blocking list refreshes: **three dependent round-trips on the UI thread**, on connect and on tab materialisation, which is where the window visibly froze.

| Round-trip | Where |
|---|---|
| Find the "SQL Troubleshooting" view | `Get-SqlTroubleShooterView.ps1:6` |
| Fetch its rows | `Get-SqlTroubleShooterView.ps1:20` |
| GET `dataobjdlg.aspx` for the first row | `Update-DataConnectionList.ps1:19` |

All three now run on a worker as **one job**.

## Why the issue's slice order was inverted

Two of those three are `Get-SqlTroubleShooterView`'s, and the issue listed that function's caller in slice 1 while the paging call underneath it was slice 2. Doing slice 1 literally would have taken this caller from three blocking round-trips to two — and the criterion *"refreshing the data connection list does not freeze the window"* would have read as met while it was not. Recorded on #90 along with the revised slice table.

## One job, not three completions

Two chained completions would work and it is deliberately not what this is. Between completions `Set-ActiveTabContext` can repoint `$Script:MainForm.Elements`, `$Script:RunTimeData` and `$Script:AppConfig` onto another tab — which #90 names as the dominant risk of this whole slice. **One job means one completion, so the risk is removed rather than managed.** Two is a smaller version of that defect, not a different one; it is the reasoning `Invoke-OmadaExecutePipeline` was written on for the execute chain.

| New | What it is |
|---|---|
| `New-OmadaPagingRequest` | Runspace-safe builder for a GetPagingData request. Used by `Get-OmadaGetPagingDataObject` too, so the inline and worker paths cannot drift |
| `Invoke-OmadaViewLookupPipeline` | The chain: find view → fetch rows → (optionally) fetch the data connection page |
| `Get-OmadaPipelineWorkerFunction` / `-File` | Which chain a worker runs, and what it must dot-source |
| `Start-SqlTroubleShooterViewLookup` | Dispatch, with `Invoke-OmadaPSWebRequestWrapperAsync`'s `$null`-means-run-inline contract |
| `Complete-DataConnectionListUpdate` | The rendering, split out so it runs unchanged either way |

## Decisions worth reviewing

- **Which chain a worker runs is now data on the pipeline context**, defaulting to the execute pipeline so #40's dispatch is unchanged by its absence. `Start-OmadaBackgroundRequest` hard-coded `Invoke-OmadaExecutePipeline` before.
- **That answer comes from one pair of functions, not three copies of an `if`.** Three places need it — the pre-flight file check, the dispatch, and the E2E harness's stand-in for the worker. See below; they disagreed once already.
- **`RetryInline` rather than retrying inside the lookup helper.** The caller's synchronous path is more than the lookup (`Update-DataConnectionList` follows it with its own request) and already exists for the not-dispatched case, so the completion sends the caller down that same path instead of keeping a second copy.
- **`CompletedSteps` decides whether to retry at all.** "Could not reach the tenant" is worth one inline retry; "the tenant answered and refused" is not — it will answer the same way again.
- **A view with no rows is not a failed fetch.** The original entered its whole body only when the view returned rows, so an empty view left the dropdown untouched and said nothing, whereas a failed page fetch warned and disabled the controls. Both arrive at the renderer as a null page, so the distinction travels beside it rather than being inferred.
- **The worker's log is replayed on the UI thread.** A worker cannot log, and redaction is a UI-thread function; without the replay these two requests would silently stop appearing in the log, which for a troubleshooting tool is the point of the tool.

## `Test-OmadaConnection` is out of scope, by design

It cannot go off-thread and will not in a later slice either. `Test-OmadaBackgroundRequestEligible` refuses any request until `$Script:ConnectionStatus` is true, and `Test-OmadaConnection` is the call that *makes* it true — both its call sites reach it while the tab still counts as disconnected. Dispatching it would always fall straight back to the inline path: dead code that looks like a fix. It is also the call that can open the interactive login, which #40 deliberately pins to the UI thread. Recorded on #90.

## Two bugs this slice found, both worth reading

**The E2E harness replaces `Start-OmadaBackgroundRequest` and hard-coded the execute pipeline.** So the view lookup dispatched correctly and came back with an execute-shaped outcome — `QueryResult`, `SaveResult`, `TempQueryDoId` and no rows. The dropdown was never populated, and the failure looked exactly like a defect in the code under test. Two E2E scenarios failed for what appeared to be a real regression and was in fact the stand-in for the worker. It now resolves the chain through the same helper the real dispatch uses.

**The pre-flight file check had the same bug in the other direction.** It required the execute pipeline's two files whatever the chain was, so a second chain's files were never checked — dispatching a worker that would then fail on its first line, which is the one thing that guard exists to prevent. Now checks the chain's own files.

## Tests

- `Invoke-OmadaViewLookupPipeline.Tests.ps1` — the order and shape of each request against a recording transport, both failure paths, `CompletedSteps`, and the runspace-safety scan
- `New-OmadaPagingRequest.Tests.ps1` — including that `sidx` and `searchString` move together, and the constant `nd`
- `Get-OmadaPipelineWorkerFunction.Tests.ps1` — including that all three callers ask the same question, which is the regression above
- `Update-DataConnectionList.Tests.ps1` — dispatch vs inline, all four completion outcomes, and **two tabs with a lookup in flight**, completing out of order, each rendering into its own tab (#90's explicit criterion)

Two E2E scenarios now use `Invoke-E2EConnectAndWait`, because the dropdown they assert on is populated by a completion rather than before the click returns. That helper exists for exactly this reason from #40's schema fetch.

The renderer creates WPF `ComboBoxItem`s and cannot run headlessly on CI, so it is stubbed in the unit tests and covered for real by E2E.

## Verification

```
./build/build.ps1 -Task TestBuildOnly   ->  1032 tests, 0 failed; PSScriptAnalyzer clean
./build/build.ps1 -Task E2E             ->    54 tests, 0 failed
```

## Survey

No duplicates or conflicts; searched async/UI-thread/freeze and list-refresh terms, checked cross-references and `git log --grep` on `origin/main`. #40 is the parent; #45 (F1) targets some of the same legacy endpoints but is a different concern.
