### PR TITLE
Ship the files a background worker loads, so the released module actually uses one

### DIFF
--- a/build/psakeBuild.ps1
+++ b/build/psakeBuild.ps1
@@ -414,6 +414,43 @@ Task Build -Depends Test, Dependencies, TestAssemblies {
         }
         (Get-Content (Join-Path $OutputDir -ChildPath $TargetFilePath) -Raw) -replace "(\r?\n\s*){3,}", "`r`n" -replace "`r?`n", "`r`n" | Invoke-Formatter -Settings $FormattingSettings | Set-Content -Path (Join-Path $OutputDir -ChildPath $TargetFilePath) -Encoding UTF8 -Force
 
+        # The background worker's own copy of the functions it dot-sources, shipped as FILES.
+        #
+        # This is not a duplicate of the merge above, because it is not for the same runspace. A
+        # worker imports OmadaWeb.PS and nothing else - it has never loaded this module, so nothing
+        # merged into the psm1 exists there, and it loads what it needs from disk by path
+        # (Start-OmadaBackgroundRequest). Without these files the pre-flight check fails, every
+        # dispatch falls back to the UI thread, and background execution, the Cancel button and the
+        # live elapsed time are all silently absent from the released module.
+        #
+        # AFTER the functions merge, deliberately: that step empties lib\functions recursively before
+        # writing, so copying earlier would delete these again.
+        #
+        # The list comes from the module's own chain table rather than being maintained here, so a
+        # chain that can be dispatched is shippable by construction. Dot-sourced rather than parsed:
+        # the file holds function definitions and that table, and nothing else.
+        "Copy background worker functions" | Write-Host
+        . (Join-Path $ModuleSource -ChildPath "lib\functions\private\Get-OmadaPipelineWorkerFunction.ps1")
+        $WorkerTargetPath = Join-Path $OutputDir -ChildPath "Lib\Functions\Private"
+        New-Item $WorkerTargetPath -ItemType Directory -Force | Out-Null
+        foreach ($WorkerFile in (Get-OmadaWorkerRuntimeFile)) {
+            $WorkerSourcePath = Join-Path $ModuleSource -ChildPath ("lib\functions\private\{0}" -f $WorkerFile)
+            if (-not (Test-Path $WorkerSourcePath -PathType Leaf)) {
+                "Background worker file '{0}' is named by the chain table but does not exist at '{1}'." -f $WorkerFile, $WorkerSourcePath | Write-Error -ErrorAction Stop
+            }
+            Copy-Item -Path $WorkerSourcePath -Destination (Join-Path $WorkerTargetPath -ChildPath $WorkerFile) -Force
+        }
+
+        # A post-condition, like the dependency lock's above and for the same reason: a package that
+        # is missing these starts perfectly well and quietly does less. The failure this guards
+        # against shipped once already, so it fails the BUILD rather than waiting to be noticed.
+        foreach ($WorkerFile in (Get-OmadaWorkerRuntimeFile)) {
+            $WorkerOutputPath = Join-Path $WorkerTargetPath -ChildPath $WorkerFile
+            if (-not (Test-Path $WorkerOutputPath -PathType Leaf)) {
+                "Background worker file '{0}' was not copied to '{1}'. The published module would run every query on the UI thread, with no Cancel button and no elapsed time." -f $WorkerFile, $WorkerTargetPath | Write-Error -ErrorAction Stop
+            }
+        }
+
         $LibSource = "events"
         $SourceChildPath = "lib\{0}" -f $LibSource
         $TargetChildPath = "lib\{0}" -f $LibSource

--- a/src/Lib/Functions/Private/Get-OmadaPipelineWorkerFunction.ps1
+++ b/src/Lib/Functions/Private/Get-OmadaPipelineWorkerFunction.ps1
@@ -7,6 +7,55 @@
 # during this slice: the harness answered "execute pipeline" while the dispatch answered "view
 # lookup", so the view lookup came back with an execute-shaped outcome and the failure looked like a
 # defect in the code under test.
