### PR TITLE
Diagnostic: E2E lane against unmodified main

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,138 @@
+name: E2E Suite
+
+# The end-to-end suite launches the real application against the fully mocked Omada backend in
+# tests/mock, so it needs no tenant, no credentials and no interaction - but it does need a
+# Windows runner and it is slow, which is why it runs on a schedule rather than on every push.
+# Trigger it by hand from the Actions tab (or from a PR branch) with "Run workflow".
+on:
+  schedule:
+    # 03:41 UTC - well clear of the 01:17 nightly build, so the two never contend for a runner.
+    - cron: '41 3 * * *'
+  workflow_dispatch: {}
+  # A change to the suite, the mock backend or this workflow is the one case worth spending a
+  # Windows runner on before merge - otherwise a broken harness is only discovered by the next
+  # scheduled run, after the change has already landed. Deliberately not triggered on src/**:
+  # that would put the slow lane on nearly every pull request, which is what the schedule avoids.
+  pull_request:
+    paths:
+      - 'tests/e2e/**'
+      - 'tests/mock/**'
+      - '.github/workflows/e2e.yml'
+
+permissions:
+  contents: read
+  checks: write
+  issues: write
+
+jobs:
+  e2e:
+    name: End-to-end (real app, mocked backend)
+    runs-on: windows-latest
+    timeout-minutes: 30
+    defaults:
+      run:
+        shell: pwsh
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install modules
+        run: ./build/InstallModules.ps1
+
+      # The suite imports the real module, and OmadaSqlTroubleshooter.psm1 refuses to load without
+      # OmadaWeb.PS. Installed here rather than in build/InstallModules.ps1, which exists for the
+      # build tooling: the unit tests dot-source individual functions and never import the module,
+      # so adding a gallery install there would slow every PR validation run for nothing.
+      # The minimum version is the one the module itself enforces on import.
+      - name: Install the OmadaWeb.PS runtime dependency
+        run: |
+          $MinimumVersion = '2026.07.09.9'
+          if (-not (Get-Module -ListAvailable -Name OmadaWeb.PS | Where-Object { $_.Version -ge [version]$MinimumVersion })) {
+            "Installing OmadaWeb.PS >= $MinimumVersion" | Write-Host
+            Install-Module -Name OmadaWeb.PS -MinimumVersion $MinimumVersion -Scope CurrentUser -Force -AllowClobber
+          }
+          $Installed = Get-Module -ListAvailable -Name OmadaWeb.PS | Sort-Object Version -Descending | Select-Object -First 1
+          if ($null -eq $Installed) {
+            throw "OmadaWeb.PS could not be installed; the end-to-end suite cannot import the module."
+          }
+          "Using OmadaWeb.PS {0}" -f $Installed.Version | Write-Host
+
+      - name: Run end-to-end suite
+        run: ./build/build.ps1 -Task E2E
+
+      - name: Check for results
+        id: results
+        if: always()
+        run: |
+          $exists = Test-Path 'buildoutput/E2EResults.xml'
+          "exists=$exists" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
+      - name: Publish results
+        uses: dorny/test-reporter@v1
+        if: always() && steps.results.outputs.exists == 'True'
+        with:
+          name: E2E Scenarios
+          path: buildoutput/E2EResults.xml
+          reporter: java-junit
+
+      - name: Upload results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: E2EResults
+          path: buildoutput/E2EResults.xml
+          if-no-files-found: warn
+
+  report-failure:
+    name: Report a failed scheduled run
+    needs: e2e
+    # Only the scheduled lane files an issue. A failed manual run is already in front of whoever
+    # started it, and a red lane nobody is watching is exactly what this job exists to prevent.
+    if: always() && needs.e2e.result == 'failure' && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Open or update the tracking issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = 'E2E suite is failing';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = [
+              `The scheduled end-to-end suite failed on \`${context.sha.substring(0, 7)}\`.`,
+              '',
+              `Run: ${runUrl}`,
+              '',
+              'The suite runs the real application against the mocked backend in `tests/mock`, so a',
+              'failure here is a real regression in the app, not a flaky external dependency.',
+              'Reproduce locally with `./build/build.ps1 -Task E2E`.'
+            ].join('\n');
+
+            // Matched on the title alone. Filtering by an 'e2e' label would find nothing until
+            // the label exists in the repository, and a lookup that always comes back empty
+            // means a fresh issue filed every single night instead of one that gets updated.
+            // The label is still applied on creation - the REST API creates it on first use.
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100
+            });
+            const open = existing.data.find(issue => issue.title === title && !issue.pull_request);
+
+            if (open) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: open.number,
+                body
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: ['e2e']
+              });
+            }

--- a/tests/e2e/Invoke-E2ESuite.ps1
+++ b/tests/e2e/Invoke-E2ESuite.ps1
@@ -37,6 +37,30 @@ Remove-Item -Path $ResultsPath, $SentinelPath -ErrorAction Ignore
 $TempAppData = Join-Path ([System.IO.Path]::GetTempPath()) ("osqE2E_{0}" -f ([guid]::NewGuid().ToString("N")))
 New-Item -Path $TempAppData -ItemType Directory -Force | Out-Null
 