+#
+# There turned out to be a FOURTH consumer, and missing it cost the whole feature: the BUILD. A worker
+# runspace imports OmadaWeb.PS and nothing else, so it has never loaded this module and cannot see any
+# function merged into the psm1 - which is why it dot-sources these files from disk instead. The
+# package shipped without them, so every dispatch failed its pre-flight check and fell back to the UI
+# thread. Background execution, the Cancel button and the live elapsed time were all absent from the
+# released module while passing every test, because dev and E2E both run from src/.
+#
+# So the chains are declared here, once, and the build reads this file to know what to ship. Adding a
+# chain to this table is what makes it shippable; there is no second list to remember.
+$Script:OmadaWorkerChainFile = [ordered]@{
+    "Invoke-OmadaExecutePipeline"    = @("New-OmadaQueryRequest.ps1", "Invoke-OmadaExecutePipeline.ps1")
+    "Invoke-OmadaViewLookupPipeline" = @("New-OmadaPagingRequest.ps1", "Invoke-OmadaViewLookupPipeline.ps1")
+}
+
+# Dot-sourced by every worker, whatever chain it runs - it is the one statement that actually talks to
+# Omada.
+$Script:OmadaWorkerCoreFile = "Invoke-OmadaRequestCore.ps1"
+
+function Get-OmadaWorkerRuntimeFile {
+    <#
+    .SYNOPSIS
+    Every file a background worker can need, for any chain.
+
+    .DESCRIPTION
+    The build's shipping list, and the thing a post-condition checks against the built package. Read
+    from the same table the dispatch resolves chains through, so a chain that is dispatchable is
+    shippable by construction rather than by someone remembering both.
+
+    .OUTPUTS
+    [string[]] file names relative to Lib\Functions\Private, without duplicates.
+    #>
+    [CmdletBinding()]
+    [OutputType([string[]])]
+    param()
+
+    $Private:Files = [System.Collections.Generic.List[string]]::new()
+    $Private:Files.Add($Script:OmadaWorkerCoreFile)
+
+    foreach ($Private:Chain in $Script:OmadaWorkerChainFile.Keys) {
+        foreach ($Private:File in $Script:OmadaWorkerChainFile[$Private:Chain]) {
+            if (-not $Private:Files.Contains($Private:File)) {
+                $Private:Files.Add($Private:File)
+            }
+        }
+    }
+
+    return $Private:Files.ToArray()
+}
 
 function Get-OmadaPipelineWorkerFunction {
     <#
@@ -64,7 +113,9 @@ function Get-OmadaPipelineWorkerFile {
         }
     }
 
-    return @("New-OmadaQueryRequest.ps1", "Invoke-OmadaExecutePipeline.ps1")
+    # From the table rather than repeated here: the default is a chain like any other, and a second
+    # copy of its file list is a second thing to update when it changes.
+    return @($Script:OmadaWorkerChainFile["Invoke-OmadaExecutePipeline"])
 }
 
 function Test-OmadaPipelineWorkerChain {

--- a/tests/Get-OmadaPipelineWorkerFunction.Tests.ps1
+++ b/tests/Get-OmadaPipelineWorkerFunction.Tests.ps1
@@ -111,6 +111,85 @@ Describe "Get-OmadaPipelineWorkerFile" {
     }
 }
 