+function Write-AppOutput {
+    <#
+    .SYNOPSIS
+    Replays whatever the hidden app process wrote, so a failure says why instead of only that it
+    happened.
+    #>
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowNull()]
+        $Line
+    )
+
+    $Captured = @($Line)
+    "" | Write-Host
+    "--- app output ({0} line(s)) ---" -f $Captured.Count | Write-Host -ForegroundColor Yellow
+    if ($Captured.Count -eq 0) {
+        "(the app process wrote nothing at all)" | Write-Host -ForegroundColor Yellow
+    }
+    else {
+        $Captured | ForEach-Object { $_ | Write-Host }
+    }
+    "--- end app output ---" | Write-Host -ForegroundColor Yellow
+}
+
 $RealAppData = Join-Path ([System.Environment]::GetFolderPath([System.Environment+SpecialFolder]::ApplicationData)) "OmadaSqlTroubleshooter"
 $RealAppDataBefore = if (Test-Path $RealAppData) { (Get-Item $RealAppData).LastWriteTimeUtc } else { $null }
 
@@ -48,23 +72,59 @@ $Command = "Import-Module '$ModulePath' -Force; Invoke-OmadaSqlTroubleshooter -R
 "  results   : $ResultsPath" | Write-Host
 
 $Process = $null
+$AppExitCode = $null
+$AppOutput = [System.Collections.Concurrent.ConcurrentQueue[string]]::new()
+$OutputSubscription = $null
+$ErrorSubscription = $null
 try {
     $ProcessInfo = New-Object System.Diagnostics.ProcessStartInfo
     $ProcessInfo.FileName = "pwsh"
     $ProcessInfo.Arguments = "-STA -NoProfile -NonInteractive -Command `"$Command`""
     $ProcessInfo.UseShellExecute = $false
     $ProcessInfo.CreateNoWindow = $true
+    # Captured rather than inherited. On a developer machine the child's console output reaches
+    # the terminal either way, but under a CI runner it did not - which left a failure reported
+    # as "the automation did not finish" with nothing above it to say why. Both streams are now
+    # collected and replayed by Write-AppOutput whenever the run does not complete cleanly.
+    $ProcessInfo.RedirectStandardOutput = $true
+    $ProcessInfo.RedirectStandardError = $true
     $ProcessInfo.EnvironmentVariables["OMADASQL_E2E_APPDATA"] = $TempAppData
     $ProcessInfo.EnvironmentVariables["OMADASQL_E2E_SCRIPT"] = $AutomationScript
     $ProcessInfo.EnvironmentVariables["OMADASQL_E2E_RESULTS"] = $ResultsPath
 
-    $Process = [System.Diagnostics.Process]::Start($ProcessInfo)
+    $Process = New-Object System.Diagnostics.Process
+    $Process.StartInfo = $ProcessInfo
+    $Process.EnableRaisingEvents = $true
+
+    # Read both streams asynchronously: a synchronous ReadToEnd on one of them deadlocks as soon
+    # as the other fills its 4 KB pipe buffer.
+    $OutputSubscription = Register-ObjectEvent -InputObject $Process -EventName OutputDataReceived -MessageData $AppOutput -Action {
+        if ($null -ne $EventArgs.Data) { $Event.MessageData.Enqueue($EventArgs.Data) }
+    }
+    $ErrorSubscription = Register-ObjectEvent -InputObject $Process -EventName ErrorDataReceived -MessageData $AppOutput -Action {
+        if ($null -ne $EventArgs.Data) { $Event.MessageData.Enqueue("STDERR: " + $EventArgs.Data) }
+    }
+
+    $Process.Start() | Out-Null
+    $Process.BeginOutputReadLine()
+    $Process.BeginErrorReadLine()
+
     if (-not $Process.WaitForExit($TimeoutSeconds * 1000)) {
         try { $Process.Kill($true) } catch { }
+        Write-AppOutput -Line $AppOutput
         throw "E2E run timed out after $TimeoutSeconds seconds (app hung)."
     }
+    # The parameterless overload waits for the async readers to drain as well.
+    $Process.WaitForExit()
+    $AppExitCode = $Process.ExitCode
 }
 finally {
+    foreach ($Subscription in @($OutputSubscription, $ErrorSubscription)) {
+        if ($null -ne $Subscription) {
+            Unregister-Event -SourceIdentifier $Subscription.Name -ErrorAction Ignore
+            Remove-Job -Job $Subscription -Force -ErrorAction Ignore
+        }
+    }
     Remove-Item -Path $TempAppData -Recurse -Force -ErrorAction Ignore
 }
 
@@ -75,7 +135,8 @@ if ($RealAppDataBefore -ne $RealAppDataAfter) {
 }
 
 if (-not (Test-Path $SentinelPath)) {
-    throw "E2E produced no completion sentinel - the automation did not finish (see app output above)."
+    Write-AppOutput -Line $AppOutput
+    throw ("E2E produced no completion sentinel - the automation did not finish (app exit code {0}). The app output is above." -f $AppExitCode)
 }
 
 [xml]$Report = Get-Content -Path $ResultsPath -Raw


### PR DESCRIPTION
Temporary draft PR. Carries only `.github/workflows/e2e.yml` on top of `main` so the scheduled E2E lane runs against main unchanged, to establish whether the 25 scenario failures on #104 come from that branch or from main. Will be closed and the branch deleted once the run reports.