+Describe "Get-OmadaWorkerRuntimeFile" {
+    # The list the BUILD ships. A worker runspace imports OmadaWeb.PS and nothing else, so it cannot
+    # see anything merged into the psm1 and loads these from disk by path. The package shipped
+    # without them once: every dispatch failed its pre-flight check and fell back to the UI thread,
+    # so background execution, the Cancel button and the live elapsed time were all absent from the
+    # released module while every test passed - because dev and E2E both run from src/.
+    It "includes the core, which every worker dot-sources whatever chain it runs" {
+        Get-OmadaWorkerRuntimeFile | Should -Contain "Invoke-OmadaRequestCore.ps1"
+    }
+
+    It "includes every file of <_>" -ForEach @("Invoke-OmadaExecutePipeline", "Invoke-OmadaViewLookupPipeline") {
+        $Private:Shipped = Get-OmadaWorkerRuntimeFile
+
+        foreach ($Private:File in (Get-OmadaPipelineWorkerFile -PipelineContext @{ PipelineFunction = $_; PipelineFiles = $null })) {
+            $Private:Shipped | Should -Contain $Private:File
+        }
+    }
+
+    It "covers the view lookup's chain, which is the one the default list does not" {
+        # The regression guard with teeth: the default chain would ship anyway. A SECOND chain is
+        # what a hand-maintained list forgets.
+        Get-OmadaWorkerRuntimeFile | Should -Contain "Invoke-OmadaViewLookupPipeline.ps1"
+        Get-OmadaWorkerRuntimeFile | Should -Contain "New-OmadaPagingRequest.ps1"
+    }
+
+    It "lists each file once, however many chains name it" {
+        $Private:Shipped = @(Get-OmadaWorkerRuntimeFile)
+
+        ($Private:Shipped | Select-Object -Unique).Count | Should -Be $Private:Shipped.Count
+    }
+
+    It "names only files that exist in source" {
+        foreach ($Private:File in (Get-OmadaWorkerRuntimeFile)) {
+            Join-Path $script:PrivatePath $Private:File | Should -Exist
+        }
+    }
+
+    It "is where the default chain's file list comes from, rather than a second copy" {
+        # If these ever diverge, the dispatch loads one thing and the build ships another.
+        Get-OmadaPipelineWorkerFile -PipelineContext $null | Should -Be $Script:OmadaWorkerChainFile["Invoke-OmadaExecutePipeline"]
+    }
+}
+
+Describe "The build ships what a worker loads" {
+    # Asserted on the build script, because the build has not run when this suite does - the psake
+    # chain is Analyze, Test, Build. The real guard is the post-condition INSIDE the build, which
+    # fails it outright; this makes sure that guard, and the copy it guards, still exist.
+    BeforeAll {
+        $script:BuildScript = Get-Content -Path (Join-Path (Split-Path -Path $PSScriptRoot -Parent) "build\psakeBuild.ps1") -Raw
+    }
+
+    It "copies the worker's files into the package" {
+        $script:BuildScript | Should -Match 'Copy background worker functions'
+        $script:BuildScript | Should -Match 'Get-OmadaWorkerRuntimeFile'
+    }
+
+    It "takes the list from the module rather than repeating it in the build" {
+        # A hand-maintained copy here is the thing that silently stops matching the code.
+        $script:BuildScript | Should -Match 'Get-OmadaPipelineWorkerFunction\.ps1'
+        $script:BuildScript | Should -Not -Match 'Invoke-OmadaViewLookupPipeline\.ps1"'
+    }
+
+    It "fails the build when a file did not make it into the package" {
+        # Not a warning: a package missing these starts perfectly well and quietly does less, which
+        # is exactly how this shipped unnoticed.
+        $script:BuildScript | Should -Match 'was not copied to .+The published module would run every query on the UI thread'
+    }
+
+    It "copies after the functions merge, which empties that folder" {
+        # Ordering is load-bearing: the merge deletes lib\functions recursively before writing, so a
+        # copy placed earlier is deleted again and the bug comes back looking like a build flake.
+        $Private:MergeAt = $script:BuildScript.IndexOf('$LibSource = "functions"')
+        $Private:CopyAt = $script:BuildScript.IndexOf('Copy background worker functions')
+
+        $Private:MergeAt | Should -BeGreaterThan 0
+        $Private:CopyAt | Should -BeGreaterThan $Private:MergeAt
+    }
+}
+
 Describe "Everyone asks the same question" {
     # The regression that made these functions necessary. Each of the three places must go through
     # them rather than deciding for itself.


### PR DESCRIPTION
Reported from a live log against the installed **2026.9.10**:

```
Background worker file 'Invoke-OmadaRequestCore.ps1' not found under
'...\Modules\OmadaSqlTroubleShooter\2026.9.10\Lib\Functions\Private'; running on the UI thread instead.
```

The package does not contain those files, so the pre-flight check refused **every** dispatch and every query ran on the UI thread. #40 shipped inert.

Three symptoms, one cause:

| Symptom | Why |
|---|---|
| Queries still freeze the window | the chain runs inline (`Invoke-ExecuteQuery.ps1:110-114`) |
| **No Cancel button** | `$Private:Pending` is `$null`, so `Set-ExecuteQueryButtonState` is never reached; `Get-ActiveExecuteQueryRequest` reads the completion queue, and nothing was ever enqueued |
| **Status bar timer stuck at zero** | `Update-BackgroundRequestElapsedTime` ticks queue items — there are none. The final value still appears, because `Reset-ExecuteQueryUiState` writes it once at the end, so it jumps from `00:00:00.0` straight to the total |

## Why the existing merge does not already cover this

The build merges `Private/*.ps1` into the `psm1`, which makes this look like it should already work. It does not, because **they are different runspaces**:

| | Main runspace | Worker runspace |
|---|---|---|
| Imports | `OmadaSqlTroubleShooter` (+ OmadaWeb.PS) | **OmadaWeb.PS only** — `Initialize-OmadaRequestPool.ps1:56-58` |
| Sees the merged `psm1` | yes | **no** |
| Loads code by | module import | dot-sourcing `.ps1` files by path |

A worker has never loaded this module, so nothing merged into the `psm1` exists there. The merge serves the runspace the worker is not.

**Why no test caught it:** dev and E2E both run from `src/`, where those files sit next to the module. 1000-odd unit tests and a full E2E suite passed against a layout the released package does not have.

## The fix

Ship the five files a worker can load — **37 KB**, next to the 629 KB merged file already in the package.

The list is **not maintained in the build**. The chains are declared once in the module and `Get-OmadaWorkerRuntimeFile` reads that table, so a chain that can be dispatched is shippable by construction rather than by someone remembering two places. `Get-OmadaPipelineWorkerFile`'s default now reads the same table instead of repeating its file list.

```powershell
$Script:OmadaWorkerChainFile = [ordered]@{
    "Invoke-OmadaExecutePipeline"    = @("New-OmadaQueryRequest.ps1", "Invoke-OmadaExecutePipeline.ps1")
    "Invoke-OmadaViewLookupPipeline" = @("New-OmadaPagingRequest.ps1", "Invoke-OmadaViewLookupPipeline.ps1")
}
```

## Decisions worth reviewing

- **Ship the files rather than point the worker at the merged `functions.ps1`.** That file would work — all five functions are in it — but it is 629 KB, 231 functions and **22 top-level `$Script:` statements**, parsed and executed per worker, up to 8 workers, in runspaces those statements were never written for.
- **A build post-condition, not a warning.** It fails the build outright, like the dependency lock's. A package missing these starts perfectly well and quietly does less, which is precisely how this shipped unnoticed.
- **Copied AFTER the functions merge.** That step empties `lib\functions` recursively before writing, so a copy placed earlier is deleted again and the bug returns looking like a build flake. A test asserts the ordering, because it is load-bearing and invisible.
- **The build dot-sources the module's chain table rather than parsing it.** The file holds function definitions and that table and nothing else, so dot-sourcing it is cheaper and more honest than a regex over source.

## Verification

Beyond the suites, I loaded the **packaged** files into a real MTA runspace that imports only OmadaWeb.PS — reproducing exactly what `Start-OmadaBackgroundRequest` does — and ran the view lookup chain's request builder inside it:

```
Invoke-OmadaRequestCore defined in worker : True
view lookup chain defined in worker       : True
builder runs in worker                    : https://t/WebService/JQGridPopulationWebService.asmx/GetPagingData
worker errors                             : 0
```

Mutation-tested: removing the copy fails the build on the post-condition —

```
Background worker file 'Invoke-OmadaRequestCore.ps1' was not copied to '...'
```

```
./build/build.ps1 -Task TestBuildOnly   ->  1077 tests, 0 failed; PSScriptAnalyzer clean
./build/build.ps1 -Task E2E             ->    54 tests, 0 failed
```

## What this does not fix

A second defect from the same log, reported separately: **`Test-OmadaConnection` discards the wrapper's result** (`Test-OmadaConnection.ps1:25`), so an unclassified failure returns `$true` and the tab shows "Connected" while nothing works. That is why the failure in that log appeared to be `Update-QueryList`'s — it is the only one of the three callers that checks for an `ErrorRecord`.

Kept out of this PR: different bug, different file, and this one wants to be reviewable on its own.

Relates to #40 and #90.
